### PR TITLE
Add lighthouse option to subctl

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	lighthouse "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/deploy"
 
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
+	lighthouse "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/deploy"
 )
 
 var (

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -28,14 +28,14 @@ import (
 
 var enableDataplane bool
 var disableDataplane bool
-var enableLighthouse bool
+var serviceDiscovery bool
 
 func init() {
 	deployBroker.PersistentFlags().BoolVar(&enableDataplane, "dataplane", false,
 		"Install the Submariner dataplane on the broker")
 	deployBroker.PersistentFlags().BoolVar(&disableDataplane, "no-dataplane", true,
 		"Don't install the Submariner dataplane on the broker (default)")
-	deployBroker.PersistentFlags().BoolVar(&enableLighthouse, "service-discovery", false,
+	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", false,
 		"Enable Multi Cluster Service Discovery")
 	err := deployBroker.PersistentFlags().MarkHidden("no-dataplane")
 	// An error here indicates a programming error (the argument isn’t declared), panic
@@ -61,8 +61,9 @@ var deployBroker = &cobra.Command{
 		status.End(err == nil)
 		exitOnError("Error deploying the broker", err)
 
-		subctlData, err := datafile.NewFromCluster(config, broker.SubmarinerBrokerNamespace, enableLighthouse)
+		subctlData, err := datafile.NewFromCluster(config, broker.SubmarinerBrokerNamespace)
 		exitOnError("Error retrieving the broker information", err)
+		subctlData.ServiceDiscovery = serviceDiscovery
 
 		fmt.Printf("Writing submariner broker data to %s\n", brokerDetailsFilename)
 		err = subctlData.WriteToFile(brokerDetailsFilename)

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -28,12 +28,15 @@ import (
 
 var enableDataplane bool
 var disableDataplane bool
+var enableLighthouse bool
 
 func init() {
 	deployBroker.PersistentFlags().BoolVar(&enableDataplane, "dataplane", false,
 		"Install the Submariner dataplane on the broker")
 	deployBroker.PersistentFlags().BoolVar(&disableDataplane, "no-dataplane", true,
 		"Don't install the Submariner dataplane on the broker (default)")
+	deployBroker.PersistentFlags().BoolVar(&enableLighthouse, "service-discovery", false,
+		"Enable Multi Cluster Service Discovery")
 	err := deployBroker.PersistentFlags().MarkHidden("no-dataplane")
 	// An error here indicates a programming error (the argument isn’t declared), panic
 	panicOnError(err)
@@ -58,7 +61,7 @@ var deployBroker = &cobra.Command{
 		status.End(err == nil)
 		exitOnError("Error deploying the broker", err)
 
-		subctlData, err := datafile.NewFromCluster(config, broker.SubmarinerBrokerNamespace)
+		subctlData, err := datafile.NewFromCluster(config, broker.SubmarinerBrokerNamespace, enableLighthouse)
 		exitOnError("Error retrieving the broker information", err)
 
 		fmt.Printf("Writing submariner broker data to %s\n", brokerDetailsFilename)

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -32,6 +32,7 @@ type SubctlData struct {
 	BrokerURL   string     `json:"brokerURL"`
 	ClientToken *v1.Secret `omitempty,json:"clientToken"`
 	IPSecPSK    *v1.Secret `omitempty,json:"ipsecPSK"`
+	Lighthouse  bool `omitempty,json:"serviceDiscovery"`
 }
 
 func (data *SubctlData) ToString() (string, error) {
@@ -73,7 +74,7 @@ func NewFromFile(filename string) (*SubctlData, error) {
 	return NewFromString(string(dat))
 }
 
-func NewFromCluster(restConfig *rest.Config, brokerNamespace string) (*SubctlData, error) {
+func NewFromCluster(restConfig *rest.Config, brokerNamespace string, enableLighthouse bool) (*SubctlData, error) {
 
 	clientSet, err := clientset.NewForConfig(restConfig)
 	if err != nil {
@@ -84,6 +85,7 @@ func NewFromCluster(restConfig *rest.Config, brokerNamespace string) (*SubctlDat
 		return nil, err
 	}
 	subCtlData.BrokerURL = restConfig.Host + restConfig.APIPath
+	subCtlData.Lighthouse = enableLighthouse
 	return subCtlData, err
 }
 

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -29,10 +29,10 @@ import (
 )
 
 type SubctlData struct {
-	BrokerURL   string     `json:"brokerURL"`
-	ClientToken *v1.Secret `omitempty,json:"clientToken"`
-	IPSecPSK    *v1.Secret `omitempty,json:"ipsecPSK"`
-	Lighthouse  bool `omitempty,json:"serviceDiscovery"`
+	BrokerURL        string     `json:"brokerURL"`
+	ClientToken      *v1.Secret `omitempty,json:"clientToken"`
+	IPSecPSK         *v1.Secret `omitempty,json:"ipsecPSK"`
+	ServiceDiscovery bool       `omitempty,json:"serviceDiscovery"`
 }
 
 func (data *SubctlData) ToString() (string, error) {
@@ -74,7 +74,7 @@ func NewFromFile(filename string) (*SubctlData, error) {
 	return NewFromString(string(dat))
 }
 
-func NewFromCluster(restConfig *rest.Config, brokerNamespace string, enableLighthouse bool) (*SubctlData, error) {
+func NewFromCluster(restConfig *rest.Config, brokerNamespace string) (*SubctlData, error) {
 
 	clientSet, err := clientset.NewForConfig(restConfig)
 	if err != nil {
@@ -85,7 +85,6 @@ func NewFromCluster(restConfig *rest.Config, brokerNamespace string, enableLight
 		return nil, err
 	}
 	subCtlData.BrokerURL = restConfig.Host + restConfig.APIPath
-	subCtlData.Lighthouse = enableLighthouse
 	return subCtlData, err
 }
 

--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -1,0 +1,25 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lighthouse
+
+import (
+	"k8s.io/client-go/rest"
+)
+
+func Ensure(config *rest.Config, repo string, version string) error {
+	return nil
+}


### PR DESCRIPTION
1. Adds 'service-discovery' option to subctl when deploying broker
2. Adds the parameter to subm file so can be used when joining clusters