### PR TITLE
Integrate network discovery into the join command

### DIFF
--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"fmt"
+
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
@@ -9,6 +11,13 @@ type ClusterNetwork struct {
 	PodCIDRs      []string
 	ServiceCIDRs  []string
 	NetworkPlugin string
+}
+
+func (cn *ClusterNetwork) Show() {
+	fmt.Printf("Discovered network details:\n")
+	fmt.Printf("  Network plugin:  %s\n", cn.NetworkPlugin)
+	fmt.Printf("  ClusterIP CIDRs: %v\n", cn.ServiceCIDRs)
+	fmt.Printf("  Pod CIDRs:       %v\n", cn.PodCIDRs)
 }
 
 func Discover(dynClient dynamic.Interface, clientSet kubernetes.Interface) (*ClusterNetwork, error) {

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install"
 )
 
 var disableDataplane bool
@@ -14,6 +14,7 @@ var disableDataplane bool
 func init() {
 	deployBroker.PersistentFlags().BoolVarP(&disableDataplane, "no-dataplane", "n", false,
 		"Don't install the submariner dataplane on the broker")
+	addJoinFlags(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 
@@ -39,14 +40,7 @@ var deployBroker = &cobra.Command{
 		panicOnError(err)
 
 		if !disableDataplane {
-			err = handleNodeLabels()
-			panicOnError(err)
-
-			//TODO: when operator handles broker, we will also need to install the operator
-			//      but make sure the operator is able to not-handle dataplane, just broker
-			fmt.Printf("* Deploying the submariner operator\n")
-			err = install.Ensure(config, OperatorNamespace, operatorImage)
-			panicOnError(err)
+			joinSubmarinerCluster(subctlData)
 		}
 	},
 }

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/deploy"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install"
@@ -19,12 +21,19 @@ var (
 )
 
 func init() {
+	addJoinFlags(joinCmd)
 	rootCmd.AddCommand(joinCmd)
-	joinCmd.Flags().StringVar(&clusterID, "clusterid", "", "cluster ID used to identify the tunnels")
-	joinCmd.Flags().StringVar(&serviceCIDR, "servicecidr", "", "service CIDR")
-	joinCmd.Flags().StringVar(&clusterCIDR, "clustercidr", "", "cluster CIDR")
-	joinCmd.Flags().StringVar(&repository, "repository", "", "image repository")
-	joinCmd.Flags().StringVar(&version, "version", "", "image version")
+
+}
+
+func addJoinFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&clusterID, "clusterid", "", "cluster ID used to identify the tunnels")
+	cmd.Flags().StringVar(&serviceCIDR, "servicecidr", "", "service CIDR")
+	cmd.Flags().StringVar(&clusterCIDR, "clustercidr", "", "cluster CIDR")
+	cmd.Flags().StringVar(&repository, "repository", "", "image repository")
+	cmd.Flags().StringVar(&version, "version", "", "image version")
+	cmd.Flags().StringVarP(&operatorImage, "operator-image", "o", DefaultOperatorImage,
+		"the operator image you wish to use")
 }
 
 const (
@@ -36,23 +45,95 @@ var joinCmd = &cobra.Command{
 	Short: "connect a cluster to an existing broker",
 	Args:  cobra.ExactArgs(1), // exactly one, the broker data file
 	Run: func(cmd *cobra.Command, args []string) {
-
-		config, err := getRestConfig()
-		panicOnError(err)
-
-		err = handleNodeLabels()
-		panicOnError(err)
-
 		subctlData, err := datafile.NewFromFile(args[0])
 		panicOnError(err)
 		fmt.Printf("* %s says broker is at: %s\n", args[0], subctlData.BrokerURL)
-
-		fmt.Printf("* Deploying the submariner operator\n")
-		err = install.Ensure(config, OperatorNamespace, operatorImage)
-		panicOnError(err)
-
-		fmt.Printf("* Deploying Submariner\n")
-		err = deploy.Ensure(config, SubmarinerNamespace, repository, version, clusterID, serviceCIDR, clusterCIDR, subctlData)
-		panicOnError(err)
+		joinSubmarinerCluster(subctlData)
 	},
+}
+
+func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
+
+	config, err := getRestConfig()
+	panicOnError(err)
+
+	err = handleNodeLabels()
+	panicOnError(err)
+
+	fmt.Printf("* Deploying the submariner operator\n")
+	err = install.Ensure(config, OperatorNamespace, operatorImage)
+	panicOnError(err)
+
+	fmt.Printf("* Discovering network details\n")
+	networkDetails := getNetworkDetails()
+
+	serviceCIDR, err = getServiceCIDR(serviceCIDR, networkDetails)
+	panicOnError(err)
+
+	clusterCIDR, err = getPodCIDR(clusterCIDR, networkDetails)
+	panicOnError(err)
+
+	fmt.Printf("* Deploying Submariner\n")
+	err = deploy.Ensure(config, SubmarinerNamespace, repository, version, clusterID, serviceCIDR, clusterCIDR, subctlData)
+	panicOnError(err)
+}
+
+func getNetworkDetails() *network.ClusterNetwork {
+
+	dynClient, clientSet, err := getClients()
+	panicOnError(err)
+	networkDetails, err := network.Discover(dynClient, clientSet)
+	if err != nil {
+		fmt.Printf("Error trying to discover network details: %s\n", err)
+	} else {
+		networkDetails.Show()
+	}
+	return networkDetails
+}
+
+func getPodCIDR(clusterCIDR string, nd *network.ClusterNetwork) (string, error) {
+	if clusterCIDR != "" {
+		if nd != nil && len(nd.PodCIDRs) > 0 && nd.PodCIDRs[0] != clusterCIDR {
+			fmt.Printf("WARNING: your provided cluster CIDR for the pods (%s) does not match discovered (%s)\n",
+				clusterCIDR, nd.PodCIDRs[0])
+		}
+		return clusterCIDR, nil
+	} else if len(nd.PodCIDRs) > 0 {
+		return nd.PodCIDRs[0], nil
+	} else {
+		return askForCIDR("Pod")
+	}
+}
+
+func getServiceCIDR(serviceCIDR string, nd *network.ClusterNetwork) (string, error) {
+	if serviceCIDR != "" {
+		if nd != nil && len(nd.ServiceCIDRs) > 0 && nd.ServiceCIDRs[0] != serviceCIDR {
+			fmt.Printf("WARNING: your provided service CIDR (%s) does not match discovered (%s)\n",
+				serviceCIDR, nd.ServiceCIDRs[0])
+		}
+		return serviceCIDR, nil
+	} else if len(nd.ServiceCIDRs) > 0 {
+		return nd.ServiceCIDRs[0], nil
+	} else {
+		return askForCIDR("ClusterIP service")
+	}
+}
+
+func askForCIDR(name string) (string, error) {
+	var qs = []*survey.Question{{
+		Name:     "cidr",
+		Prompt:   &survey.Input{Message: fmt.Sprintf("What's the %s CIDR for your cluster?", name)},
+		Validate: survey.Required,
+	}}
+
+	answers := struct {
+		Cidr string
+	}{}
+
+	err := survey.Ask(qs, &answers)
+	if err != nil {
+		return "", err
+	} else {
+		return answers.Cidr, nil
+	}
 }

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -37,8 +37,6 @@ func init() {
 	} else {
 		rootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path(s) to the kubeconfig file(s)")
 	}
