### PR TITLE
Vendor as needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARGETS := $(shell ls scripts)
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper
 
-$(TARGETS): .dapper
+$(TARGETS): .dapper vendor/modules.txt
 	./.dapper -m bind $@ $(status) $(lighthouse)
 
 shell: .dapper
@@ -21,6 +21,9 @@ bin/subctl: pkg/subctl/operator/common/embeddedyamls/yamls.go $(shell find pkg/s
 
 pkg/subctl/operator/common/embeddedyamls/yamls.go: pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go $(shell find deploy/ -name "*.yaml")
 	$(MAKE) generate-embeddedyamls
+
+vendor/modules.txt: .dapper go.mod
+	./.dapper -m bind vendor
 
 .DEFAULT_GOAL := ci
 


### PR DESCRIPTION
vendor/modules.txt is updated whenever "go mod vendor" is run, so we
can use that to track vendor freshness compared to go.mod. This avoids
problems with an already-present but out-dated vendor directory when
we add or update dependencies.

Signed-off-by: Stephen Kitt <skitt@redhat.com>