### PR TITLE
Provide config and context arguments to commands

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -100,7 +100,7 @@ var deployBroker = &cobra.Command{
 		status.End(err == nil)
 		exitOnError("Error writing the broker information", err)
 
-		err = lighthouse.HandleCommand(status, config, true)
+		err = lighthouse.HandleCommand(status, config, true, kubeConfig, kubeContext)
 		exitOnError("Error setting up service discovery", err)
 
 		if enableDataplane {

--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -92,14 +92,15 @@ func Validate() error {
 	return nil
 }
 
-func HandleCommand(status *cli.Status, config *rest.Config, isController bool) error {
+func HandleCommand(status *cli.Status, config *rest.Config, isController bool, kubeConfig string, kubeContext string) error {
 	status.Start("Deploying Service Discovery controller")
-	err := Ensure(status, config, imageRepo, imageVersion, isController)
+	err := Ensure(status, config, imageRepo, imageVersion, isController, kubeConfig, kubeContext)
 	status.End(err == nil)
 	return err
 }
 
-func Ensure(status *cli.Status, config *rest.Config, repo string, version string, isController bool) error {
+func Ensure(status *cli.Status, config *rest.Config, repo string, version string, isController bool,
+	kubeConfig string, kubeContext string) error {
 	repo, version = canonicaliseRepoVersion(repo, version)
 
 	// Ensure DNS
@@ -110,7 +111,7 @@ func Ensure(status *cli.Status, config *rest.Config, repo string, version string
 
 	// Ensure KubeFed
 	err = kubefed.Ensure(status, config, "kubefed-operator",
-		"quay.io/openshift/kubefed-operator:"+versions.KubeFedVersion, isController)
+		"quay.io/openshift/kubefed-operator:"+versions.KubeFedVersion, isController, kubeConfig, kubeContext)
 	if err != nil {
 		return fmt.Errorf("error deploying KubeFed: %s", err)
 	}
@@ -119,7 +120,7 @@ func Ensure(status *cli.Status, config *rest.Config, repo string, version string
 	if isController {
 		image = generateImageName(repo, defaultControllerImageName, version)
 	}
-	return install.Ensure(status, config, image, isController)
+	return install.Ensure(status, config, image, isController, kubeConfig)
 }
 
 // canonicaliseRepoVersion returns the canonical repo and version for the given

--- a/pkg/subctl/lighthouse/install/crds/ensure.go
+++ b/pkg/subctl/lighthouse/install/crds/ensure.go
@@ -34,7 +34,7 @@ import (
 // Copied over from operator/install/crds/ensure.go
 
 //Ensure functions updates or installs the multiclusterservives CRDs in the cluster
-func Ensure(restConfig *rest.Config) (bool, error) {
+func Ensure(restConfig *rest.Config, kubeConfig string) (bool, error) {
 	clientSet, err := clientset.NewForConfig(restConfig)
 	if err != nil {
 		return false, err
@@ -52,7 +52,12 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	out, err := exec.Command("kubefedctl", "enable", "MulticlusterService", "--kubefed-namespace", "kubefed-operator").CombinedOutput()
+	args := []string{"enable", "MulticlusterService"}
+	if kubeConfig != "" {
+		args = append(args, "--kubeconfig", kubeConfig)
+	}
+	args = append(args, "--kubefed-namespace", "kubefed-operator")
+	out, err := exec.Command("kubefedctl", args...).CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("error federating MulticlusterService CRD: %s\n%s", err, out)
 	}

--- a/pkg/subctl/lighthouse/install/ensure.go
+++ b/pkg/subctl/lighthouse/install/ensure.go
@@ -24,19 +24,15 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/install/deployment"
 )
 
-func Ensure(status *cli.Status, config *rest.Config, image string, isController bool) error {
+func Ensure(status *cli.Status, config *rest.Config, image string, isController bool, kubeConfig string) error {
 
-	if created, err := crds.Ensure(config); err != nil {
+	if created, err := crds.Ensure(config, kubeConfig); err != nil {
 		return err
 	} else if created {
 		status.QueueSuccessMessage("Created lighthouse CRDs")
 	}
 
 	if isController {
-		//TODO: Install controller
-		//TODO: kubefedctl enable MulticlusterService
-		//TODO: kubectl --context=cluster1 patch clusterrole  -n kube-federation-system  kubefed-role  --type json -p "$(cat ${PRJ_ROOT}/scripts/kind-e2e/config/patch-kubefed-clusterrole.yaml)"
-		//TODO: kubectl --context=cluster1 apply -f ${PRJ_ROOT}/package/lighthouse-controller-deployment.yaml
 		if created, err := deployment.Ensure(config, "kubefed-operator", image); err != nil {
 			return err
 		} else if created {

--- a/pkg/subctl/operator/kubefedcr/ensure.go
+++ b/pkg/subctl/operator/kubefedcr/ensure.go
@@ -33,9 +33,17 @@ spec:
   scope: Cluster
 `
 
-func Ensure(config *rest.Config, namespace string) error {
+func Ensure(config *rest.Config, namespace string, kubeConfig string, kubeContext string) error {
 
-	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", "-")
+	args := []string{}
+	if kubeConfig != "" {
+		args = append(args, "--kubeconfig", kubeConfig)
+	}
+	if kubeContext != "" {
+		args = append(args, "--context", kubeContext)
+	}
+	args = append(args, "apply", "-n", namespace, "-f", "-")
+	cmd := exec.Command("kubectl", args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("error setting up kubectl to deploy KubeFed: %s", err)


### PR DESCRIPTION
Currently, subctl runs kubectl and kubefedctl in the default context:
whichever kubeconfig is the default, and whichever context is the
default. If the user specifies --kubeconfig and/or --kubecontext on
the subctl command-line, this causes mix-ups since subctl and the
other tools don’t touch the same cluster.

With this patch, kubectl and kubefedctl are given the appropriate
flags as necessary. This isn’t particularly elegant but it will all be
removed once KubeFed is removed.

Fixes: #180
Signed-off-by: Stephen Kitt <skitt@redhat.com>