### PR TITLE
Fix issue with wrong token stored in subm file (OpenShift)

### DIFF
--- a/pkg/subctl/datafile/datafile_test.go
+++ b/pkg/subctl/datafile/datafile_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	testBrokerUrl             = "https://my-broker-url:8443"
-	testSASecret              = "test-sa-secret"
+	testSASecret              = "submariner-k8s-broker-client-token-abcdef"
 	testToken                 = "i-am-a-token"
 	SubmarinerBrokerNamespace = "submariner-k8s-broker"
 )


### PR DESCRIPTION
Sometimes the service account inverts the order of the secrets,
and our code is not smart enough, this patch fixes it looking
for the right secret.

Fixes: #244
(cherry picked from commit aa8f09fb5a3189e136044c2a9a8311dfb5621395)