### PR TITLE
Install SubM on broker cluster

### DIFF
--- a/scripts/kind-e2e/cluster1-config.yaml
+++ b/scripts/kind-e2e/cluster1-config.yaml
@@ -12,3 +12,5 @@ kubeadmConfigPatches:
     dnsDomain: cluster1.local
 nodes:
 - role: control-plane
+  - role: worker
+  - role: worker

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -103,7 +103,10 @@ function create_subm_cr() {
 
   # These all need to end up in pod container/environment vars
   sed -i "/spec:/a \ \ namespace: $subm_ns" $cr_file
-  if [[ $context = cluster2 ]]; then
+  if [[ $context = cluster1 ]]; then
+    sed -i "/spec:/a \ \ serviceCIDR: $serviceCIDR_cluster1" $cr_file
+    sed -i "/spec:/a \ \ clusterCIDR: $clusterCIDR_cluster1" $cr_file
+  elif [[ $context = cluster2 ]]; then
     sed -i "/spec:/a \ \ serviceCIDR: $serviceCIDR_cluster2" $cr_file
     sed -i "/spec:/a \ \ clusterCIDR: $clusterCIDR_cluster2" $cr_file
   elif [[ $context = cluster3 ]]; then

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -135,7 +135,10 @@ function verify_subm_cr() {
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.debug}' | grep $subm_debug
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.namespace}' | grep $subm_ns
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.natEnabled}' | grep $natEnabled
-  if [[ $context = cluster2 ]]; then
+  if [[ $context = cluster1 ]]; then
+    kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.serviceCIDR}' | grep $serviceCIDR_cluster1
+    kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.clusterCIDR}' | grep $clusterCIDR_cluster1
+  elif [[ $context = cluster2 ]]; then
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.serviceCIDR}' | grep $serviceCIDR_cluster2
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.clusterCIDR}' | grep $clusterCIDR_cluster2
   elif [[ $context = cluster3 ]]; then
@@ -174,7 +177,10 @@ function verify_subm_engine_pod() {
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..command}' | grep submariner.sh
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}'
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_NAMESPACE value:$subm_ns"
-  if [[ $context = cluster2 ]]; then
+  if [[ $context = cluster1 ]]; then
+    kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_SERVICECIDR value:$serviceCIDR_cluster1"
+    kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_CLUSTERCIDR value:$clusterCIDR_cluster1"
+  elif [[ $context = cluster2 ]]; then
     kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_SERVICECIDR value:$serviceCIDR_cluster2"
     kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_CLUSTERCIDR value:$clusterCIDR_cluster2"
   elif [[ $context = cluster3 ]]; then
@@ -282,7 +288,10 @@ function verify_subm_routeagent_pod() {
     kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}'
     kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_NAMESPACE value:$subm_ns"
     kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_DEBUG value:$subm_debug"
-    if [[ $context = cluster2 ]]; then
+    if [[ $context = cluster1 ]]; then
+      kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_SERVICECIDR value:$serviceCIDR_cluster1"
+      kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_CLUSTERCIDR value:$clusterCIDR_cluster1"
+    elif [[ $context = cluster2 ]]; then
       kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_SERVICECIDR value:$serviceCIDR_cluster2"
       kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_CLUSTERCIDR value:$clusterCIDR_cluster2"
     elif [[ $context = cluster3 ]]; then
@@ -348,7 +357,10 @@ function verify_subm_engine_container() {
   kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_DEBUG=$subm_debug"
   kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "BROKER_K8S_APISERVERTOKEN=$SUBMARINER_BROKER_TOKEN"
   kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "BROKER_K8S_REMOTENAMESPACE=$SUBMARINER_BROKER_NS"
-  if [[ $context = cluster2 ]]; then
+  if [[ $context = cluster1 ]]; then
+    kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_SERVICECIDR=$serviceCIDR_cluster1"
+    kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_CLUSTERCIDR=$clusterCIDR_cluster1"
+  elif [[ $context = cluster2 ]]; then
     kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_SERVICECIDR=$serviceCIDR_cluster2"
     kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_CLUSTERCIDR=$clusterCIDR_cluster2"
   elif [[ $context = cluster3 ]]; then
@@ -393,7 +405,10 @@ function verify_subm_routeagent_container() {
     kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "HOSTNAME=$context-worker"
     kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_NAMESPACE=$subm_ns"
     kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_DEBUG=$subm_debug"
-    if [[ $context = cluster2 ]]; then
+    if [[ $context = cluster1 ]]; then
+      kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_SERVICECIDR=$serviceCIDRcluster1"
+      kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_CLUSTERCIDR=$clusterCIDR_cluster1"
+    elif [[ $context = cluster2 ]]; then
       kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_SERVICECIDR=$serviceCIDRcluster2"
       kubectl exec $subm_routeagent_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_CLUSTERCIDR=$clusterCIDR_cluster2"
     elif [[ $context = cluster3 ]]; then


### PR DESCRIPTION
One of the test scenarios requires dynamically
adding/removing third cluster to the setup.
The idea is to use broker cluster as the third
cluster.

This patch just installs SubM on broker cluster
but does not tag any gateway nodes. Node is tagged
later in the test case to mimic adding third cluster.

Signed-Off-By: Janki Chhatbar jchhatba@redhat.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/42)
<!-- Reviewable:end -->
