### PR TITLE
Provide defaults, check clusterID

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -19,6 +19,9 @@ var (
 	clusterCIDR string
 	repository  string
 	version     string
+	nattPort    int
+	ikePort     int
+	colorCodes  string
 )
 
 func init() {
@@ -35,6 +38,9 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&version, "version", "", "image version")
 	cmd.Flags().StringVarP(&operatorImage, "operator-image", "o", DefaultOperatorImage,
 		"the operator image you wish to use")
+	cmd.Flags().StringVar(&colorCodes, "colorcodes", "", "color codes")
+	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
+	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
 }
 
 const (
@@ -83,7 +89,8 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 	panicOnError(err)
 
 	fmt.Printf("* Deploying Submariner\n")
-	err = deploy.Ensure(config, SubmarinerNamespace, repository, version, clusterID, serviceCIDR, clusterCIDR, subctlData)
+	err = deploy.Ensure(config, SubmarinerNamespace, repository, version,
+		clusterID, serviceCIDR, clusterCIDR, colorCodes, nattPort, ikePort, subctlData)
 	panicOnError(err)
 }
 

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -45,6 +46,14 @@ var joinCmd = &cobra.Command{
 	Short: "connect a cluster to an existing broker",
 	Args:  cobra.ExactArgs(1), // exactly one, the broker data file
 	Run: func(cmd *cobra.Command, args []string) {
+		// Make sure the clusterid is a valid DNS-1123 string
+		if match, _ := regexp.MatchString("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", clusterID); !match {
+			fmt.Printf("Cluster IDs must be valid DNS-1123 names, with only lowercase alphanumerics,\n"+
+				"'.' or '-' (and the first and last characters must be alphanumerics).\n"+
+				"%s doesn't meet these requirements\n", clusterID)
+			return
+		}
+
 		subctlData, err := datafile.NewFromFile(args[0])
 		panicOnError(err)
 		fmt.Printf("* %s says broker is at: %s\n", args[0], subctlData.BrokerURL)

--- a/pkg/subctl/operator/deploy/ensure.go
+++ b/pkg/subctl/operator/deploy/ensure.go
@@ -18,7 +18,8 @@ import (
 )
 
 func Ensure(config *rest.Config, submarinerNamespace string, repository string, version string,
-	clusterID string, serviceCIDR string, clusterCIDR string, subctlData *datafile.SubctlData) error {
+	clusterID string, serviceCIDR string, clusterCIDR string, colorCodes string, nattPort int,
+	ikePort int, subctlData *datafile.SubctlData) error {
 
 	// Create the CRDs we need
 	apiext, err := apiextension.NewForConfig(config)
@@ -68,8 +69,8 @@ func Ensure(config *rest.Config, submarinerNamespace string, repository string, 
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,
 		Version:                  version,
-		CeIPSecNATTPort:          0,
-		CeIPSecIKEPort:           0,
+		CeIPSecNATTPort:          nattPort,
+		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             false,
 		CeIPSecPSK:               base64.StdEncoding.EncodeToString(subctlData.IPSecPSK.Data["psk"]),
 		BrokerK8sCA:              base64.StdEncoding.EncodeToString(subctlData.ClientToken.Data["ca.crt"]),
@@ -79,7 +80,7 @@ func Ensure(config *rest.Config, submarinerNamespace string, repository string, 
 		Broker:                   "k8s",
 		NatEnabled:               false,
 		Debug:                    false,
-		ColorCodes:               "blue",
+		ColorCodes:               colorCodes,
 		ClusterID:                clusterID,
 		ServiceCIDR:              serviceCIDR,
 		ClusterCIDR:              clusterCIDR,

--- a/pkg/subctl/operator/deploy/ensure.go
+++ b/pkg/subctl/operator/deploy/ensure.go
@@ -52,6 +52,18 @@ func Ensure(config *rest.Config, submarinerNamespace string, repository string, 
 		brokerURL = brokerURL[(idx + 3):]
 	}
 
+	if len(repository) == 0 {
+		// Default repository
+		// This is handled in the operator after 0.0.1 (of the operator)
+		repository = "quay.io/submariner"
+	}
+
+	if len(version) == 0 {
+		// Default engine version
+		// This is handled in the operator after 0.0.1 (of the operator)
+		version = "0.0.2"
+	}
+
 	// Populate the Submariner CR for the operator
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -255,6 +255,9 @@ for i in 2 3; do
                         --clusterid ${context} \
                         --repository ${subm_engine_image_repo} \
                         --version ${subm_engine_image_tag} \
+                        --nattport ${ce_ipsec_nattport} \
+                        --ikeport ${ce_ipsec_ikeport} \
+                        --colorcodes ${subm_colorcodes} \
                         broker-info.subm
     elif [ "${context}" = "cluster3" ]; then
         ../bin/subctl join --operator-image submariner-operator:local \
@@ -262,6 +265,9 @@ for i in 2 3; do
                         --clusterid ${context} \
                         --repository ${subm_engine_image_repo} \
                         --version ${subm_engine_image_tag} \
+                        --nattport ${ce_ipsec_nattport} \
+                        --ikeport ${ce_ipsec_ikeport} \
+                        --colorcodes ${subm_colorcodes} \
                         broker-info.subm
     else
         echo Unknown context ${context}

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -121,6 +121,8 @@ function verify_subm_cr() {
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.brokerK8sCA}' | grep $SUBMARINER_BROKER_CA
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.brokerK8sRemoteNamespace}' | grep $SUBMARINER_BROKER_NS
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.ceIPSecDebug}' | grep $ce_ipsec_debug
+  kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.ceIPSecIKEPort}' | grep $ce_ipsec_ikeport
+  kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.ceIPSecNATTPort}' | grep $ce_ipsec_nattport
   # FIXME: Sometimes this changes between runs, causes failures
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.ceIPSecPSK}' | grep $SUBMARINER_PSK || true
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.repository}' | grep $subm_engine_image_repo
@@ -189,6 +191,8 @@ function verify_subm_engine_pod() {
   # FIXME: This changes between some deployment runs and causes failures
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:CE_IPSEC_PSK value:$SUBMARINER_PSK" || true
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:CE_IPSEC_DEBUG value:$ce_ipsec_debug"
+  kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:CE_IPSEC_IKEPORT value:$ce_ipsec_ikeport"
+  kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:CE_IPSEC_NATTPORT value:$ce_ipsec_nattport"
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.status.phase}' | grep Running
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.metadata.namespace}' | grep $subm_ns
 }


### PR DESCRIPTION
The current release of the operator doesn’t fill in default values, so
we need to ensure subctl does it instead.

ClusterID needs to be a valid DNS-1123 name, enforce that in Ensure()
for now.

Signed-off-by: Stephen Kitt <skitt@redhat.com>