### PR TITLE
Flip the dataplane default

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -9,11 +9,11 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 )
 
-var disableDataplane bool
+var enableDataplane bool
 
 func init() {
-	deployBroker.PersistentFlags().BoolVarP(&disableDataplane, "no-dataplane", "n", false,
-		"Don't install the submariner dataplane on the broker")
+	deployBroker.PersistentFlags().BoolVar(&enableDataplane, "dataplane", false,
+		"Install the Submariner dataplane on the broker")
 	addJoinFlags(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
@@ -39,7 +39,7 @@ var deployBroker = &cobra.Command{
 		err = subctlData.WriteToFile(brokerDetailsFilename)
 		panicOnError(err)
 
-		if !disableDataplane {
+		if enableDataplane {
 			joinSubmarinerCluster(subctlData)
 		}
 	},

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -73,7 +73,7 @@ function setup_broker() {
         echo Submariner CRDs already exist, skipping broker creation...
     else
         echo Installing broker on cluster1.
-        ../bin/subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster1 deploy-broker --no-dataplane
+        ../bin/subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster1 deploy-broker
     fi
 
     SUBMARINER_BROKER_URL=$(kubectl --context=cluster1 -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")


### PR DESCRIPTION
This changes the broker deployment command so that it doesn’t join the
cluster by default, and adds a --dataplane option to join (instead of
the --no-dataplane option to disable joining).

This is an alternative to #70, and would also fix: #69.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/75)
<!-- Reviewable:end -->
