### PR TITLE
Deploy the KubeFed controller

### DIFF
--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/install"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/kubefedop"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/kubefed"
 )
 
 const (
@@ -34,7 +34,8 @@ const (
 
 func Ensure(status *cli.Status, config *rest.Config, repo string, version string, isController bool) error {
 	image := ""
-	err := kubefedop.Ensure(status, config, "kubefed-operator", "quay.io/openshift/kubefed-operator:v0.1.0-rc3")
+	// Ensure KubeFed
+	err := kubefed.Ensure(status, config, "kubefed-operator", "quay.io/openshift/kubefed-operator:v0.1.0-rc3")
 	if err != nil {
 		return fmt.Errorf("error deploying KubeFed: %s", err)
 	}

--- a/pkg/subctl/operator/kubefed/ensure.go
+++ b/pkg/subctl/operator/kubefed/ensure.go
@@ -1,0 +1,41 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/kubefedcr"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/kubefedop"
+)
+
+func Ensure(status *cli.Status, config *rest.Config, operatorNamespace string, operatorImage string) error {
+
+	err := kubefedop.Ensure(status, config, "kubefed-operator", "quay.io/openshift/kubefed-operator:v0.1.0-rc3")
+	if err != nil {
+		return fmt.Errorf("error deploying KubeFed: %s", err)
+	}
+	err = kubefedcr.Ensure(config, "kubefed-operator")
+	if err != nil {
+		return fmt.Errorf("error deploying KubeFed: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/subctl/operator/kubefedcr/ensure.go
+++ b/pkg/subctl/operator/kubefedcr/ensure.go
@@ -1,0 +1,55 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefedcr
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+
+	"k8s.io/client-go/rest"
+)
+
+const kubefedResource = `
+apiVersion: operator.kubefed.io/v1alpha1
+kind: KubeFed
+metadata:
+  name: kubefed-resource
+spec:
+  scope: Cluster
+`
+
+func Ensure(config *rest.Config, namespace string) error {
+
+	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", "-")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("error setting up kubectl to deploy KubeFed: %s", err)
+	}
+
+	go func() {
+		defer stdin.Close()
+		_, _ = io.WriteString(stdin, kubefedResource)
+	}()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running kubectl to deploy KubeFed: %s\n%s", err, out)
+	}
+
+	return nil
+}


### PR DESCRIPTION
I wasn’t able to generate the correct KubeFed clientset, so this runs
kubectl to deploy the CR.

Signed-off-by: Stephen Kitt <skitt@redhat.com>