### PR TITLE
Use the base dapper image from submariner

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,52 +1,13 @@
-FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
+FROM quay.io/submariner/dapper-base
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} DAPPER_ENV=REPO DAPPER_ENV=TAG \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/submariner-operator DAPPER_DOCKER_SOCKET=true \
     TRASH_CACHE=${DAPPER_SOURCE}/.trash-cache HOME=${DAPPER_SOURCE} DAPPER_OUTPUT=output \
-    LINT_VERSION=v1.16.0 \
-    HELM_VERSION=v2.14.1 \
-    KIND_VERSION=v0.3.0 \
-    KUBEFED_VERSION=0.1.0-rc2 \
-    GO_VERSION=1.12.6 \
     OPERATOR_SDK_VERSION=0.11.0
 
-RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
-
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:/root/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor \
-    GOPROXY=https://proxy.golang.org
-
-# Requirements:
-# Component      | Usage
-# -----------------------------------------------------------
-# gcc            | ginkgo
-# git            | find the workspace root
-# curl           | download other tools
-# docker.io      | Dapper
-# golang         | build
-# kubectl        | e2e tests
-# golangci-lint  | code linting
-# helm           | e2e tests
-# kubefedctl     | e2e tests
-# kind           | e2e tests
-# ginkgo         | tests
-# goimports      | code formatting
-RUN apt-get -q update && \
-    apt-get install -y gcc git curl docker.io mercurial make && \
-    curl https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
-    chmod a+x /usr/bin/kubectl && \
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${LINT_VERSION} && \
-    curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
-    cp linux-${ARCH}/helm /usr/bin/ && chmod a+x /usr/bin/helm && \
-    curl -LO "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" && \
-    tar -xzf kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz && cp kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
-    curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
-    curl -Lo /usr/bin/operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu" && chmod a+x /usr/bin/operator-sdk && \
-    GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports
+RUN curl -Lo /usr/bin/operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu" && \
+    chmod a+x /usr/bin/operator-sdk
 
 WORKDIR ${DAPPER_SOURCE}
 


### PR DESCRIPTION
We use the fedora dapper image from submariner, and we remove the installation
of mercurial which does not seem to be necessary anymore.