### PR TITLE
Fix error handling in updateOrCreateCRD

### DIFF
--- a/pkg/subctl/operator/install/crds/crds_test.go
+++ b/pkg/subctl/operator/install/crds/crds_test.go
@@ -5,6 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("getSubmarinerCRD", func() {
@@ -16,7 +19,42 @@ var _ = Describe("getSubmarinerCRD", func() {
 			Expect(crd.Spec.Versions[0].Name).Should(Equal("v1alpha1"))
 		})
 	})
+})
 
+var _ = Describe("updateOrCreateCRD", func() {
+
+	var (
+		crd    *apiextensionsv1beta1.CustomResourceDefinition
+		client *fake.Clientset
+	)
+	BeforeEach(func() {
+		var err error
+		crd, err = getSubmarinerCRD()
+		Expect(err).ShouldNot(HaveOccurred())
+		client = fake.NewSimpleClientset()
+	})
+	When("When called", func() {
+		It("Should add the CRD properly", func() {
+			created, err := updateOrCreateCRD(client, crd)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdCrd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdCrd.Spec.Names.Kind).Should(Equal("Submariner"))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the CRD properly, and return false on second call", func() {
+			created, err := updateOrCreateCRD(client, crd)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = updateOrCreateCRD(client, crd)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })
 
 func TestOperatorCRDs(t *testing.T) {

--- a/pkg/subctl/operator/install/crds/ensure.go
+++ b/pkg/subctl/operator/install/crds/ensure.go
@@ -33,11 +33,10 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 
 }
 
-func updateOrCreateCRD(clientSet *clientset.Clientset, crd *apiextensionsv1beta1.CustomResourceDefinition) (bool, error) {
-
+func updateOrCreateCRD(clientSet clientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) (bool, error) {
 	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 	if err == nil {
-		return true, err
+		return true, nil
 	} else if errors.IsAlreadyExists(err) {
 		existingCrd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
 		if err != nil {
@@ -48,8 +47,9 @@ func updateOrCreateCRD(clientSet *clientset.Clientset, crd *apiextensionsv1beta1
 		if err != nil {
 			return false, fmt.Errorf("failed to update pre-existing CRD %s : %s", crd.Name, err)
 		}
+		return false, nil
 	}
-	return false, nil
+	return false, err
 }
 
 func getSubmarinerCRD() (*apiextensionsv1beta1.CustomResourceDefinition, error) {


### PR DESCRIPTION
The unit tests have been extended to cover the case where
updateOrCreateCRD was called when the CRD already existed.