### PR TITLE
Update versions to latest tags

### DIFF
--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -2,8 +2,8 @@ package versions
 
 const (
 	DefaultSubmarinerRepo            = "quay.io/submariner"
-	DefaultSubmarinerOperatorVersion = "0.1.0"
-	DefaultSubmarinerVersion         = "0.1.0"
+	DefaultSubmarinerOperatorVersion = "0.1.1"
+	DefaultSubmarinerVersion         = "0.1.1"
 	DefaultLighthouseVersion         = "0.1.0"
 	KubeFedVersion                   = "v0.1.0-rc3"
 )


### PR DESCRIPTION
 * submariner to v0.1.1
 * submariner-operator to v0.1.1
 * lighthouse needs no update since there are no code changes between since v0.1.0,
   all changes have been around CI and docs.

(cherry picked from commit fb1fea63edcd93e456e0dde2e7832ca6ac041fc8)