### PR TITLE
Version on crash

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -84,6 +84,9 @@ func homeDir() string {
 
 func panicOnError(err error) {
 	if err != nil {
+		fmt.Fprintln(os.Stderr, "")
+		PrintSubctlVersion(os.Stderr)
+		fmt.Fprintln(os.Stderr, "")
 		panic(err.Error())
 	}
 }
@@ -92,6 +95,8 @@ func panicOnError(err error) {
 func exitOnError(format string, err error) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, format, err.Error())
+		fmt.Fprintln(os.Stderr, "")
+		PrintSubctlVersion(os.Stderr)
 		fmt.Fprintln(os.Stderr, "")
 		os.Exit(1)
 	}

--- a/pkg/subctl/cmd/version.go
+++ b/pkg/subctl/cmd/version.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -38,6 +40,10 @@ func init() {
 }
 
 func subctlVersion(cmd *cobra.Command, args []string) {
-	fmt.Printf("subctl version: %s\n", version.Version)
-	fmt.Printf("built from git commit id: %s\n", version.Commit)
+	PrintSubctlVersion(os.Stdout)
+}
+
+func PrintSubctlVersion(w io.Writer) {
+	fmt.Fprintf(w, "subctl version: %s\n", version.Version)
+	fmt.Fprintf(w, "built from git commit id: %s\n", version.Commit)
 }


### PR DESCRIPTION
Sometimes we have crash reports, but no info on which version was it ran from.

This will dump the version of subctl as part of the exit or panic error.