### PR TITLE
Improved retry and errors for kubefed deployment

### DIFF
--- a/pkg/subctl/lighthouse/dns/ensure.go
+++ b/pkg/subctl/lighthouse/dns/ensure.go
@@ -38,7 +38,7 @@ const (
 	coreDNSImage            = "lighthouse-coredns"
 	openShiftCoreDNSImage   = "openshift-lighthouse-coredns"
 	deploymentCheckInterval = 5 * time.Second
-	deploymentWaitTime      = 2 * time.Minute
+	deploymentWaitTime      = 10 * time.Minute
 )
 
 func Ensure(status *cli.Status, config *rest.Config, repo string, version string) error {

--- a/pkg/subctl/lighthouse/install/deployment/ensure.go
+++ b/pkg/subctl/lighthouse/install/deployment/ensure.go
@@ -30,7 +30,7 @@ import (
 )
 
 const deploymentCheckInterval = 5 * time.Second
-const deploymentWaitTime = 2 * time.Minute
+const deploymentWaitTime = 10 * time.Minute
 
 //Ensure the lighthouse controller is deployed, and running
 func Ensure(restConfig *rest.Config, namespace string, image string) (bool, error) {

--- a/pkg/subctl/operator/common/operatorpod/ensure.go
+++ b/pkg/subctl/operator/common/operatorpod/ensure.go
@@ -29,7 +29,7 @@ import (
 )
 
 const deploymentCheckInterval = 5 * time.Second
-const deploymentWaitTime = 5 * time.Minute
+const deploymentWaitTime = 10 * time.Minute
 
 //Ensure the operator is deployed, and running
 func Ensure(restConfig *rest.Config, namespace string, operatorName string, image string) (bool, error) {

--- a/pkg/subctl/operator/kubefed/ensure.go
+++ b/pkg/subctl/operator/kubefed/ensure.go
@@ -32,23 +32,23 @@ import (
 )
 
 const deploymentCheckInterval = 5 * time.Second
-const deploymentWaitTime = 5 * time.Minute
+const deploymentWaitTime = 10 * time.Minute
 
 func Ensure(status *cli.Status, config *rest.Config, operatorNamespace string, operatorImage string, isController bool,
 	kubeConfig string, kubeContext string) error {
 
 	err := kubefedop.Ensure(status, config, "kubefed-operator", "quay.io/openshift/kubefed-operator:v0.1.0-rc3", isController)
 	if err != nil {
-		return fmt.Errorf("error deploying KubeFed: %s", err)
+		return fmt.Errorf("error deploying KubeFed operator: %s", err)
 	}
 	err = kubefedcr.Ensure(config, "kubefed-operator", kubeConfig, kubeContext)
 	if err != nil {
-		return fmt.Errorf("error deploying KubeFed: %s", err)
+		return fmt.Errorf("error deploying KubeFed CR: %s", err)
 	}
 
 	clientSet, err := clientset.NewForConfig(config)
 	if err != nil {
-		return fmt.Errorf("error deploying KubeFed: %s", err)
+		return fmt.Errorf("error creating kubefed clientset: %s", err)
 	}
 
 	if isController {


### PR DESCRIPTION
kubefed deployment is timing out in CI. Increase timeout duration
so we wait longer for it to come up. Errors are also bit misleading
as they don't truly show which step of kubefed failed. Modify the
error messages to accurately specify which step failed.