### PR TITLE
Return appropriate err for globalClusterSize

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -139,9 +139,10 @@ func isValidGlobalnetConfig() (bool, error) {
 	}
 	ones, totalbits := network.Mask.Size()
 	availableSize := 1 << uint(totalbits-ones)
+	userClusterSize := globalnetClusterSize
 	globalnetClusterSize = nextPowerOf2(uint32(globalnetClusterSize))
-	if globalnetClusterSize >= uint(availableSize/2) {
-		return false, fmt.Errorf("Cluster size %d, should be <= %d", globalnetClusterSize, availableSize/2)
+	if globalnetClusterSize > uint(availableSize/2) {
+		return false, fmt.Errorf("Cluster size %d, should be <= %d", userClusterSize, availableSize/2)
 	}
 	return true, nil
 }


### PR DESCRIPTION
Issue-258
When user specifys a global cluster size that is not power of 2,
we upscale it to nearest power of two that can accommodate user size.
If this size is bigger than what Global CIDR can allow, we return
an error to user with a recommended size.

This error displays the "upscaled" value instead of what was
passed by user, which can be confusing. This patch is to display
the value passed by user.