### PR TITLE
Discovery for canal-flannel, and avoid crash on join

### DIFF
--- a/pkg/discovery/network/canal.go
+++ b/pkg/discovery/network/canal.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func discoverCanalFlannelNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, error) {
+
+	// TODO: this must be smarter, looking for the canal daemonset, with labels k8s-app=canal
+	//  and then the reference on the container volumes:
+	//   - configMap:
+	//          defaultMode: 420
+	//          name: canal-config
+	//        name: flannel-cfg
+	cm, err := clientSet.CoreV1().ConfigMaps("kube-system").Get("canal-config", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	podCIDR := extractPodCIDRFromNetConfigJSON(cm)
+
+	if podCIDR == nil {
+		return nil, nil
+	}
+
+	clusterNetwork := &ClusterNetwork{
+		NetworkPlugin: "canal-flannel",
+		PodCIDRs:      []string{*podCIDR},
+	}
+
+	// Try to networkPluginsDiscovery the service CIDRs using the generic functions
+	genNetwork, err := discoverGenericNetwork(clientSet)
+	if err != nil && genNetwork != nil {
+		clusterNetwork.ServiceCIDRs = genNetwork.ServiceCIDRs
+	}
+
+	return clusterNetwork, nil
+}
+
+func extractPodCIDRFromNetConfigJSON(cm *v1.ConfigMap) *string {
+	netConfJson := cm.Data["net-conf.json"]
+	if netConfJson == "" {
+		return nil
+	}
+	var netConf struct {
+		Network string `json:"Network"`
+		// All the other fields are ignored by Unmarshal
+	}
+	if err := json.Unmarshal([]byte(netConfJson), &netConf); err == nil {
+		return &netConf.Network
+	}
+	return nil
+}

--- a/pkg/discovery/network/canal_test.go
+++ b/pkg/discovery/network/canal_test.go
@@ -1,0 +1,74 @@
+package network
+
+import (
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("discoverCanalFlannelNetwork", func() {
+	When("There are no generic k8s pods to look at", func() {
+		It("Should return still return the pod CIDR", func() {
+			clusterNet := testDiscoverCanalFlannelWith(&canalFlannelCfgMap)
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal("canal-flannel"))
+			Expect(clusterNet.PodCIDRs).To(Equal([]string{testCannalFlannelPodCIDR}))
+		})
+	})
+
+	When("There is a kubeapi pod at least ", func() {
+
+		It("Should return the ClusterNetwork structure with ServiceCIDRs too", func() {
+			clusterNet := testDiscoverWith(
+				&canalFlannelCfgMap,
+				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []v1.EnvVar{}),
+			)
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal("canal-flannel"))
+			Expect(clusterNet.PodCIDRs).To(Equal([]string{testCannalFlannelPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
+		})
+
+	})
+})
+
+func testDiscoverCanalFlannelWith(objects ...runtime.Object) *ClusterNetwork {
+
+	clientSet := fake.NewSimpleClientset(objects...)
+	clusterNet, err := discoverCanalFlannelNetwork(clientSet)
+	Expect(err).NotTo(HaveOccurred())
+	return clusterNet
+}
+
+func testDiscoverWith(objects ...runtime.Object) *ClusterNetwork {
+
+	clientSet := fake.NewSimpleClientset(objects...)
+	clusterNet, err := Discover(nil, clientSet)
+	Expect(err).NotTo(HaveOccurred())
+	return clusterNet
+}
+
+var canalFlannelCfgMap v1.ConfigMap = v1.ConfigMap{
+	ObjectMeta: v1meta.ObjectMeta{
+		Name:      "canal-config",
+		Namespace: "kube-system",
+	},
+	Data: map[string]string{
+		"net-conf.json": `{
+			"Network": "10.0.0.0/8",
+			"SubnetLen": 20,
+			"SubnetMin": "10.10.0.0",
+			"SubnetMax": "10.99.0.0",
+			"Backend": {
+				"Type": "udp",
+				"Port": 7890
+			}
+		}`,
+	},
+}
+
+const testCannalFlannelPodCIDR = "10.0.0.0/8"

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -14,13 +14,50 @@ type ClusterNetwork struct {
 }
 
 func (cn *ClusterNetwork) Show() {
-	fmt.Printf("Discovered network details:\n")
-	fmt.Printf("  Network plugin:  %s\n", cn.NetworkPlugin)
-	fmt.Printf("  ClusterIP CIDRs: %v\n", cn.ServiceCIDRs)
-	fmt.Printf("  Pod CIDRs:       %v\n", cn.PodCIDRs)
+	fmt.Printf("    Discovered network details:\n")
+	fmt.Printf("        Network plugin:  %s\n", cn.NetworkPlugin)
+	fmt.Printf("        ClusterIP CIDRs: %v\n", cn.ServiceCIDRs)
+	fmt.Printf("        Pod CIDRs:       %v\n", cn.PodCIDRs)
+}
+
+func (cn *ClusterNetwork) IsComplete() bool {
+	return cn != nil && len(cn.ServiceCIDRs) > 0 && len(cn.PodCIDRs) > 0
 }
 
 func Discover(dynClient dynamic.Interface, clientSet kubernetes.Interface) (*ClusterNetwork, error) {
+
+	discovery, err := networkPluginsDiscovery(dynClient, clientSet)
+
+	if err == nil && discovery != nil {
+		if discovery.IsComplete() {
+			return discovery, nil
+		} else {
+			// If the info we got from the non-generic plugins is incomplete
+			// try to complete with the generic discovery mechanisms
+			genericNet, err := discoverGenericNetwork(clientSet)
+			if genericNet == nil || err != nil {
+				return discovery, nil
+			}
+
+			if len(discovery.ServiceCIDRs) == 0 {
+				discovery.ServiceCIDRs = genericNet.ServiceCIDRs
+			}
+			if len(discovery.PodCIDRs) == 0 {
+				discovery.PodCIDRs = genericNet.PodCIDRs
+			}
+			return discovery, nil
+		}
+	} else {
+		// If nothing specific was discovered, use the generic discovery
+		genericNet, err := discoverGenericNetwork(clientSet)
+		if err == nil && genericNet != nil {
+			return genericNet, nil
+		}
+	}
+	return nil, nil
+}
+
+func networkPluginsDiscovery(dynClient dynamic.Interface, clientSet kubernetes.Interface) (*ClusterNetwork, error) {
 
 	osClusterNet, err := discoverOpenShift4Network(dynClient)
 	if err == nil && osClusterNet != nil {
@@ -32,9 +69,9 @@ func Discover(dynClient dynamic.Interface, clientSet kubernetes.Interface) (*Clu
 		return weaveClusterNet, nil
 	}
 
-	genericNet, err := discoverGenericNetwork(clientSet)
-	if err == nil && genericNet != nil {
-		return genericNet, nil
+	canalClusterNet, err := discoverCanalFlannelNetwork(clientSet)
+	if err == nil && canalClusterNet != nil {
+		return canalClusterNet, nil
 	}
 
 	return nil, nil

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -20,6 +20,10 @@ var (
 
 func discoverOpenShift4Network(dynClient dynamic.Interface) (*ClusterNetwork, error) {
 
+	if dynClient == nil {
+		return nil, nil
+	}
+
 	crClient := dynClient.Resource(openshift4clusterNetworkGVR)
 
 	cr, err := crClient.Get("default", metav1.GetOptions{})

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -85,7 +85,7 @@ func getNetworkDetails() *network.ClusterNetwork {
 	networkDetails, err := network.Discover(dynClient, clientSet)
 	if err != nil {
 		fmt.Printf("Error trying to discover network details: %s\n", err)
-	} else {
+	} else if networkDetails != nil {
 		networkDetails.Show()
 	}
 	return networkDetails


### PR DESCRIPTION
Crash on join happened if networkDiscovery was nil, which can
still happen even for err == nil.