### PR TITLE
Add PSK byte/string getter fns, use in datafile

### DIFF
--- a/pkg/broker/ipsec_psk_test.go
+++ b/pkg/broker/ipsec_psk_test.go
@@ -5,7 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const testPSKLen = 32
+// FIXME: Use shared var for PSK byte array length everywhere
+const testPSKLen = 48
 
 var _ = Describe("ipsec_psk handling", func() {
 	When("generateRandonPSK is called", func() {
@@ -26,4 +27,21 @@ var _ = Describe("ipsec_psk handling", func() {
 		})
 	})
 
+	When("NewBrokerPSKByte is called", func() {
+		It("should return psk as a string", func() {
+			psk, err := NewBrokerPSKSecret(testPSKLen)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(psk).To(HaveLen(testPSKLen))
+			// TODO: Assert type is []byte
+		})
+	})
+
+	When("NewBrokerPSKString is called", func() {
+		It("should return psk as a string", func() {
+			psk, err := NewBrokerPSKSecret(testPSKLen)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(psk).To(HaveLen(testPSKLen))
+			// TODO: Assert type is string
+		})
+	})
 })

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -17,6 +17,7 @@ func init() {
 	rootCmd.AddCommand(deployBroker)
 }
 
+// FIXME: Use this var everywhere
 const IPSECPSKBytes = 48 // using base64 this results on a 64 character password
 const brokerDetailsFilename = "broker-info.subm"
 

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -15,7 +15,7 @@ import (
 type SubctlData struct {
 	BrokerURL   string     `json:"brokerURL"`
 	ClientToken *v1.Secret `omitempty,json:"clientToken"`
-	IPSecPSK    *v1.Secret `omitempty,json:"ipsecPSK"`
+	IPSecPSK    string     `omitempty,json:"ipsecPSK"`
 }
 
 func (data *SubctlData) ToString() (string, error) {
@@ -80,6 +80,6 @@ func newFromCluster(clientSet clientset.Interface, brokerNamespace string) (*Sub
 		return nil, err
 	}
 
-	subctlData.IPSecPSK, err = broker.GetIPSECPSKSecret(clientSet, brokerNamespace)
+	subctlData.IPSecPSK, err = broker.GetIPSECPSKString(clientSet, brokerNamespace)
 	return subctlData, err
 }

--- a/pkg/subctl/datafile/datafile_test.go
+++ b/pkg/subctl/datafile/datafile_test.go
@@ -56,7 +56,8 @@ var _ = Describe("datafile", func() {
 
 		var clientSet *fake.Clientset
 		BeforeEach(func() {
-			pskSecret, _ := broker.NewBrokerPSKSecret(32)
+			// FIXME: Use shared var for PSK byte array length everywhere
+			pskSecret, _ := broker.NewBrokerPSKSecret(48)
 			pskSecret.Namespace = SubmarinerBrokerNamespace
 
 			sa := broker.NewBrokerSA()
@@ -78,7 +79,7 @@ var _ = Describe("datafile", func() {
 		It("Should produce a valid structure", func() {
 			subCtlData, err := newFromCluster(clientSet, SubmarinerBrokerNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(subCtlData.IPSecPSK.Name).To(Equal("submariner-ipsec-psk"))
+			Expect(subCtlData.IPSecPSK).NotTo(BeEmpty())
 			Expect(subCtlData.ClientToken.Name).To(Equal(testSASecret))
 		})
 	})


### PR DESCRIPTION
Also changes datafile from storing Secret to string.

Also marks places PSK key length vars are dependent on each other, and
where ideally we'd find ways to de-duplicate as much as possible.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/39)
<!-- Reviewable:end -->