-	rootCmd.PersistentFlags().StringVarP(&operatorImage, "image", "i", DefaultOperatorImage,
-		"the operator image you wish to use")
 }
 
 const (

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -249,22 +249,17 @@ for i in 2 3; do
     verify_subm_gateway_label
 
     # Deploy SubM Operator
-    # TODO skitt Use arrays for the CIDRs
     if [ "${context}" = "cluster2" ]; then
-        ../bin/subctl join --image submariner-operator:local \
+        ../bin/subctl join --operator-image submariner-operator:local \
                         --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context \
                         --clusterid ${context} \
-                        --servicecidr ${serviceCIDR_cluster2} \
-                        --clustercidr ${clusterCIDR_cluster2} \
                         --repository ${subm_engine_image_repo} \
                         --version ${subm_engine_image_tag} \
                         broker-info.subm
     elif [ "${context}" = "cluster3" ]; then
-        ../bin/subctl join --image submariner-operator:local \
+        ../bin/subctl join --operator-image submariner-operator:local \
                         --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context \
                         --clusterid ${context} \
-                        --servicecidr ${serviceCIDR_cluster3} \
-                        --clustercidr ${clusterCIDR_cluster3} \
                         --repository ${subm_engine_image_repo} \
                         --version ${subm_engine_image_tag} \
                         broker-info.subm


### PR DESCRIPTION
This commit adds the network discovery logic, and also reuses the
join logic on the deploy-cluster side.

The priority of the CIDRs will be:
1) command line overriden CIDRs, with a warning if they don't match discovery
2) discovered network details
3) ask admin