### PR TITLE
Encapsulate Lighthouse DNS handling

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -32,7 +32,6 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	lighthouse "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/deploy"
-	lighthousedns "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/dns"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
 )
@@ -163,11 +162,6 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 	exitOnError("Error deploying the operator", err)
 
 	if subctlData.ServiceDiscovery {
-		status.Start("Setting up DNS")
-		err = lighthousedns.Ensure(status, config)
-		status.End(err == nil)
-		exitOnError("Error setting up DNS", err)
-
 		status.Start("Deploying multi cluster service discovery")
 		err = lighthouse.Ensure(status, config, "", "", false)
 		status.End(err == nil)

--- a/pkg/subctl/lighthouse/install/ensure.go
+++ b/pkg/subctl/lighthouse/install/ensure.go
@@ -42,7 +42,6 @@ func Ensure(status *cli.Status, config *rest.Config, image string, isController 
 		} else if created {
 			status.QueueSuccessMessage("Created lighthouse controller")
 		}
-		status.QueueSuccessMessage("TODO: Create lighthouse controller")
 	}
 
 	return nil


### PR DESCRIPTION
This pulls in the Lighthouse DNS setup inside the general Lighthouse
setup, so that external callers don’t need to know about it. It also
centralises version handling for the Lighthouse components.

Signed-off-by: Stephen Kitt <skitt@redhat.com>