### PR TITLE
Support specifying contexts

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -64,7 +64,7 @@ var deployBroker = &cobra.Command{
 	Use:   "deploy-broker",
 	Short: "set the broker up",
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := getRestConfig()
+		config, err := getRestConfig(kubeConfig, kubeContext)
 		exitOnError("The provided kubeconfig is invalid", err)
 
 		status := cli.NewStatus()
@@ -110,7 +110,7 @@ var deployBroker = &cobra.Command{
 		}
 
 		if enableDataplane {
-			joinSubmarinerCluster(subctlData)
+			joinSubmarinerCluster(config, subctlData)
 		}
 	},
 }

--- a/pkg/subctl/cmd/info.go
+++ b/pkg/subctl/cmd/info.go
@@ -37,7 +37,9 @@ func init() {
 
 func clusterInfo(cmd *cobra.Command, args []string) {
 
-	dynClient, clientSet, err := getClients()
+	config, err := getRestConfig(kubeConfig, kubeContext)
+	panicOnError(err)
+	dynClient, clientSet, err := getClients(config)
 	panicOnError(err)
 
 	clusterNetwork, err := network.Discover(dynClient, clientSet)

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 
 	submariner "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
@@ -87,7 +88,9 @@ var joinCmd = &cobra.Command{
 		subctlData, err := datafile.NewFromFile(args[0])
 		exitOnError("Error loading the broker information from the given file", err)
 		fmt.Printf("* %s says broker is at: %s\n", args[0], subctlData.BrokerURL)
-		joinSubmarinerCluster(subctlData)
+		config, err := getRestConfig(kubeConfig, kubeContext)
+		exitOnError("Error connecting to the target cluster", err)
+		joinSubmarinerCluster(config, subctlData)
 	},
 }
 
@@ -98,7 +101,7 @@ func checkArgumentPassed(args []string) error {
 	return nil
 }
 
-func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
+func joinSubmarinerCluster(config *rest.Config, subctlData *datafile.SubctlData) {
 
 	// Missing information
 	var qs = []*survey.Question{}
@@ -143,18 +146,15 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 		}
 	}
 
-	config, err := getRestConfig()
-	exitOnError("Unable to determine the Kubernetes connection configuration", err)
-
 	if !noLabel {
-		err = handleNodeLabels()
+		err := handleNodeLabels(config)
 		exitOnError("Unable to set the gateway node up", err)
 	}
 
 	status := cli.NewStatus()
 
 	status.Start("Deploying the Submariner operator")
-	err = submarinerop.Ensure(status, config, OperatorNamespace, operatorImage)
+	err := submarinerop.Ensure(status, config, OperatorNamespace, operatorImage)
 	status.End(err == nil)
 	exitOnError("Error deploying the operator", err)
 
@@ -166,7 +166,7 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 	}
 
 	fmt.Printf("* Discovering network details\n")
-	networkDetails := getNetworkDetails()
+	networkDetails := getNetworkDetails(config)
 
 	serviceCIDR, err = getServiceCIDR(serviceCIDR, networkDetails)
 	exitOnError("Error determining the service CIDR", err)
@@ -180,9 +180,9 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 	exitOnError("Error deploying Submariner", err)
 }
 
-func getNetworkDetails() *network.ClusterNetwork {
+func getNetworkDetails(config *rest.Config) *network.ClusterNetwork {
 
-	dynClient, clientSet, err := getClients()
+	dynClient, clientSet, err := getClients(config)
 	exitOnError("Unable to set the Kubernetes cluster connection up", err)
 	networkDetails, err := network.Discover(dynClient, clientSet)
 	if err != nil {

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -41,8 +41,9 @@ import (
 )
 
 var (
-	kubeConfig string
-	rootCmd    = &cobra.Command{
+	kubeConfig  string
+	kubeContext string
+	rootCmd     = &cobra.Command{
 		Use:   "subctl",
 		Short: "An installer for Submariner",
 	}
@@ -54,6 +55,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", kubeConfigFile(), "absolute path(s) to the kubeconfig file(s)")
+	rootCmd.PersistentFlags().StringVar(&kubeContext, "kubecontext", "", "kubeconfig context to use")
 }
 
 const (
@@ -102,11 +104,7 @@ func exitOnError(message string, err error) {
 	}
 }
 
-func getClients() (dynamic.Interface, kubernetes.Interface, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
-	if err != nil {
-		return nil, nil, err
-	}
+func getClients(config *rest.Config) (dynamic.Interface, kubernetes.Interface, error) {
 	dynClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err
@@ -118,12 +116,19 @@ func getClients() (dynamic.Interface, kubernetes.Interface, error) {
 	return dynClient, clientSet, nil
 }
 
-func getRestConfig() (*rest.Config, error) {
-	return clientcmd.BuildConfigFromFlags("", kubeConfig)
+func getRestConfig(kubeConfigPath string, kubeContext string) (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = kubeConfigPath
+	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+	if kubeContext != "" {
+		overrides.CurrentContext = kubeContext
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
 }
 
-func handleNodeLabels() error {
-	_, clientset, err := getClients()
+func handleNodeLabels(config *rest.Config) error {
+	_, clientset, err := getClients(config)
 	exitOnError("Unable to set the Kubernetes cluster connection up", err)
 	// List Submariner-labeled nodes
 	const submarinerGatewayLabel = "submariner.io/gateway"

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -77,7 +77,7 @@ function setup_broker() {
         echo Installing broker on cluster1.
          sd=
          [[ $lighthouse = true ]] && sd=--service-discovery
-         ../bin/subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster1 deploy-broker ${sd} |& cat
+         ../bin/subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster1 --kubecontext cluster1 deploy-broker ${sd} |& cat
     fi
 
     SUBMARINER_BROKER_URL=$(kubectl --context=cluster1 -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
@@ -245,6 +245,7 @@ for i in 2 3; do
     if [ "${context}" = "cluster2" ] || [ "${context}" = "cluster3" ]; then
         ../bin/subctl join --operator-image submariner-operator:local \
                         --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context \
+                        --kubecontext ${context} \
                         --clusterid ${context} \
                         --repository ${subm_engine_image_repo} \
                         --version ${subm_engine_image_tag} \
@@ -297,6 +298,7 @@ echo "Running subctl a second time to verify if running subctl a second time wor
 
 ../bin/subctl join --operator-image submariner-operator:local \
                 --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context \
+                --kubecontext ${context} \
                 --clusterid ${context} \
                 --repository ${subm_engine_image_repo} \
                 --version ${subm_engine_image_tag} \


### PR DESCRIPTION
... as well as the kubeconfig file. This will be necessary for KIND
upgrades since KIND (and Kubernetes in general) is moving away from
separate kubeconfig files.

Signed-off-by: Stephen Kitt <skitt@redhat.com>