### PR TITLE
Bump versions to 0.1.0 and centralize versions

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: submariner-operator
           # Replace this with the built image name
-          image: quay.io/submariner/submariner-operator:0.0.2
+          image: quay.io/submariner/submariner-operator:0.1.0
           command:
           - submariner-operator
           imagePullPolicy: Always

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	submarinerv1alpha1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/versions"
+
 	corev1 "k8s.io/api/core/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -382,11 +384,11 @@ func setSubmarinerDefaults(submariner *submarinerv1alpha1.Submariner) {
 
 	if submariner.Spec.Repository == "" {
 		// An empty field is converted to the default upstream submariner repository where all images live
-		submariner.Spec.Repository = "quay.io/submariner"
+		submariner.Spec.Repository = versions.DefaultSubmarinerRepo
 	}
 
 	if submariner.Spec.Version == "" {
-		submariner.Spec.Version = "0.0.3"
+		submariner.Spec.Version = versions.DefaultSubmarinerVersion
 	}
 
 	if submariner.Spec.ColorCodes == "" {

--- a/pkg/controller/submariner/submariner_controller_test.go
+++ b/pkg/controller/submariner/submariner_controller_test.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	submariner_v1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/versions"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,8 +194,8 @@ func testReconciliation() {
 			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: submarinerName, Namespace: submarinerNamespace}, updated)
 			Expect(err).To(Succeed())
 
-			Expect(updated.Spec.Repository).To(Equal("quay.io/submariner"))
-			Expect(updated.Spec.Version).To(Equal("0.0.3"))
+			Expect(updated.Spec.Repository).To(Equal(versions.DefaultSubmarinerRepo))
+			Expect(updated.Spec.Version).To(Equal(versions.DefaultSubmarinerVersion))
 		})
 	})
 

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -35,6 +35,7 @@ import (
 	lighthouse "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/deploy"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
+	"github.com/submariner-io/submariner-operator/pkg/versions"
 )
 
 var (
@@ -270,13 +271,13 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData) submariner.Submarin
 	if len(repository) == 0 {
 		// Default repository
 		// This is handled in the operator after 0.0.1 (of the operator)
-		repository = "quay.io/submariner"
+		repository = versions.DefaultSubmarinerRepo
 	}
 
 	if len(imageVersion) == 0 {
 		// Default engine version
 		// This is handled in the operator after 0.0.1 (of the operator)
-		imageVersion = "0.0.3"
+		imageVersion = versions.DefaultSubmarinerVersion
 	}
 
 	submarinerSpec := submariner.SubmarinerSpec{

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/spf13/cobra"
+
+	"github.com/submariner-io/submariner-operator/pkg/versions"
 )
 
 var (
@@ -62,7 +64,7 @@ func addKubeconfigFlag(cmd *cobra.Command) {
 }
 
 const (
-	DefaultOperatorImage = "quay.io/submariner/submariner-operator:0.0.1"
+	DefaultOperatorImage = versions.DefaultSubmarinerRepo + "/submariner-operator:" + versions.DefaultSubmarinerOperatorVersion
 	OperatorNamespace    = "submariner-operator"
 )
 

--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -116,7 +116,7 @@ func canonicaliseRepoVersion(repo string, version string) (string, string) {
 		return "", version
 	}
 	if repo == "" {
-		repo = defaultControllerImageRepo
+		repo = versions.DefaultSubmarinerRepo
 	}
 	if repo[len(repo)-1:] != "/" {
 		repo = repo + "/"

--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -30,14 +30,11 @@ import (
 	lighthousedns "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/dns"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/install"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/kubefed"
+	"github.com/submariner-io/submariner-operator/pkg/versions"
 )
 
 const (
-	defaultControllerImageName    = "lighthouse-controller"
-	defaultControllerImageRepo    = "quay.io/submariner"
-	defaultControllerImageVersion = "0.1.0"
-	kubefedVersion                = "v0.1.0-rc3"
-	kubefedctlVersionPrefix       = "kubefedctl version: version.Info"
+	kubefedctlVersionPrefix = "kubefedctl version: version.Info"
 )
 
 var (
@@ -49,9 +46,9 @@ var (
 func AddFlags(cmd *cobra.Command, prefix string) {
 	cmd.PersistentFlags().BoolVar(&serviceDiscovery, prefix, false,
 		"Enable Multi Cluster Service Discovery")
-	cmd.PersistentFlags().StringVar(&imageRepo, prefix+"-repo", defaultControllerImageRepo,
+	cmd.PersistentFlags().StringVar(&imageRepo, prefix+"-repo", versions.DefaultSubmarinerRepo,
 		"Service Discovery Image repository")
-	cmd.PersistentFlags().StringVar(&imageVersion, prefix+"-version", defaultControllerImageVersion,
+	cmd.PersistentFlags().StringVar(&imageVersion, prefix+"-version", versions.DefaultLighthouseVersion,
 		"Service Discovery Image version")
 }
 
@@ -64,7 +61,7 @@ func Validate() error {
 		}
 		output := string(out)
 		if !strings.HasPrefix(output, kubefedctlVersionPrefix) {
-			return fmt.Errorf("unable to determine kubefedctl version, please use %s", kubefedVersion)
+			return fmt.Errorf("unable to determine kubefedctl version, please use %s", versions.KubeFedVersion)
 		}
 		// We need to tweak the output to make it valid JSON again...
 		output = output[len(kubefedctlVersionPrefix):]
@@ -80,8 +77,9 @@ func Validate() error {
 		if err != nil {
 			return err
 		}
-		if v.Version != kubefedVersion {
-			return fmt.Errorf("invalid kubefedctl version %s, please use %s", v.Version, kubefedVersion)
+		if v.Version != versions.KubeFedVersion {
+			return fmt.Errorf("invalid kubefedctl version %s, please use %s", v.Version,
+				versions.KubeFedVersion)
 		}
 	}
 	return nil
@@ -97,14 +95,15 @@ func Ensure(status *cli.Status, config *rest.Config, repo string, version string
 	}
 
 	// Ensure KubeFed
-	err = kubefed.Ensure(status, config, "kubefed-operator", "quay.io/openshift/kubefed-operator:"+kubefedVersion, isController)
+	err = kubefed.Ensure(status, config, "kubefed-operator",
+		"quay.io/openshift/kubefed-operator:"+versions.KubeFedVersion, isController)
 	if err != nil {
 		return fmt.Errorf("error deploying KubeFed: %s", err)
 	}
 	image := ""
 	// Ensure lighthouse
 	if isController {
-		image = generateImageName(repo, defaultControllerImageName, version)
+		image = generateImageName(repo, versions.DefaultLighthouseVersion, version)
 	}
 	return install.Ensure(status, config, image, isController)
 }
@@ -123,7 +122,7 @@ func canonicaliseRepoVersion(repo string, version string) (string, string) {
 		repo = repo + "/"
 	}
 	if version == "" {
-		version = defaultControllerImageVersion
+		version = versions.DefaultLighthouseVersion
 	}
 	return repo, version
 }

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -1,0 +1,9 @@
+package versions
+
+const (
+	DefaultSubmarinerRepo            = "quay.io/submariner"
+	DefaultSubmarinerOperatorVersion = "0.1.0"
+	DefaultSubmarinerVersion         = "0.1.0"
+	DefaultLighthouseVersion         = "0.1.0"
+	KubeFedVersion                   = "v0.1.0-rc3"
+)


### PR DESCRIPTION
This will fail until we release 0.1.0 in submariner.