### PR TITLE
Add a default colour code

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -383,6 +383,10 @@ func setSubmarinerDefaults(submariner *submarinerv1alpha1.Submariner) {
 		submariner.Spec.Version = "0.0.2"
 	}
 
+	if submariner.Spec.ColorCodes == "" {
+		submariner.Spec.ColorCodes = "blue"
+	}
+
 }
 
 const (

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -38,7 +38,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&version, "version", "", "image version")
 	cmd.Flags().StringVarP(&operatorImage, "operator-image", "o", DefaultOperatorImage,
 		"the operator image you wish to use")
-	cmd.Flags().StringVar(&colorCodes, "colorcodes", "", "color codes")
+	cmd.Flags().StringVar(&colorCodes, "colorcodes", "blue", "color codes")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
 }


### PR DESCRIPTION
This avoids having to explain what it’s used for...

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/55)
<!-- Reviewable:end -->
