### PR TITLE
Dump clusters information on error

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -284,6 +284,15 @@ function cleanup {
     fi
 }
 
+function dump_clusters_on_error {
+    for i in 1 2 3; do
+        echo "Dumping cluster information for cluster$i ==========================="
+        kubectl --context=cluster$i cluster-info dump
+        echo ""
+    done
+    exit 1
+}
+
 ### Main ###
 
 if [[ $1 = clean ]]; then
@@ -322,6 +331,8 @@ create_subm_vars
 verify_subm_broker_secrets
 
 . kind-e2e/lib_operator_deploy_subm.sh
+
+trap dump_clusters_on_error ERR
 
 for i in 2 3; do
     context=cluster$i


### PR DESCRIPTION
This will run a cluster-info dump on each cluster in case of
failure during the deployment, or basic check phase.

The cluster dump contains information about all pods, deployments,
services, etc, along with the pod logs for each cluster.

Tested on: https://api.travis-ci.com/v3/job/250733047/log.txt