### PR TITLE
subctl: Check for overlapping CIDRs

### DIFF
--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -1,0 +1,82 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalnet
+
+import (
+	"fmt"
+	"net"
+
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type GlobalNetwork struct {
+	GlobalCIDRs  []string
+	ServiceCIDRs []string
+	ClusterId    string
+}
+
+func (gn *GlobalNetwork) Show() {
+	if gn == nil {
+		fmt.Println("    No global network details discovered")
+	} else {
+		fmt.Printf("    Discovered global network details for Cluster %s:\n", gn.ClusterId)
+		fmt.Printf("        ServiceCidrs: %v\n", gn.ServiceCIDRs)
+		fmt.Printf("        Global CIDRs: %v\n", gn.GlobalCIDRs)
+
+	}
+}
+
+func ShowNetworks(networks map[string]*GlobalNetwork) {
+	for _, network := range networks {
+		network.Show()
+	}
+}
+
+func Discover(client *submarinerClientset.Clientset, namespace string) (map[string]*GlobalNetwork, error) {
+	clusters, err := client.SubmarinerV1().Clusters(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var globalNetworks = make(map[string]*GlobalNetwork)
+	for _, cluster := range clusters.Items {
+		globalNetwork := GlobalNetwork{
+			GlobalCIDRs:  cluster.Spec.GlobalCIDR,
+			ServiceCIDRs: cluster.Spec.ServiceCIDR,
+			ClusterId:    cluster.Spec.ClusterID,
+		}
+		globalNetworks[cluster.Spec.ClusterID] = &globalNetwork
+	}
+	return globalNetworks, nil
+}
+
+func IsOverlappingCIDR(cidrList []string, cidr string) (bool, error) {
+	_, newNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, err
+	}
+	for _, v := range cidrList {
+		_, baseNet, err := net.ParseCIDR(v)
+		if err != nil {
+			return false, err
+		}
+		if baseNet.Contains(newNet.IP) || newNet.Contains(baseNet.IP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -27,6 +27,7 @@ import (
 type GlobalNetwork struct {
 	GlobalCIDRs  []string
 	ServiceCIDRs []string
+	ClusterCIDRs []string
 	ClusterId    string
 }
 
@@ -36,6 +37,7 @@ func (gn *GlobalNetwork) Show() {
 	} else {
 		fmt.Printf("    Discovered global network details for Cluster %s:\n", gn.ClusterId)
 		fmt.Printf("        ServiceCidrs: %v\n", gn.ServiceCIDRs)
+		fmt.Printf("        ClusterCidrs: %v\n", gn.ClusterCIDRs)
 		fmt.Printf("        Global CIDRs: %v\n", gn.GlobalCIDRs)
 
 	}
@@ -57,6 +59,7 @@ func Discover(client *submarinerClientset.Clientset, namespace string) (map[stri
 		globalNetwork := GlobalNetwork{
 			GlobalCIDRs:  cluster.Spec.GlobalCIDR,
 			ServiceCIDRs: cluster.Spec.ServiceCIDR,
+			ClusterCIDRs: cluster.Spec.ClusterCIDR,
 			ClusterId:    cluster.Spec.ClusterID,
 		}
 		globalNetworks[cluster.Spec.ClusterID] = &globalNetwork

--- a/pkg/discovery/globalnet/globalnet_suite_test.go
+++ b/pkg/discovery/globalnet/globalnet_suite_test.go
@@ -1,0 +1,13 @@
+package globalnet_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGlobalnet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Globalnet Suite")
+}

--- a/pkg/discovery/globalnet/globalnet_test.go
+++ b/pkg/discovery/globalnet/globalnet_test.go
@@ -1,0 +1,99 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalnet
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IsOverlappingCidr", func() {
+	When("There are no base CIDRs", func() {
+		overlapping, err := IsOverlappingCIDR([]string{}, "10.10.10.0/24")
+		It("Should return false", func() {
+			Expect(overlapping).To(BeFalse())
+		})
+		It("Should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("At least one Base CIDR is superset of new CIDR", func() {
+		overlapping, err := IsOverlappingCIDR([]string{"10.10.0.0/16", "10.20.30.0/24"}, "10.10.10.0/24")
+		It("Should return true", func() {
+			Expect(overlapping).To(BeTrue())
+		})
+		It("Should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("At least one Base CIDR is subset of new CIDR", func() {
+		overlapping, err := IsOverlappingCIDR([]string{"10.10.10.0/24", "10.10.20.0/24"}, "10.10.30.0/16")
+		It("Should return true", func() {
+			Expect(overlapping).To(BeTrue())
+		})
+		It("Should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("At least one Base CIDR is subset of new CIDR", func() {
+		overlapping, err := IsOverlappingCIDR([]string{"10.10.0.0/16", "10.20.30.0/24"}, "10.10.10.0/24")
+		It("Should return true", func() {
+			Expect(overlapping).To(BeTrue())
+		})
+		It("Should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("New CIDR partially overlaps with at least one Base CIDR", func() {
+		overlapping, err := IsOverlappingCIDR([]string{"10.10.10.0/24"}, "10.10.10.128/22")
+		It("Should return true", func() {
+			Expect(overlapping).To(BeTrue())
+		})
+		It("Should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("New CIDR lies between any two Base CIDR", func() {
+		overlapping, err := IsOverlappingCIDR([]string{"10.10.10.0/24", "10.10.30.0/24"}, "10.10.20.128/24")
+		It("Should return false", func() {
+			Expect(overlapping).To(BeFalse())
+		})
+		It("Should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("At least one Base CIDR is invalid", func() {
+		_, err := IsOverlappingCIDR([]string{"10.10.10.0/33", "10.10.30.0/24"}, "10.10.20.128/24")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("New CIDR is invalid", func() {
+		_, err := IsOverlappingCIDR([]string{"10.10.10.0/24", "10.10.30.0/24"}, "10.10.20.300/24")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+})

--- a/pkg/discovery/globalnet/globalnet_test.go
+++ b/pkg/discovery/globalnet/globalnet_test.go
@@ -24,61 +24,51 @@ import (
 var _ = Describe("IsOverlappingCidr", func() {
 	When("There are no base CIDRs", func() {
 		overlapping, err := IsOverlappingCIDR([]string{}, "10.10.10.0/24")
-		It("Should return false", func() {
-			Expect(overlapping).To(BeFalse())
-		})
 		It("Should not return error", func() {
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should return false", func() {
+			Expect(overlapping).To(BeFalse())
 		})
 	})
 
 	When("At least one Base CIDR is superset of new CIDR", func() {
 		overlapping, err := IsOverlappingCIDR([]string{"10.10.0.0/16", "10.20.30.0/24"}, "10.10.10.0/24")
-		It("Should return true", func() {
-			Expect(overlapping).To(BeTrue())
-		})
 		It("Should not return error", func() {
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should return true", func() {
+			Expect(overlapping).To(BeTrue())
 		})
 	})
 
 	When("At least one Base CIDR is subset of new CIDR", func() {
 		overlapping, err := IsOverlappingCIDR([]string{"10.10.10.0/24", "10.10.20.0/24"}, "10.10.30.0/16")
-		It("Should return true", func() {
-			Expect(overlapping).To(BeTrue())
-		})
 		It("Should not return error", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
-	})
-
-	When("At least one Base CIDR is subset of new CIDR", func() {
-		overlapping, err := IsOverlappingCIDR([]string{"10.10.0.0/16", "10.20.30.0/24"}, "10.10.10.0/24")
 		It("Should return true", func() {
 			Expect(overlapping).To(BeTrue())
-		})
-		It("Should not return error", func() {
-			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
 	When("New CIDR partially overlaps with at least one Base CIDR", func() {
 		overlapping, err := IsOverlappingCIDR([]string{"10.10.10.0/24"}, "10.10.10.128/22")
-		It("Should return true", func() {
-			Expect(overlapping).To(BeTrue())
-		})
 		It("Should not return error", func() {
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should return true", func() {
+			Expect(overlapping).To(BeTrue())
 		})
 	})
 
 	When("New CIDR lies between any two Base CIDR", func() {
 		overlapping, err := IsOverlappingCIDR([]string{"10.10.10.0/24", "10.10.30.0/24"}, "10.10.20.128/24")
-		It("Should return false", func() {
-			Expect(overlapping).To(BeFalse())
-		})
 		It("Should not return error", func() {
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should return false", func() {
+			Expect(overlapping).To(BeFalse())
 		})
 	})
 

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -111,3 +111,16 @@ func newFromCluster(clientSet clientset.Interface, brokerNamespace, ipsecSubmFil
 		return subctlData, err
 	}
 }
+
+func (data *SubctlData) GetBrokerConfig() *rest.Config {
+	tlsClientconfig := rest.TLSClientConfig{}
+	tlsClientconfig.CAData = data.ClientToken.Data["ca.crt"]
+	bearerToken := data.ClientToken.Data["token"]
+	restConfig := rest.Config{
+		Host:            data.BrokerURL,
+		TLSClientConfig: tlsClientconfig,
+		BearerToken:     string(bearerToken),
+	}
+	return &restConfig
+
+}


### PR DESCRIPTION
When joining a new cluster, check if serviceCIDR
or clusterCIDR overlaps with any existing cluster.

This code will also be reused for
Globalnet (overlapping cidrs).