### PR TITLE
Rename ClusterIP CIDRs to Service CIDRs

### DIFF
--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -35,8 +35,8 @@ func (cn *ClusterNetwork) Show() {
 	} else {
 		fmt.Printf("    Discovered network details:\n")
 		fmt.Printf("        Network plugin:  %s\n", cn.NetworkPlugin)
-		fmt.Printf("        ClusterIP CIDRs: %v\n", cn.ServiceCIDRs)
-		fmt.Printf("        Pod CIDRs:       %v\n", cn.PodCIDRs)
+		fmt.Printf("        Service CIDRs: %v\n", cn.ServiceCIDRs)
+		fmt.Printf("        Cluster CIDRs: %v\n", cn.PodCIDRs)
 	}
 }
 


### PR DESCRIPTION
Currently when we query the cluster info using "subctl info ..." command
the output displays ClusterIP Cidrs and Pod CIDRs. In K8s, POD CIDR is
usually referred to as Cluster CIDR. So, using ClusterIP CIDR for Service
CIDR is really confusing. This patch modifies the output accordingly.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>