### PR TITLE
Fix panic in getPodCIDR

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -277,7 +277,7 @@ func getPodCIDR(clusterCIDR string, nd *network.ClusterNetwork) (string, error) 
 				clusterCIDR, nd.PodCIDRs[0])
 		}
 		return clusterCIDR, nil
-	} else if len(nd.PodCIDRs) > 0 {
+	} else if nd != nil && len(nd.PodCIDRs) > 0 {
 		return nd.PodCIDRs[0], nil
 	} else {
 		return askForCIDR("Pod")


### PR DESCRIPTION
Need to check for nd != nil.
See https://github.com/submariner-io/submariner/issues/367 for details.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>