### PR TITLE
WIP: Convert e2e to use shared scripts from image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/dapper-base:e791638
+FROM quay.io/submariner/dapper-base
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} DAPPER_ENV=REPO DAPPER_ENV=TAG \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 status ?= onetime
+version ?= 1.14.2
+logging ?= false
+kubefed ?= false
+deploytool ?= helm
+globalnet ?= false
+build_debug ?= false
 lighthouse ?= false
 globalnet ?= false
 
@@ -12,7 +18,7 @@ TARGETS := $(shell ls scripts)
 	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper vendor/modules.txt
-	./.dapper -m bind $@ $(status) $(lighthouse) $(globalnet)
+	./.dapper -m bind $@ --status $(status) --k8s_version $(version) --logging $(logging) --kubefed $(kubefed) --deploytool $(deploytool) --globalnet $(globalnet) --build_debug $(build_debug) --lighthouse $(lighthouse)
 
 shell: .dapper
 	./.dapper -s -m bind

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -4,11 +4,6 @@ set -e
 source $(dirname $0)/lib/debug_functions
 source $(dirname $0)/lib/version
 
-
 cd $(dirname $0)
 
-if [[ $1 = clean ]]; then
-    ./../scripts/kind-e2e/e2e.sh clean
-else
-    ./../scripts/kind-e2e/e2e.sh "$@"
-fi
+/opt/kind-e2e/e2e.sh "$@"


### PR DESCRIPTION
Instead of using the e2e.sh and subsequent scripts in this repo, use the
shared /opt/kind-e2e logic now packaged in the dapper-base image built
in submariner-io/submariner.

Allows de-duplication of deployment scripting, preventing fragmentation
and easing maintains.

Any special logic added to the submariner-operator e2e scripting after
it was copied from the main submariner repo will need to be ported back
to the main submariner repo.

Relates to: #369

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>