### PR TITLE
Use context when enabling namespaces

### DIFF
--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -125,7 +125,7 @@ func Ensure(status *cli.Status, config *rest.Config, repo string, version string
 	if isController {
 		image = generateImageName(repo, defaultControllerImageName, version)
 	}
-	return install.Ensure(status, config, image, isController, kubeConfig)
+	return install.Ensure(status, config, image, isController, kubeConfig, kubeContext)
 }
 
 // canonicaliseRepoVersion returns the canonical repo and version for the given

--- a/pkg/subctl/lighthouse/install/crds/ensure.go
+++ b/pkg/subctl/lighthouse/install/crds/ensure.go
@@ -34,7 +34,7 @@ import (
 // Copied over from operator/install/crds/ensure.go
 
 //Ensure functions updates or installs the multiclusterservives CRDs in the cluster
-func Ensure(restConfig *rest.Config, kubeConfig string) (bool, error) {
+func Ensure(restConfig *rest.Config, kubeConfig string, kubeContext string) (bool, error) {
 	clientSet, err := clientset.NewForConfig(restConfig)
 	if err != nil {
 		return false, err
@@ -55,6 +55,9 @@ func Ensure(restConfig *rest.Config, kubeConfig string) (bool, error) {
 	args := []string{"enable", "MulticlusterService"}
 	if kubeConfig != "" {
 		args = append(args, "--kubeconfig", kubeConfig)
+	}
+	if kubeContext != "" {
+		args = append(args, "--host-cluster-context", kubeContext)
 	}
 	args = append(args, "--kubefed-namespace", "kubefed-operator")
 	out, err := exec.Command("kubefedctl", args...).CombinedOutput()

--- a/pkg/subctl/lighthouse/install/ensure.go
+++ b/pkg/subctl/lighthouse/install/ensure.go
@@ -24,9 +24,9 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/install/deployment"
 )
 
-func Ensure(status *cli.Status, config *rest.Config, image string, isController bool, kubeConfig string) error {
+func Ensure(status *cli.Status, config *rest.Config, image string, isController bool, kubeConfig string, kubeContext string) error {
 
-	if created, err := crds.Ensure(config, kubeConfig); err != nil {
+	if created, err := crds.Ensure(config, kubeConfig, kubeContext); err != nil {
 		return err
 	} else if created {
 		status.QueueSuccessMessage("Created lighthouse CRDs")

--- a/pkg/subctl/operator/kubefed/ensure.go
+++ b/pkg/subctl/operator/kubefed/ensure.go
@@ -61,6 +61,9 @@ func Ensure(status *cli.Status, config *rest.Config, operatorNamespace string, o
 	if kubeConfig != "" {
 		args = append(args, "--kubeconfig", kubeConfig)
 	}
+	if kubeContext != "" {
+		args = append(args, "--host-cluster-context", kubeContext)
+	}
 	args = append(args, "--kubefed-namespace", "kubefed-operator")
 	out, err := exec.Command("kubefedctl", args...).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
When enabling namespaces in kubefed, use kubeContext if available.