### PR TITLE
Don’t set DNS up on broker

### DIFF
--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -103,14 +103,16 @@ func Ensure(status *cli.Status, config *rest.Config, repo string, version string
 	kubeConfig string, kubeContext string) error {
 	repo, version = canonicaliseRepoVersion(repo, version)
 
-	// Ensure DNS
-	err := lighthousedns.Ensure(status, config, repo, version)
-	if err != nil {
-		return fmt.Errorf("error setting DNS up: %s", err)
+	if !isController {
+		// Ensure DNS
+		err := lighthousedns.Ensure(status, config, repo, version)
+		if err != nil {
+			return fmt.Errorf("error setting DNS up: %s", err)
+		}
 	}
 
 	// Ensure KubeFed
-	err = kubefed.Ensure(status, config, "kubefed-operator",
+	err := kubefed.Ensure(status, config, "kubefed-operator",
 		"quay.io/openshift/kubefed-operator:"+versions.KubeFedVersion, isController, kubeConfig, kubeContext)
 	if err != nil {
 		return fmt.Errorf("error deploying KubeFed: %s", err)


### PR DESCRIPTION
The broker doesn’t need DNS overrides (and we don’t want to replace
its CoreDNS and break its CVO, or ask the user about it).

Signed-off-by: Stephen Kitt <skitt@redhat.com>