### PR TITLE
Separate deploy-broker and join

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -9,12 +9,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 )
 
-var disableDataplane bool
-
 func init() {
-	deployBroker.PersistentFlags().BoolVarP(&disableDataplane, "no-dataplane", "n", false,
-		"Don't install the submariner dataplane on the broker")
-	addJoinFlags(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 
@@ -38,9 +33,5 @@ var deployBroker = &cobra.Command{
 		fmt.Printf("Writing submariner broker data to %s\n", brokerDetailsFilename)
 		err = subctlData.WriteToFile(brokerDetailsFilename)
 		panicOnError(err)
-
-		if !disableDataplane {
-			joinSubmarinerCluster(subctlData)
-		}
 	},
 }

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -73,7 +73,7 @@ function setup_broker() {
         echo Submariner CRDs already exist, skipping broker creation...
     else
         echo Installing broker on cluster1.
-        ../bin/subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster1 deploy-broker --no-dataplane
+        ../bin/subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster1 deploy-broker
     fi
 
     SUBMARINER_BROKER_URL=$(kubectl --context=cluster1 -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")


### PR DESCRIPTION
deploy-broker’s ability to set the dataplane up is confusing, it’s
best to leave that to an explicit join (or the all-in-one deploy which
is explicitly all-in-one).

Fixes: #69
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/70)
<!-- Reviewable:end -->
