### PR TITLE
Omit label details

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -90,9 +90,7 @@ func handleNodeLabels() error {
 	}
 	fmt.Printf("There are %d labeled nodes in the cluster\n", len(labeledNodes.Items))
 	for _, node := range labeledNodes.Items {
-		for _, label := range node.GetLabels() {
-			fmt.Printf("Node %s, label %s\n", node.GetName(), label)
-		}
+		fmt.Printf("Node %s\n", node.GetName())
 	}
 	if len(labeledNodes.Items) == 0 {
 		// List all nodes and select one


### PR DESCRIPTION
This was used for debugging, but we don’t need to see the details of
all the labeled nodes’ labels in practice. We still output the number
of labeled nodes and their names.

Signed-off-by: Stephen Kitt <skitt@redhat.com>