### PR TITLE
Provide explicit error if no non-master nodes

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -151,7 +151,9 @@ func askForGatewayNode(clientset kubernetes.Interface) (struct{ Node string }, e
 	if err != nil {
 		return struct{ Node string }{}, err
 	}
-	fmt.Printf("There are %d nodes in the cluster\n", len(allNodes.Items))
+	if len(allNodes.Items) == 0 {
+		return struct{ Node string }{}, fmt.Errorf("there are no non-master nodes in the cluster")
+	}
 	allNodeNames := []string{}
 	for _, node := range allNodes.Items {
 		allNodeNames = append(allNodeNames, node.GetName())


### PR DESCRIPTION
When attempting to label a gateway, if subctl doesn’t find any
non-master nodes, it errors out with an obscure error message (“please
provide options to select from”, produced by the survey library).
This patch handles this situation explicitly, with a friendlier error
message (“there are no non-master nodes in the cluster”).

Signed-off-by: Stephen Kitt <skitt@redhat.com>