### PR TITLE
Validate resolved-ip to globalIp before validating datapath

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -205,7 +205,6 @@ function test_connection() {
     fi
     try_connect $nginx_svc_ip_cluster3
     if [[ $lighthouse = true ]]; then
-        try_connect nginx-demo
         resolved_ip=$(kubectl --context=cluster2 exec ${netshoot_pod} -- ping -c 1 -W 1 nginx-demo 2>/dev/null | grep PING | awk '{print $3}')
         # strip the () braces from resolved_ip
         resolved_ip=${resolved_ip:1:-1}
@@ -213,6 +212,7 @@ function test_connection() {
             echo "Resolved IP $resolved_ip doesn't match with service ip $nginx_svc_ip_cluster3"
             exit 1
         fi
+        try_connect nginx-demo
     fi
 
     echo "Connection test was successful!"


### PR DESCRIPTION
Based on the current design of LightHouse (that supports Cross Cluster Service Discovery), there is a small possibility where the initial DNS resolution for a remoteService might get resolved to ClusterIP first and subsequently get updated to globalIP (that is annotated on the remote service). 

In the current e2e validation, we are initially checking curl to nginx-demo and later validating if the resolvedIPAddress matches to remoteServiceGlobalIP. But when curl to nginx-demo fails, its hard to know if the failure was due to resolution of wrongIP (aka ClusterIP) or if its some datapath issue. This PR moves the validation prior to datapath testing which makes it easier for us to understand the reason for failure.