### PR TITLE
subctl: globalnet support for join

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 status ?= onetime
 lighthouse ?= false
+globalnet ?= false
 
 TARGETS := $(shell ls scripts)
 
@@ -11,7 +12,7 @@ TARGETS := $(shell ls scripts)
 	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper vendor/modules.txt
-	./.dapper -m bind $@ $(status) $(lighthouse)
+	./.dapper -m bind $@ $(status) $(lighthouse) $(globalnet)
 
 shell: .dapper
 	./.dapper -s -m bind

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -17,9 +17,12 @@ limitations under the License.
 package globalnet
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math/bits"
 	"net"
 
+	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,6 +34,21 @@ type GlobalNetwork struct {
 	ClusterId    string
 }
 
+type GlobalCIDR struct {
+	cidr string
+	net  *net.IPNet
+	allocatedClusters []*CIDR
+	allocatedCount    int
+}
+
+type CIDR struct {
+	network *net.IPNet
+	size    int
+	lastIp  uint
+}
+
+var globalCidr = GlobalCIDR{allocatedCount: 0}
+
 func (gn *GlobalNetwork) Show() {
 	if gn == nil {
 		fmt.Println("    No global network details discovered")
@@ -39,7 +57,6 @@ func (gn *GlobalNetwork) Show() {
 		fmt.Printf("        ServiceCidrs: %v\n", gn.ServiceCIDRs)
 		fmt.Printf("        ClusterCidrs: %v\n", gn.ClusterCIDRs)
 		fmt.Printf("        Global CIDRs: %v\n", gn.GlobalCIDRs)
-
 	}
 }
 
@@ -82,4 +99,103 @@ func IsOverlappingCIDR(cidrList []string, cidr string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func NewCIDR(cidr string) CIDR {
+	_, network, _ := net.ParseCIDR(cidr)
+	ones, total := network.Mask.Size()
+	size := total - ones
+	lastIp := LastIp(network)
+	clusterCidr := CIDR{network: network, size: size, lastIp: lastIp}
+	return clusterCidr
+}
+
+func LastIp(network *net.IPNet) uint {
+	ones, total := network.Mask.Size()
+	clusterSize := uint(total - ones)
+	firstIpInt := ipToUint(network.IP)
+	lastIpUint := (firstIpInt + 1<<clusterSize) - 1
+	return lastIpUint
+}
+
+func allocateByCidr(cidr string) (uint, error) {
+	requestedIp, requestedNetwork, err := net.ParseCIDR(cidr)
+	if err != nil || !globalCidr.net.Contains(requestedIp) {
+		return 0, fmt.Errorf("%s not a valid subnet of %v\n", cidr, globalCidr.net)
+	}
+	clusterCidr := NewCIDR(cidr)
+	if !globalCidr.net.Contains(uintToIP(clusterCidr.lastIp)) {
+		return 0, fmt.Errorf("%s not a valid subnet of %v\n", cidr, globalCidr.net)
+	}
+	for i := 0; i < globalCidr.allocatedCount; i++ {
+		allocated := globalCidr.allocatedClusters[i]
+		if allocated.network.Contains(requestedIp) {
+			//subset of already allocated, try next
+			return allocated.lastIp, fmt.Errorf("%s subset of already allocated globalCidr %v\n", cidr, allocated.network)
+		}
+		if requestedNetwork.Contains(allocated.network.IP) {
+			//already allocated is subset of requested, no valid lastIp
+			return clusterCidr.lastIp, fmt.Errorf("%s overlaps with already allocated globalCidr %s\n", cidr, allocated.network)
+		}
+	}
+	globalCidr.allocatedClusters = append(globalCidr.allocatedClusters, &clusterCidr)
+	globalCidr.allocatedCount++
+	return 0, nil
+}
+
+func allocateByClusterSize(numSize uint) (string, error) {
+	bitSize := bits.LeadingZeros(0) - bits.LeadingZeros(numSize-1)
+	_, totalbits := globalCidr.net.Mask.Size()
+	clusterPrefix := totalbits - bitSize
+	mask := net.CIDRMask(clusterPrefix, totalbits)
+
+	cidr := fmt.Sprintf("%s/%d", globalCidr.net.IP, clusterPrefix)
+
+	last, err := allocateByCidr(cidr)
+	if err != nil && last == 0 {
+		return "", err
+	}
+	for err != nil {
+		nextNet := net.IPNet{
+			IP:   uintToIP(last + 1),
+			Mask: mask,
+		}
+		cidr = nextNet.String()
+		last, err = allocateByCidr(cidr)
+		if err != nil && last == 0 {
+			return "", fmt.Errorf("allocation not available")
+		}
+	}
+	return cidr, nil
+}
+
+func AllocateGlobalCIDR(globalNetworks map[string]*GlobalNetwork, subctlData *datafile.SubctlData) (string, error) {
+	globalCidr = GlobalCIDR{allocatedCount: 0, cidr: subctlData.GlobalnetCidrRange}
+	_, network, err := net.ParseCIDR(globalCidr.cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid GlobalCIDR %s configured", globalCidr.cidr)
+	}
+	globalCidr.net = network
+	for _, globalNetwork := range globalNetworks {
+		for _, otherCluster := range globalNetwork.GlobalCIDRs {
+			otherClusterCIDR := NewCIDR(otherCluster)
+			globalCidr.allocatedClusters = append(globalCidr.allocatedClusters, &otherClusterCIDR)
+			globalCidr.allocatedCount++
+		}
+	}
+	return allocateByClusterSize(subctlData.GlobalnetClusterSize)
+}
+
+func ipToUint(ip net.IP) uint {
+	intIp := ip
+	if len(ip) == 16 {
+		intIp = ip[12:16]
+	}
+	return uint(binary.BigEndian.Uint32(intIp))
+}
+
+func uintToIP(ip uint) net.IP {
+	netIp := make(net.IP, 4)
+	binary.BigEndian.PutUint32(netIp, uint32(ip))
+	return netIp
 }

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -49,6 +49,7 @@ var (
 	clusterID            string
 	serviceCIDR          string
 	clusterCIDR          string
+	globalCIDR           string
 	repository           string
 	imageVersion         string
 	nattPort             int
@@ -242,13 +243,25 @@ func joinSubmarinerCluster(config *rest.Config, subctlData *datafile.SubctlData)
 	status.Start("Discovering multi cluster details")
 	globalNetworks := getGlobalNetworks(subctlData)
 
-	err = checkOverlappingServiceCidr(globalNetworks)
-	status.End(err == nil)
-	exitOnError("Error validating overlapping ServiceCIDRs", err)
-
-	err = checkOverlappingClusterCidr(globalNetworks)
-	status.End(err == nil)
-	exitOnError("Error validating overlapping ClusterCIDRs", err)
+	if subctlData.GlobalnetCidrRange == "" {
+		// Globalnet not enabled
+		err = checkOverlappingServiceCidr(globalNetworks)
+		status.End(err == nil)
+		exitOnError("Error validating overlapping ServiceCIDRs", err)
+		err = checkOverlappingClusterCidr(globalNetworks)
+		status.End(err == nil)
+		exitOnError("Error validating overlapping ClusterCIDRs", err)
+	} else if globalNetworks[clusterID] == nil || globalNetworks[clusterID].GlobalCIDRs == nil || len(globalNetworks[clusterID].GlobalCIDRs) <= 0 {
+		// Globalnet enabled, no globalCidr configured on this cluster
+		globalCIDR, err = globalnet.AllocateGlobalCIDR(globalNetworks, subctlData)
+		status.End(err == nil)
+		status.QueueSuccessMessage(fmt.Sprintf("Allocated GlobalCIDR: %s", globalCIDR))
+		exitOnError("Globalnet failed", err)
+	} else {
+		// Globalnet enabled, globalCidr already configured on this cluster
+		globalCIDR = globalNetworks[clusterID].GlobalCIDRs[0]
+		status.QueueSuccessMessage(fmt.Sprintf("Cluster already has GlobalCIDR allocated: %s", globalNetworks[clusterID].GlobalCIDRs[0]))
+	}
 
 	status.Start("Deploying Submariner")
 	err = submarinercr.Ensure(config, OperatorNamespace, populateSubmarinerSpec(subctlData))
@@ -420,6 +433,10 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData) submariner.Submarin
 		ServiceCIDR:              serviceCIDR,
 		ClusterCIDR:              clusterCIDR,
 		Namespace:                SubmarinerNamespace,
+	}
+
+	if globalCIDR != "" {
+		submarinerSpec.GlobalCIDR = globalCIDR
 	}
 
 	return submarinerSpec

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -133,12 +133,19 @@ function verify_subm_cr() {
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.debug}' | grep $subm_debug
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.namespace}' | grep $subm_ns
   kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.natEnabled}' | grep $natEnabled
+
   if [[ $context = cluster2 ]]; then
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.serviceCIDR}' | grep $serviceCIDR_cluster2
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.clusterCIDR}' | grep $clusterCIDR_cluster2
+    if [[ $globalnet = true ]]; then
+        kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.globalCIDR}' | grep $globalCIDR_cluster2
+    fi
   elif [[ $context = cluster3 ]]; then
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.serviceCIDR}' | grep $serviceCIDR_cluster3
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.clusterCIDR}' | grep $clusterCIDR_cluster3
+    if [[ $globalnet = true ]]; then
+        kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.globalCIDR}' | grep $globalCIDR_cluster3
+    fi
   fi
 }
 


### PR DESCRIPTION
1. Check for Overlapping CIDRs only if globalnet not enabled
2. Allocate globalCIDR to cluster if available
3. Update the spec with globalCIDR
4. Add Makefile and e2e flags to support globalnet
5. e2e: GlobalCIDR validations if globalnet enabled.