### PR TITLE
Provide friendlier error messages on exit

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -119,7 +119,7 @@ func getRestConfig() (*rest.Config, error) {
 
 func handleNodeLabels() error {
 	_, clientset, err := getClients()
-	panicOnError(err)
+	exitOnError("Unable to set the Kubernetes cluster connection up", err)
 	// List Submariner-labeled nodes
 	const submarinerGatewayLabel = "submariner.io/gateway"
 	const trueLabel = "true"
@@ -139,7 +139,7 @@ func handleNodeLabels() error {
 			return err
 		}
 		err = addLabelsToNode(clientset, answer.Node, map[string]string{submarinerGatewayLabel: trueLabel})
-		panicOnError(err)
+		exitOnError("Error labeling the gateway node", err)
 
 	}
 	return nil


### PR DESCRIPTION
This replaces most panicOnError calls with exitOnError calls with
appropriate error messages. This avoids confusing stack traces.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner-operator/94)
<!-- Reviewable:end -->
