### PR TITLE
Skip labeling if there are no nodes

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -45,6 +45,7 @@ var (
 	ipsecDebug      bool
 	submarinerDebug bool
 	replicas        int
+	noLabel         bool
 )
 
 func init() {
@@ -68,6 +69,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&ipsecDebug, "ipsec-debug", false, "Enable IPsec debugging (verbose logging)")
 	cmd.Flags().BoolVar(&submarinerDebug, "subm-debug", false, "Enable Submariner debugging (verbose logging)")
 	cmd.Flags().IntVar(&replicas, "replicas", 0, "Set the number of engine replicas (no more than the number of gateway nodes)")
+	cmd.Flags().BoolVar(&noLabel, "no-label", false, "skip gateway labeling")
 }
 
 const (
@@ -134,8 +136,10 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 	config, err := getRestConfig()
 	exitOnError("Unable to determine the Kubernetes connection configuration", err)
 
-	err = handleNodeLabels()
-	exitOnError("Unable to set the gateway node up", err)
+	if !noLabel {
+		err = handleNodeLabels()
+		exitOnError("Unable to set the gateway node up", err)
+	}
 
 	fmt.Printf("* Deploying the submariner operator\n")
 	err = install.Ensure(config, OperatorNamespace, operatorImage)

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -138,9 +138,12 @@ func handleNodeLabels() error {
 		if err != nil {
 			return err
 		}
-		err = addLabelsToNode(clientset, answer.Node, map[string]string{submarinerGatewayLabel: trueLabel})
-		exitOnError("Error labeling the gateway node", err)
-
+		if len(answer.Node) == 0 {
+			fmt.Printf("* No available node, skipping labeling\n")
+		} else {
+			err = addLabelsToNode(clientset, answer.Node, map[string]string{submarinerGatewayLabel: trueLabel})
+			exitOnError("Error labeling the gateway node", err)
+		}
 	}
 	return nil
 }
@@ -152,7 +155,7 @@ func askForGatewayNode(clientset kubernetes.Interface) (struct{ Node string }, e
 		return struct{ Node string }{}, err
 	}
 	if len(allNodes.Items) == 0 {
-		return struct{ Node string }{}, fmt.Errorf("there are no non-master nodes in the cluster")
+		return struct{ Node string }{}, nil
 	}
 	allNodeNames := []string{}
 	for _, node := range allNodes.Items {


### PR DESCRIPTION
In subctl, if we don’t find any candidate nodes for labeling, skip
instead of exiting. This sets up Submariner, which will then wait for
a gateway to be labeled.

This also adds a --no-label option to skip labeling in all cases.

Signed-off-by: Stephen Kitt <skitt@redhat.com>