### PR TITLE
Remove cluster-dump on error

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -191,15 +191,6 @@ function cleanup {
     fi
 }
 
-function dump_clusters_on_error {
-    for i in 1 2 3; do
-        echo "Dumping cluster information for cluster$i ==========================="
-        kubectl --context=cluster$i cluster-info dump
-        echo ""
-    done
-    exit 1
-}
-
 ### Main ###
 
 if [[ $1 = clean ]]; then
@@ -236,8 +227,6 @@ create_subm_vars
 verify_subm_broker_secrets
 
 . kind-e2e/lib_operator_deploy_subm.sh
-
-trap dump_clusters_on_error ERR
 
 for i in 2 3; do
     context=cluster$i


### PR DESCRIPTION
Cluster dump only generates a lot of noise on the logs, and nothing
useful so far. We're removing it because it's caused more headaches
than help.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>