### PR TITLE
Handle OpenShift's privileged SCC

### DIFF
--- a/pkg/subctl/cmd/info.go
+++ b/pkg/subctl/cmd/info.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
-
 	"github.com/spf13/cobra"
+
+	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 )
 
 // infoCmd represents the info command
@@ -32,4 +32,5 @@ func clusterInfo(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("cluster network info: %v\n", clusterNetwork)
+
 }

--- a/pkg/subctl/operator/install/ensure.go
+++ b/pkg/subctl/operator/install/ensure.go
@@ -3,11 +3,13 @@ package install
 import (
 	"fmt"
 
+	"k8s.io/client-go/rest"
+
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install/crds"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install/deployment"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install/namespace"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install/scc"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install/serviceaccount"
-	"k8s.io/client-go/rest"
 )
 
 func Ensure(config *rest.Config, operatorNamespace string, operatorImage string) error {
@@ -28,6 +30,12 @@ func Ensure(config *rest.Config, operatorNamespace string, operatorImage string)
 		return err
 	} else if created {
 		fmt.Printf("* Created operator service account and role\n")
+	}
+
+	if created, err := scc.Ensure(config, operatorNamespace); err != nil {
+		return err
+	} else if created {
+		fmt.Printf("* Updated the privileged SCC\n")
 	}
 
 	if created, err := deployment.Ensure(config, operatorNamespace, operatorImage); err != nil {

--- a/pkg/subctl/operator/install/scc/ensure.go
+++ b/pkg/subctl/operator/install/scc/ensure.go
@@ -43,7 +43,7 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 		return false, err
 	}
 
-	submarinerUser := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceaccount.OperatorServiceAccout)
+	submarinerUser := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceaccount.OperatorServiceAccount)
 
 	for _, user := range users {
 		if submarinerUser == user.(string) {

--- a/pkg/subctl/operator/install/scc/ensure.go
+++ b/pkg/subctl/operator/install/scc/ensure.go
@@ -1,0 +1,63 @@
+package scc
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/install/serviceaccount"
+)
+
+var (
+	openshiftSCCGVR = schema.GroupVersionResource{
+		Group:    "security.openshift.io",
+		Version:  "v1",
+		Resource: "securitycontextconstraints",
+	}
+)
+
+func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
+
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return false, err
+	}
+
+	sccClient := dynClient.Resource(openshiftSCCGVR)
+
+	cr, err := sccClient.Get("privileged", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	users, found, err := unstructured.NestedSlice(cr.Object, "users")
+	if !found || err != nil {
+		return false, err
+	}
+
+	submarinerUser := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceaccount.OperatorServiceAccout)
+
+	for _, user := range users {
+		if submarinerUser == user.(string) {
+			// the user is already part of the scc
+			return false, nil
+		}
+	}
+
+	if err = unstructured.SetNestedSlice(cr.Object, append(users, submarinerUser), "users"); err != nil {
+		return false, err
+	}
+
+	if _, err = sccClient.Update(cr, metav1.UpdateOptions{}); err != nil {
+		return false, fmt.Errorf("Error updating OpenShift privileged SCC: %s", err)
+	}
+	return true, nil
+}

--- a/pkg/subctl/operator/install/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/install/serviceaccount/ensure.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate go run generators/yamls2go.go
 
-const OperatorServiceAccout = "submariner-operator"
+const OperatorServiceAccount = "submariner-operator"
 
 //Ensure functions updates or installs the operator CRDs in the cluster
 func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
@@ -44,7 +44,7 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 }
 
 func ensureServiceAccount(clientSet *clientset.Clientset, namespace string) (bool, error) {
-	sa := &v1.ServiceAccount{ObjectMeta: v1meta.ObjectMeta{Name: OperatorServiceAccout}}
+	sa := &v1.ServiceAccount{ObjectMeta: v1meta.ObjectMeta{Name: OperatorServiceAccount}}
 	_, err := clientSet.CoreV1().ServiceAccounts(namespace).Create(sa)
 	if err == nil {
 		return true, nil

--- a/pkg/subctl/operator/install/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/install/serviceaccount/ensure.go
@@ -15,6 +15,8 @@ import (
 
 //go:generate go run generators/yamls2go.go
 
+const OperatorServiceAccout = "submariner-operator"
+
 //Ensure functions updates or installs the operator CRDs in the cluster
 func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 	clientSet, err := clientset.NewForConfig(restConfig)
@@ -42,7 +44,7 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 }
 
 func ensureServiceAccount(clientSet *clientset.Clientset, namespace string) (bool, error) {
-	sa := &v1.ServiceAccount{ObjectMeta: v1meta.ObjectMeta{Name: "submariner-operator"}}
+	sa := &v1.ServiceAccount{ObjectMeta: v1meta.ObjectMeta{Name: OperatorServiceAccout}}
 	_, err := clientSet.CoreV1().ServiceAccounts(namespace).Create(sa)
 	if err == nil {
 		return true, nil


### PR DESCRIPTION
When installing on top of OpenShift the operator service
account must be added to the privileged scc, otherwise it
won't be able to create privileged pods.