### PR TITLE
Generate random Broker PSK and store in Secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-openapi/spec v0.19.4
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.11.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect

--- a/pkg/broker/broker_test_suite.go
+++ b/pkg/broker/broker_test_suite.go
@@ -1,0 +1,13 @@
+package broker
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBrokerSetup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Broker setup handling")
+}

--- a/pkg/broker/ipsec_psk.go
+++ b/pkg/broker/ipsec_psk.go
@@ -7,25 +7,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GenerateRandomPSK returns securely generated n-byte array.
-func GenerateRandomPSK(n int) ([]byte, error) {
+// generateRandomPSK returns securely generated n-byte array.
+func generateRandomPSK(n int) ([]byte, error) {
 	psk := make([]byte, n)
 	_, err := rand.Read(psk)
 	return psk, err
 }
 
-func NewBrokerPSKSecret(psk []byte) *v1.Secret {
+func NewBrokerPSKSecret(bytes int) (*v1.Secret, error) {
+
+	psk, err := generateRandomPSK(bytes)
+	if err != nil {
+		return nil, err
+	}
+
 	psk_secret_data := make(map[string][]byte)
 	psk_secret_data["psk"] = psk
 
 	psk_secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "submariner-k8s-broker-psk",
-			// FIXME: Get namespace somehow
-			Namespace: "submariner-k8s-broker",
+			Name: "submariner-ipsec-psk",
 		},
 		Data: psk_secret_data,
 	}
 
-	return psk_secret
+	return psk_secret, nil
 }

--- a/pkg/broker/ipsec_psk_test.go
+++ b/pkg/broker/ipsec_psk_test.go
@@ -1,0 +1,29 @@
+package broker
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const testPSKLen = 32
+
+var _ = Describe("ipsec_psk handling", func() {
+	When("generateRandonPSK is called", func() {
+		It("should return the amount of entropy requested", func() {
+			psk, err := generateRandomPSK(testPSKLen)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(psk).To(HaveLen(testPSKLen))
+		})
+	})
+
+	When("NewBrokerPSKSecret is called", func() {
+		It("should return a secret with a psk data inside", func() {
+			secret, err := NewBrokerPSKSecret(testPSKLen)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(secret.Name).To(Equal("submariner-ipsec-psk"))
+			Expect(secret.Data).To(HaveKey("psk"))
+			Expect(secret.Data["psk"]).To(HaveLen(testPSKLen))
+		})
+	})
+
+})

--- a/pkg/broker/secret.go
+++ b/pkg/broker/secret.go
@@ -1,0 +1,31 @@
+package broker
+
+import (
+	"crypto/rand"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GenerateRandomPSK returns securely generated n-byte array.
+func GenerateRandomPSK(n int) ([]byte, error) {
+	psk := make([]byte, n)
+	_, err := rand.Read(psk)
+	return psk, err
+}
+
+func NewBrokerPSKSecret(psk []byte) *v1.Secret {
+	psk_secret_data := make(map[string][]byte)
+	psk_secret_data["psk"] = psk
+
+	psk_secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "submariner-k8s-broker-psk",
+			// FIXME: Get namespace somehow
+			Namespace: "submariner-k8s-broker",
+		},
+		Data: psk_secret_data,
+	}
+
+	return psk_secret
+}

--- a/pkg/subctl/cmd/createbroker.go
+++ b/pkg/subctl/cmd/createbroker.go
@@ -18,6 +18,8 @@ func init() {
 	createCmd.AddCommand(createBrokerCmd)
 }
 
+const IPSECPSKBytes = 48 // using base64 this results on a 64 character password
+
 var createBrokerCmd = &cobra.Command{
 	Use:   "broker",
 	Short: "set the broker up",
@@ -89,17 +91,13 @@ var createBrokerCmd = &cobra.Command{
 			panic(err.Error())
 		}
 
-		// Generate random PSK
-		fmt.Printf("Creating the broker PSK\n")
-		psk, err := broker.GenerateRandomPSK(1024)
-		// TODO: Should we check if error already exists in same way wit this error? /me thinks no
+		// Generate and store a psk in secret
+		pskSecret, err := broker.NewBrokerPSKSecret(IPSECPSKBytes)
 		if err != nil {
 			panic(err.Error())
 		}
-
-		// Store PSK in secret
 		fmt.Printf("Creating the broker PSK secret\n")
-		_, err = clientset.CoreV1().Secrets("submariner-k8s-broker").Create(broker.NewBrokerPSKSecret(psk))
+		_, err = clientset.CoreV1().Secrets("submariner-k8s-broker").Create(pskSecret)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			panic(err.Error())
 		}

--- a/pkg/subctl/cmd/createbroker.go
+++ b/pkg/subctl/cmd/createbroker.go
@@ -89,6 +89,21 @@ var createBrokerCmd = &cobra.Command{
 			panic(err.Error())
 		}
 
+		// Generate random PSK
+		fmt.Printf("Creating the broker PSK\n")
+		psk, err := broker.GenerateRandomPSK(1024)
+		// TODO: Should we check if error already exists in same way wit this error? /me thinks no
+		if err != nil {
+			panic(err.Error())
+		}
+
+		// Store PSK in secret
+		fmt.Printf("Creating the broker PSK secret\n")
+		_, err = clientset.CoreV1().Secrets("submariner-k8s-broker").Create(broker.NewBrokerPSKSecret(psk))
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			panic(err.Error())
+		}
+
 		// List pods
 		pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
 		if err != nil {


### PR DESCRIPTION
The purpose of this, is that we will be providing an unified IPSEC key between runs of
subctl, aditionally this could be used to automate rotation of IPSEC keys.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>