### PR TITLE
Adjust kind clusters for 0.6.1

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/dapper-base:e791638
+FROM quay.io/submariner/dapper-base
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} DAPPER_ENV=REPO DAPPER_ENV=TAG \

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -43,7 +43,7 @@ function verify_subm_crd() {
   kubectl get crd $crd_name -o jsonpath='{.metadata.name}' | grep $crd_name
   kubectl get crd $crd_name -o jsonpath='{.spec.scope}' | grep Namespaced
   kubectl get crd $crd_name -o jsonpath='{.spec.group}' | grep submariner.io
-  kubectl get crd $crd_name -o jsonpath='{.spec.version}' | grep v1alpha1
+  kubectl get crd $crd_name -o jsonpath='{.spec.versions[?(.name=="v1alpha1")].name}' | grep v1alpha1
   kubectl get crd $crd_name -o jsonpath='{.spec.names.kind}' | grep Submariner
 
   if [[ $openapi_checks_enabled = true ]]; then
@@ -80,7 +80,7 @@ function verify_endpoints_crd() {
   kubectl get crd $crd_name -o jsonpath='{.spec.scope}' | grep Namespaced
   kubectl get crd $crd_name -o jsonpath='{.spec.group}' | grep submariner.io
   # TODO: Should this version really be v1, or maybe v1alpha1?
-  kubectl get crd $crd_name -o jsonpath='{.spec.version}' | grep v1
+  kubectl get crd $crd_name -o jsonpath='{.spec.versions[?(.name=="v1")].name}' | grep v1
   kubectl get crd $crd_name -o jsonpath='{.spec.names.kind}' | grep Endpoint
   kubectl get crd $crd_name -o jsonpath='{.status.acceptedNames.kind}' | grep Endpoint
 }
@@ -99,7 +99,7 @@ function verify_clusters_crd() {
   kubectl get crd $crd_name -o jsonpath='{.spec.scope}' | grep Namespaced
   kubectl get crd $crd_name -o jsonpath='{.spec.group}' | grep submariner.io
   # TODO: Should this version really be v1, or maybe v1alpha1?
-  kubectl get crd $crd_name -o jsonpath='{.spec.version}' | grep v1
+  kubectl get crd $crd_name -o jsonpath='{.spec.versions[?(.name=="v1")].name}' | grep v1
   kubectl get crd $crd_name -o jsonpath='{.spec.names.kind}' | grep Cluster
   kubectl get crd $crd_name -o jsonpath='{.status.acceptedNames.kind}' | grep Cluster
 }


### PR DESCRIPTION
This is a port of
https://github.com/submariner-io/submariner/commit/c2fc6b5e6db363d9ab555320827bf044b5c690e3
to submariner-operator, taking into account the new cluster naming
with recent versions of kind.

Signed-off-by: Stephen Kitt <skitt@redhat.com>