### PR TITLE
Fix getClients() return order

### DIFF
--- a/pkg/subctl/cmd/info.go
+++ b/pkg/subctl/cmd/info.go
@@ -23,7 +23,7 @@ func init() {
 
 func clusterInfo(cmd *cobra.Command, args []string) {
 
-	err, dynClient, clientSet := getClients()
+	dynClient, clientSet, err := getClients()
 	panicOnError(err)
 
 	clusterNetwork, err := network.Discover(dynClient, clientSet)

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -55,20 +55,20 @@ func panicOnError(err error) {
 	}
 }
 
-func getClients() (error, dynamic.Interface, kubernetes.Interface) {
+func getClients() (dynamic.Interface, kubernetes.Interface, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
 	if err != nil {
-		return err, nil, nil
+		return nil, nil, err
 	}
 	dynClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return err, nil, nil
+		return nil, nil, err
 	}
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return err, nil, nil
+		return nil, nil, err
 	}
-	return nil, dynClient, clientSet
+	return dynClient, clientSet, nil
 }
 
 func getRestConfig() (*rest.Config, error) {


### PR DESCRIPTION
Errors should always be returned last.

Signed-off-by: Stephen Kitt <skitt@redhat.com>