### PR TITLE
subctl: add more information to join error

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -170,8 +170,11 @@ func joinSubmarinerCluster(config *rest.Config, subctlData *datafile.SubctlData)
 		exitOnError("Error deploying multi cluster service discovery", err)
 
 		status.Start("Joining to Kubefed control plane")
-		_, err := exec.Command("kubefedctl", "join", "--kubefed-namespace", "kubefed-operator",
+		out, err := exec.Command("kubefedctl", "join", "--kubefed-namespace", "kubefed-operator",
 			clusterID, "--host-cluster-context", brokerClusterContext).CombinedOutput()
+		if err != nil {
+			err = fmt.Errorf("kubefedctl join failed: %s\n%s", err, out)
+		}
 		status.End(err == nil)
 		exitOnError("Error joining to Kubefed control plane", err)
 	}


### PR DESCRIPTION
When kubefed join step of subctl join fails, it only shows a numeric
error code and not actual error output. This change is to show the
actual error output to make troubleshooting easier.