### PR TITLE
Allow --no-dataplane

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -26,10 +26,15 @@ import (
 )
 
 var enableDataplane bool
+var disableDataplane bool
 
 func init() {
 	deployBroker.PersistentFlags().BoolVar(&enableDataplane, "dataplane", false,
 		"Install the Submariner dataplane on the broker")
+	deployBroker.PersistentFlags().BoolVar(&disableDataplane, "no-dataplane", true,
+		"Don't install the Submariner dataplane on the broker (default)")
+	err := deployBroker.PersistentFlags().MarkHidden("no-dataplane")
+	panicOnError(err)
 	addJoinFlags(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }


### PR DESCRIPTION
To simplify documentation, and because it’s used in demos, we should
keep --no-dataplane for now. This patch allows it, sets it by default,
but effectively ignores it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/87)
<!-- Reviewable:end -->
