### PR TITLE
Remove IPSEC secret storage in broker

### DIFF
--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func Ensure(config *rest.Config, ipsecPSKBytes int) error {
+func Ensure(config *rest.Config) error {
 	err := engine.Ensure(config)
 	if err != nil {
 		return fmt.Errorf("error setting up the engine requirements: %s", err)
@@ -61,17 +61,6 @@ func Ensure(config *rest.Config, ipsecPSKBytes int) error {
 	_, err = clientset.RbacV1().RoleBindings(SubmarinerBrokerNamespace).Create(NewBrokerRoleBinding())
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("error creating the broker rolebinding: %s", err)
-	}
-
-	// Generate and store a psk in secret
-	pskSecret, err := NewBrokerPSKSecret(ipsecPSKBytes)
-	if err != nil {
-		return fmt.Errorf("error generating the IPSEC PSK secret: %s", err)
-	}
-
-	_, err = clientset.CoreV1().Secrets(SubmarinerBrokerNamespace).Create(pskSecret)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("error creating the IPSEC PSK secret: %s", err)
 	}
 
 	return waitForClientToken(clientset)

--- a/pkg/subctl/datafile/backup.go
+++ b/pkg/subctl/datafile/backup.go
@@ -1,0 +1,17 @@
+package datafile
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+func BackupIfExists(filename string) (string, error) {
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return "", nil
+	}
+	now := time.Now()
+	nowStr := strings.Replace(now.Format(time.RFC3339), ":", "_", -1)
+	newFilename := filename + "." + nowStr
+	return newFilename, os.Rename(filename, newFilename)
+}

--- a/pkg/subctl/datafile/datafile_test.go
+++ b/pkg/subctl/datafile/datafile_test.go
@@ -72,7 +72,7 @@ var _ = Describe("datafile", func() {
 
 		var clientSet *fake.Clientset
 		BeforeEach(func() {
-			pskSecret, _ := broker.NewBrokerPSKSecret(32)
+			pskSecret, _ := newIPSECPSKSecret()
 			pskSecret.Namespace = SubmarinerBrokerNamespace
 
 			sa := broker.NewBrokerSA()
@@ -92,7 +92,7 @@ var _ = Describe("datafile", func() {
 		})
 
 		It("Should produce a valid structure", func() {
-			subCtlData, err := newFromCluster(clientSet, SubmarinerBrokerNamespace)
+			subCtlData, err := newFromCluster(clientSet, SubmarinerBrokerNamespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(subCtlData.IPSecPSK.Name).To(Equal("submariner-ipsec-psk"))
 			Expect(subCtlData.ClientToken.Name).To(Equal(testSASecret))

--- a/pkg/subctl/datafile/ipsec_psk.go
+++ b/pkg/subctl/datafile/ipsec_psk.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
+package datafile
 
 import (
 	"crypto/rand"
@@ -25,6 +25,7 @@ import (
 )
 
 const ipsecPSKSecretName = "submariner-ipsec-psk"
+const ipsecSecretLength = 48
 
 // generateRandomPSK returns securely generated n-byte array.
 func generateRandomPSK(n int) ([]byte, error) {
@@ -33,9 +34,9 @@ func generateRandomPSK(n int) ([]byte, error) {
 	return psk, err
 }
 
-func NewBrokerPSKSecret(bytes int) (*v1.Secret, error) {
+func newIPSECPSKSecret() (*v1.Secret, error) {
 
-	psk, err := generateRandomPSK(bytes)
+	psk, err := generateRandomPSK(ipsecSecretLength)
 	if err != nil {
 		return nil, err
 	}
@@ -53,6 +54,6 @@ func NewBrokerPSKSecret(bytes int) (*v1.Secret, error) {
 	return psk_secret, nil
 }
 
-func GetIPSECPSKSecret(clientSet clientset.Interface, brokerNamespace string) (*v1.Secret, error) {
-	return clientSet.CoreV1().Secrets(brokerNamespace).Get(ipsecPSKSecretName, metav1.GetOptions{})
+func GetIPSECPSKSecret(clientSet clientset.Interface, namespace string) (*v1.Secret, error) {
+	return clientSet.CoreV1().Secrets(namespace).Get(ipsecPSKSecretName, metav1.GetOptions{})
 }

--- a/pkg/subctl/datafile/ipsec_psk_test.go
+++ b/pkg/subctl/datafile/ipsec_psk_test.go
@@ -14,31 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
+package datafile
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-const testPSKLen = 32
-
 var _ = Describe("ipsec_psk handling", func() {
 	When("generateRandonPSK is called", func() {
 		It("should return the amount of entropy requested", func() {
-			psk, err := generateRandomPSK(testPSKLen)
+			psk, err := generateRandomPSK(ipsecSecretLength)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(psk).To(HaveLen(testPSKLen))
+			Expect(psk).To(HaveLen(ipsecSecretLength))
 		})
 	})
 
 	When("NewBrokerPSKSecret is called", func() {
 		It("should return a secret with a psk data inside", func() {
-			secret, err := NewBrokerPSKSecret(testPSKLen)
+			secret, err := newIPSECPSKSecret()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(secret.Name).To(Equal("submariner-ipsec-psk"))
 			Expect(secret.Data).To(HaveKey("psk"))
-			Expect(secret.Data["psk"]).To(HaveLen(testPSKLen))
+			Expect(secret.Data["psk"]).To(HaveLen(ipsecSecretLength))
 		})
 	})
 


### PR DESCRIPTION
Subctl should not store the IPSEC secret in the broker, because
even if the broker is compromised, still without the IPSEC factor
an attacking actor could not connect to the remote clusters.

To minimize the risk of IPSEC key loss the broker-info.subm file
is backed up, and if the file is found locally, it's IPSEC PSK key
is reused. Also can be provided via a cmdline flag "--ipsec-psk-from"
Fixes: #93

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>