### PR TITLE
Tell the user the operator is being deployed

### DIFF
--- a/pkg/subctl/operator/install/ensure.go
+++ b/pkg/subctl/operator/install/ensure.go
@@ -54,10 +54,13 @@ func Ensure(config *rest.Config, operatorNamespace string, operatorImage string)
 		fmt.Printf("* Updated the privileged SCC\n")
 	}
 
+	fmt.Printf("* Deploying the operator...\r")
 	if created, err := deployment.Ensure(config, operatorNamespace, operatorImage); err != nil {
 		return err
 	} else if created {
 		fmt.Printf("* Deployed the operator successfully\n")
+	} else {
+		fmt.Printf("                           \r")
 	}
 
 	fmt.Printf("* The operator is up and running\n")


### PR DESCRIPTION
When deploying the operator without a pre-loaded container image, the
operator can spend quite a while in the ContainerCreating phase, with
no feedback on screen. This adds a “Deploying the operator...”
message, which is replaced once the operation completes (successfully
or otherwise).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/83)
<!-- Reviewable:end -->
