### PR TITLE
Ensure embedded YAMLs are generated if yamls2go changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ shell: .dapper
 bin/subctl: pkg/subctl/operator/install/embeddedyamls/yamls.go $(shell find pkg/subctl/ -name "*.go")
 	$(MAKE) build-subctl
 
-pkg/subctl/operator/install/embeddedyamls/yamls.go: $(shell find deploy/ -name "*.yaml")
+pkg/subctl/operator/install/embeddedyamls/yamls.go: pkg/subctl/operator/install/embeddedyamls/generators/yamls2go.go $(shell find deploy/ -name "*.yaml")
 	$(MAKE) generate-embeddedyamls
 
 .DEFAULT_GOAL := ci


### PR DESCRIPTION
Currently, we rebuild the embedded YAMLs if the source YAMLs change;
but since the list of YAMLs is contained in yamls2go, we need to watch
that too.

Signed-off-by: Stephen Kitt <skitt@redhat.com>