### PR TITLE
Generate a cluster id if one is not provided

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -3,6 +3,7 @@ package submariner
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -370,6 +371,10 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Submariner) *appsv1.DaemonSet
 	return routeAgentDaemonSet
 }
 
+const (
+	dns1123 = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
+
 //TODO: move to a method on the API definitions, as the example shown by the etcd operator here :
 //      https://github.com/coreos/etcd-operator/blob/8347d27afa18b6c76d4a8bb85ad56a2e60927018/pkg/apis/etcd/v1beta2/cluster.go#L185
 func setSubmarinerDefaults(submariner *submarinerv1alpha1.Submariner) {
@@ -381,6 +386,16 @@ func setSubmarinerDefaults(submariner *submarinerv1alpha1.Submariner) {
 
 	if submariner.Spec.Version == "" {
 		submariner.Spec.Version = "0.0.2"
+	}
+
+	if submariner.Spec.ClusterID == "" {
+		// Cluster ids are used as DNS-1123 subdomains, so it must only contain lowercase alphanumerics, . and -
+		// The cluster id can't start or end with . or -, so we ignore those entirely
+		b := make([]byte, 16)
+		for i := range b {
+			b[i] = dns1123[rand.Intn(len(dns1123))]
+		}
+		submariner.Spec.ClusterID = string(b)
 	}
 
 }

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -101,6 +101,9 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	setSubmarinerDefaults(instance)
+	if err = r.client.Update(context.TODO(), instance); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	// Create submariner-engine SA
 	//subm_engine_sa := corev1.ServiceAccount{}
@@ -371,15 +374,15 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Submariner) *appsv1.DaemonSet
 //      https://github.com/coreos/etcd-operator/blob/8347d27afa18b6c76d4a8bb85ad56a2e60927018/pkg/apis/etcd/v1beta2/cluster.go#L185
 func setSubmarinerDefaults(submariner *submarinerv1alpha1.Submariner) {
 
-	spec := submariner.Spec
-	if spec.Repository == "" {
+	if submariner.Spec.Repository == "" {
 		// An empty field is converted to the default upstream submariner repository where all images live
-		spec.Repository = "quay.io/submariner"
+		submariner.Spec.Repository = "quay.io/submariner"
 	}
 
-	if spec.Version == "" {
-		spec.Version = "0.0.2"
+	if submariner.Spec.Version == "" {
+		submariner.Spec.Version = "0.0.2"
 	}
+
 }
 
 const (

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -141,7 +141,6 @@ function create_subm_cr() {
     sed -i "/spec:/a \ \ serviceCIDR: $serviceCIDR_cluster3" $cr_file
     sed -i "/spec:/a \ \ clusterCIDR: $clusterCIDR_cluster3" $cr_file
   fi
-  sed -i "/spec:/a \ \ clusterID: $context" $cr_file
   sed -i "/spec:/a \ \ colorCodes: $subm_colorcodes" $cr_file
   # NB: Quoting bool-like vars is required or Go will type as bool and fail when set as env vars as strs
   sed -i "/spec:/a \ \ debug: $subm_debug" $cr_file

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -130,7 +130,7 @@ function create_subm_cr() {
   # TODO: Use $engine_deployment_name here?
   sed -i "s|name: example-submariner|name: $deployment_name|g" $cr_file
 
-  sed -i "/spec:/a \ \ size: $subm_engine_size" $cr_file
+  sed -i "/spec:/a \ \ count: $subm_engine_size" $cr_file
 
   # These all need to end up in pod container/environment vars
   sed -i "/spec:/a \ \ namespace: $subm_ns" $cr_file

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -127,7 +127,7 @@ function verify_subm_cr() {
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.ceIPSecPSK}' | grep $SUBMARINER_PSK || true
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.repository}' | grep $subm_engine_image_repo
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.version}' | grep $subm_engine_image_tag
-  kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.size}' | grep $subm_engine_size
+  kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.count}' | grep $subm_engine_size
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.broker}' | grep $subm_broker
   echo Generated cluster id:
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.clusterID}'


### PR DESCRIPTION
This allows the user to skip that part of the CR.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/8)
<!-- Reviewable:end -->
