### PR TITLE
Pass a filled-in SubmarinerSpec

### DIFF
--- a/pkg/subctl/operator/deploy/ensure.go
+++ b/pkg/subctl/operator/deploy/ensure.go
@@ -1,14 +1,11 @@
 package deploy
 
 import (
-	"encoding/base64"
 	"fmt"
-	"strings"
 
 	submariner "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/engine"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,9 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func Ensure(config *rest.Config, submarinerNamespace string, repository string, version string,
-	clusterID string, serviceCIDR string, clusterCIDR string, colorCodes string, nattPort int,
-	ikePort int, disableNat bool, subctlData *datafile.SubctlData) error {
+func Ensure(config *rest.Config, submarinerSpec submariner.SubmarinerSpec) error {
 
 	err := engine.Ensure(config)
 	if err != nil {
@@ -34,47 +29,6 @@ func Ensure(config *rest.Config, submarinerNamespace string, repository string, 
 	_, err = clientset.CoreV1().Namespaces().Create(NewSubmarinerNamespace())
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("error creating the Submariner namespace %s", err)
-	}
-
-	brokerURL := subctlData.BrokerURL
-	if idx := strings.Index(brokerURL, "://"); idx >= 0 {
-		// Submariner doesn't work with a schema prefix
-		brokerURL = brokerURL[(idx + 3):]
-	}
-
-	if len(repository) == 0 {
-		// Default repository
-		// This is handled in the operator after 0.0.1 (of the operator)
-		repository = "quay.io/submariner"
-	}
-
-	if len(version) == 0 {
-		// Default engine version
-		// This is handled in the operator after 0.0.1 (of the operator)
-		version = "0.0.3"
-	}
-
-	// Populate the Submariner CR for the operator
-	submarinerSpec := submariner.SubmarinerSpec{
-		Repository:               repository,
-		Version:                  version,
-		CeIPSecNATTPort:          nattPort,
-		CeIPSecIKEPort:           ikePort,
-		CeIPSecDebug:             false,
-		CeIPSecPSK:               base64.StdEncoding.EncodeToString(subctlData.IPSecPSK.Data["psk"]),
-		BrokerK8sCA:              base64.StdEncoding.EncodeToString(subctlData.ClientToken.Data["ca.crt"]),
-		BrokerK8sRemoteNamespace: string(subctlData.ClientToken.Data["namespace"]),
-		BrokerK8sApiServerToken:  string(subctlData.ClientToken.Data["token"]),
-		BrokerK8sApiServer:       brokerURL,
-		Broker:                   "k8s",
-		NatEnabled:               !disableNat,
-		Debug:                    false,
-		ColorCodes:               colorCodes,
-		ClusterID:                clusterID,
-		ServiceCIDR:              serviceCIDR,
-		ClusterCIDR:              clusterCIDR,
-		Namespace:                submarinerNamespace,
-		Count:                    0,
 	}
 
 	submariner := &submariner.Submariner{


### PR DESCRIPTION
This reduces the number of arguments to deploy.Ensure().

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/57)
<!-- Reviewable:end -->
