### PR TITLE
Describe subctl dependencies on build-subctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ $(TARGETS): .dapper
 shell: .dapper
 	./.dapper -s -m bind
 
-bin/subctl: pkg/subctl/operator/common/embeddedyamls/yamls.go $(shell find pkg/subctl/ -name "*.go")
-	$(MAKE) build-subctl
+build-subctl: pkg/subctl/operator/common/embeddedyamls/yamls.go $(shell find pkg/subctl/ -name "*.go")
+
+bin/subctl: build-subctl
 
 pkg/subctl/operator/common/embeddedyamls/yamls.go: pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go $(shell find deploy/ -name "*.yaml")
 	$(MAKE) generate-embeddedyamls


### PR DESCRIPTION
Targets can have multiple sets of dependencies, so we can specify
build-subctl’s dependencies, and specify that bin/subctl depends on
that.

(This can’t be extended too far, otherwise we end up with too many
phony dependencies in the chain, and everything gets rebuilt all the
time.)

Fixes: #126
Signed-off-by: Stephen Kitt <skitt@redhat.com>