### PR TITLE
Ensure that update operations are retried

### DIFF
--- a/pkg/subctl/lighthouse/install/deployment/ensure.go
+++ b/pkg/subctl/lighthouse/install/deployment/ensure.go
@@ -21,12 +21,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/deployments"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/deployments"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 const deploymentCheckInterval = 5 * time.Second
@@ -54,7 +56,7 @@ func Ensure(restConfig *rest.Config, namespace string, image string) (bool, erro
 		return false, fmt.Errorf("error parsing controller deployment yaml: %s", err)
 	}
 
-	created, err := deployments.CreateOrUpdateDeployment(clientSet, namespace, deployment)
+	created, err := utils.CreateOrUpdateDeployment(clientSet, namespace, deployment)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/subctl/operator/common/deployments/utils.go
+++ b/pkg/subctl/operator/common/deployments/utils.go
@@ -28,18 +28,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func CreateOrUpdateDeployment(clientSet *clientset.Clientset, namespace string, deployment *appsv1.Deployment) (bool, error) {
-
-	_, err := clientSet.AppsV1().Deployments(namespace).Update(deployment)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.AppsV1().Deployments(namespace).Create(deployment)
-	return true, err
-}
-
 func WaitForReady(clientSet *clientset.Clientset, namespace string, deployment string, interval, timeout time.Duration) error {
 
 	deployments := clientSet.AppsV1().Deployments(namespace)

--- a/pkg/subctl/operator/common/operatorpod/ensure.go
+++ b/pkg/subctl/operator/common/operatorpod/ensure.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/deployments"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/deployments"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 const deploymentCheckInterval = 5 * time.Second
@@ -89,7 +91,7 @@ func Ensure(restConfig *rest.Config, namespace string, operatorName string, imag
 		},
 	}
 
-	created, err := deployments.CreateOrUpdateDeployment(clientSet, namespace, deployment)
+	created, err := utils.CreateOrUpdateDeployment(clientSet, namespace, deployment)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/subctl/operator/kubefedop/clusterrole/ensure.go
+++ b/pkg/subctl/operator/kubefedop/clusterrole/ensure.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 //go:generate go run generators/yamls2go.go
@@ -41,18 +41,7 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 		return false, fmt.Errorf("Cluster role update or create failed: %s", err)
 	}
 
-	return updateOrCreateClusterRole(clientSet, clusterRole)
-}
-
-func updateOrCreateClusterRole(clientSet *clientset.Clientset, clusterRole *rbacv1.ClusterRole) (bool, error) {
-	_, err := clientSet.RbacV1().ClusterRoles().Update(clusterRole)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().ClusterRoles().Create(clusterRole)
-	return true, err
+	return utils.CreateOrUpdateClusterRole(clientSet, clusterRole)
 }
 
 func getOperatorClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/subctl/operator/kubefedop/clusterrolebinding/ensure.go
+++ b/pkg/subctl/operator/kubefedop/clusterrolebinding/ensure.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 //go:generate go run generators/yamls2go.go
@@ -40,18 +40,7 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("ClusterRoleBinding update or create failed: %s", err)
 	}
-	return updateOrCreateClusterRoleBinding(clientSet, clusterRoleBinding)
-}
-
-func updateOrCreateClusterRoleBinding(clientSet *clientset.Clientset, clusterRoleBinding *rbacv1.ClusterRoleBinding) (bool, error) {
-	_, err := clientSet.RbacV1().ClusterRoleBindings().Update(clusterRoleBinding)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().ClusterRoleBindings().Create(clusterRoleBinding)
-	return true, err
+	return utils.CreateOrUpdateClusterRoleBinding(clientSet, clusterRoleBinding)
 }
 
 func getOperatorClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {

--- a/pkg/subctl/operator/kubefedop/crds/crds_test.go
+++ b/pkg/subctl/operator/kubefedop/crds/crds_test.go
@@ -21,9 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("getKubeFedCRDs", func() {
@@ -31,43 +28,6 @@ var _ = Describe("getKubeFedCRDs", func() {
 		It("Should parse the embedded yaml properly", func() {
 			_, err := getKubeFedCRDs()
 			Expect(err).ShouldNot(HaveOccurred())
-		})
-	})
-})
-
-var _ = Describe("updateOrCreateCRD", func() {
-
-	var (
-		crd    *apiextensionsv1beta1.CustomResourceDefinition
-		client *fake.Clientset
-	)
-	BeforeEach(func() {
-		var err error
-		crds, err := getKubeFedCRDs()
-		Expect(err).ShouldNot(HaveOccurred())
-		crd = crds[0]
-		client = fake.NewSimpleClientset()
-	})
-	When("When called", func() {
-		It("Should add the CRD properly", func() {
-			created, err := updateOrCreateCRD(client, crd)
-			Expect(created).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			createdCrd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(createdCrd.Spec.Names.Kind).Should(Equal("ClusterPropagatedVersion"))
-		})
-	})
-
-	When("When called twice", func() {
-		It("Should add the CRD properly, and return false on second call", func() {
-			created, err := updateOrCreateCRD(client, crd)
-			Expect(created).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-			created, err = updateOrCreateCRD(client, crd)
-			Expect(created).To(BeFalse())
-			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/subctl/operator/kubefedop/crds/ensure.go
+++ b/pkg/subctl/operator/kubefedop/crds/ensure.go
@@ -17,15 +17,12 @@ limitations under the License.
 package crds
 
 import (
-	"fmt"
-
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 //go:generate go run generators/yamls2go.go
@@ -44,7 +41,7 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	}
 
 	for _, crd := range crds {
-		updated, err := updateOrCreateCRD(clientSet, crd)
+		updated, err := utils.CreateOrUpdateCRD(clientSet, crd)
 		if err != nil {
 			return false, err
 		}
@@ -52,25 +49,6 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	}
 	return updatedCrds, nil
 
-}
-
-func updateOrCreateCRD(clientSet clientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) (bool, error) {
-	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-	if err == nil {
-		return true, nil
-	} else if errors.IsAlreadyExists(err) {
-		existingCrd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
-		if err != nil {
-			return false, fmt.Errorf("failed to get pre-existing CRD %s : %s", crd.Name, err)
-		}
-		crd.ResourceVersion = existingCrd.ResourceVersion
-		_, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd)
-		if err != nil {
-			return false, fmt.Errorf("failed to update pre-existing CRD %s : %s", crd.Name, err)
-		}
-		return false, nil
-	}
-	return false, err
 }
 
 var (

--- a/pkg/subctl/operator/kubefedop/role/ensure.go
+++ b/pkg/subctl/operator/kubefedop/role/ensure.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 //go:generate go run generators/yamls2go.go
@@ -41,18 +41,7 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 		return false, fmt.Errorf("Role update or create failed: %s", err)
 	}
 
-	return updateOrCreateRole(clientSet, namespace, role)
-}
-
-func updateOrCreateRole(clientSet *clientset.Clientset, namespace string, role *rbacv1.Role) (bool, error) {
-	_, err := clientSet.RbacV1().Roles(namespace).Update(role)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().Roles(namespace).Create(role)
-	return true, err
+	return utils.CreateOrUpdateRole(clientSet, namespace, role)
 }
 
 func getOperatorRole() (*rbacv1.Role, error) {

--- a/pkg/subctl/operator/kubefedop/rolebinding/ensure.go
+++ b/pkg/subctl/operator/kubefedop/rolebinding/ensure.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 //go:generate go run generators/yamls2go.go
@@ -40,18 +40,7 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("RoleBinding update or create failed: %s", err)
 	}
-	return updateOrCreateRoleBinding(clientSet, namespace, roleBinding)
-}
-
-func updateOrCreateRoleBinding(clientSet *clientset.Clientset, namespace string, roleBinding *rbacv1.RoleBinding) (bool, error) {
-	_, err := clientSet.RbacV1().RoleBindings(namespace).Update(roleBinding)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().RoleBindings(namespace).Create(roleBinding)
-	return true, err
+	return utils.CreateOrUpdateRoleBinding(clientSet, namespace, roleBinding)
 }
 
 func getOperatorRoleBinding() (*rbacv1.RoleBinding, error) {

--- a/pkg/subctl/operator/submarinerop/crds/crds_test.go
+++ b/pkg/subctl/operator/submarinerop/crds/crds_test.go
@@ -21,9 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("getSubmarinerCRD", func() {
@@ -33,42 +30,6 @@ var _ = Describe("getSubmarinerCRD", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).Should(Equal("Submariner"))
 			Expect(crd.Spec.Versions[0].Name).Should(Equal("v1alpha1"))
-		})
-	})
-})
-
-var _ = Describe("updateOrCreateCRD", func() {
-
-	var (
-		crd    *apiextensionsv1beta1.CustomResourceDefinition
-		client *fake.Clientset
-	)
-	BeforeEach(func() {
-		var err error
-		crd, err = getSubmarinerCRD()
-		Expect(err).ShouldNot(HaveOccurred())
-		client = fake.NewSimpleClientset()
-	})
-	When("When called", func() {
-		It("Should add the CRD properly", func() {
-			created, err := updateOrCreateCRD(client, crd)
-			Expect(created).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			createdCrd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(createdCrd.Spec.Names.Kind).Should(Equal("Submariner"))
-		})
-	})
-
-	When("When called twice", func() {
-		It("Should add the CRD properly, and return false on second call", func() {
-			created, err := updateOrCreateCRD(client, crd)
-			Expect(created).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-			created, err = updateOrCreateCRD(client, crd)
-			Expect(created).To(BeFalse())
-			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 )
 
 //go:generate go run generators/yamls2go.go
@@ -88,19 +89,7 @@ func ensureRole(clientSet *clientset.Clientset, namespace string) (bool, error) 
 		return false, fmt.Errorf("Role update or create failed: %s", err)
 	}
 
-	return updateOrCreateRole(clientSet, namespace, role)
-
-}
-
-func updateOrCreateRole(clientSet *clientset.Clientset, namespace string, role *rbacv1.Role) (bool, error) {
-	_, err := clientSet.RbacV1().Roles(namespace).Update(role)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().Roles(namespace).Create(role)
-	return true, err
+	return utils.CreateOrUpdateRole(clientSet, namespace, role)
 }
 
 func ensureRoleBinding(clientSet *clientset.Clientset, namespace string) (bool, error) {
@@ -108,18 +97,7 @@ func ensureRoleBinding(clientSet *clientset.Clientset, namespace string) (bool, 
 	if err != nil {
 		return false, fmt.Errorf("RoleBinding update or create failed: %s", err)
 	}
-	return updateOrCreateRoleBinding(clientSet, namespace, roleBinding)
-}
-
-func updateOrCreateRoleBinding(clientSet *clientset.Clientset, namespace string, roleBinding *rbacv1.RoleBinding) (bool, error) {
-	_, err := clientSet.RbacV1().RoleBindings(namespace).Update(roleBinding)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().RoleBindings(namespace).Create(roleBinding)
-	return true, err
+	return utils.CreateOrUpdateRoleBinding(clientSet, namespace, roleBinding)
 }
 
 func getOperatorRoleBinding() (*rbacv1.RoleBinding, error) {
@@ -148,19 +126,8 @@ func ensureClusterRole(clientSet *clientset.Clientset, namespace string) (bool, 
 		return false, fmt.Errorf("ClusterRole update or create failed: %s", err)
 	}
 
-	return updateOrCreateClusterRole(clientSet, namespace, clusterRole)
+	return utils.CreateOrUpdateClusterRole(clientSet, clusterRole)
 
-}
-
-func updateOrCreateClusterRole(clientSet *clientset.Clientset, namespace string, clusterRole *rbacv1.ClusterRole) (bool, error) {
-	_, err := clientSet.RbacV1().ClusterRoles().Update(clusterRole)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().ClusterRoles().Create(clusterRole)
-	return true, err
 }
 
 func ensureClusterRoleBinding(clientSet *clientset.Clientset, namespace string) (bool, error) {
@@ -168,18 +135,7 @@ func ensureClusterRoleBinding(clientSet *clientset.Clientset, namespace string) 
 	if err != nil {
 		return false, fmt.Errorf("clusterRoleBinding update or create failed: %s", err)
 	}
-	return updateOrCreateClusterRoleBinding(clientSet, namespace, clusterRoleBinding)
-}
-
-func updateOrCreateClusterRoleBinding(clientSet *clientset.Clientset, namespace string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (bool, error) {
-	_, err := clientSet.RbacV1().ClusterRoleBindings().Update(clusterRoleBinding)
-	if err == nil {
-		return false, nil
-	} else if !errors.IsNotFound(err) {
-		return false, err
-	}
-	_, err = clientSet.RbacV1().ClusterRoleBindings().Create(clusterRoleBinding)
-	return true, err
+	return utils.CreateOrUpdateClusterRoleBinding(clientSet, clusterRoleBinding)
 }
 
 func getOperatorClusterRoleBinding(namespace string) (*rbacv1.ClusterRoleBinding, error) {

--- a/pkg/utils/createorupdate.go
+++ b/pkg/utils/createorupdate.go
@@ -1,0 +1,162 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extendedclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+func CreateOrUpdateClusterRole(clientSet clientset.Interface, clusterRole *rbacv1.ClusterRole) (bool, error) {
+	_, err := clientSet.RbacV1().ClusterRoles().Create(clusterRole)
+	if err == nil {
+		return true, nil
+	} else if errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingClusterRole, err := clientSet.RbacV1().ClusterRoles().Get(clusterRole.Name, v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to retrieve pre-existing cluster role %s : %v", clusterRole.Name, err)
+			}
+			clusterRole.ResourceVersion = existingClusterRole.ResourceVersion
+			// Potentially retried
+			_, err = clientSet.RbacV1().ClusterRoles().Update(clusterRole)
+			if err != nil {
+				return fmt.Errorf("failed to update pre-existing cluster role %s : %v", clusterRole.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return false, err
+}
+
+func CreateOrUpdateClusterRoleBinding(clientSet clientset.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) (bool, error) {
+	_, err := clientSet.RbacV1().ClusterRoleBindings().Create(clusterRoleBinding)
+	if err == nil {
+		return true, nil
+	} else if errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingClusterRoleBinding, err := clientSet.RbacV1().ClusterRoleBindings().Get(clusterRoleBinding.Name, v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to retrieve pre-existing cluster role binding %s : %v", clusterRoleBinding.Name, err)
+			}
+			clusterRoleBinding.ResourceVersion = existingClusterRoleBinding.ResourceVersion
+			// Potentially retried
+			_, err = clientSet.RbacV1().ClusterRoleBindings().Update(clusterRoleBinding)
+			if err != nil {
+				return fmt.Errorf("failed to update pre-existing cluster role binding %s : %v", clusterRoleBinding.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return false, err
+}
+
+func CreateOrUpdateCRD(clientSet extendedclientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) (bool, error) {
+	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	if err == nil {
+		return true, nil
+	} else if errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingCrd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to retrieve pre-existing CRD %s : %v", crd.Name, err)
+			}
+			crd.ResourceVersion = existingCrd.ResourceVersion
+			// Potentially retried
+			_, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd)
+			if err != nil {
+				return fmt.Errorf("failed to update pre-existing CRD %s : %v", crd.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return false, err
+}
+
+func CreateOrUpdateDeployment(clientSet clientset.Interface, namespace string, deployment *appsv1.Deployment) (bool, error) {
+	_, err := clientSet.AppsV1().Deployments(namespace).Create(deployment)
+	if err != nil && errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingDeployment, err := clientSet.AppsV1().Deployments(namespace).Get(deployment.Name, v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to retrieve pre-existing deployment %s : %v", deployment.Name, err)
+			}
+			deployment.ResourceVersion = existingDeployment.ResourceVersion
+			// Potentially retried
+			_, err = clientSet.AppsV1().Deployments(namespace).Update(deployment)
+			if err != nil {
+				return fmt.Errorf("failed to update pre-existing deployment %s : %v", deployment.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return true, err
+}
+
+func CreateOrUpdateRole(clientSet clientset.Interface, namespace string, role *rbacv1.Role) (bool, error) {
+	_, err := clientSet.RbacV1().Roles(namespace).Create(role)
+	if err != nil && errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingRole, err := clientSet.RbacV1().Roles(namespace).Get(role.Name, v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to retrieve pre-existing role %s : %v", role.Name, err)
+			}
+			role.ResourceVersion = existingRole.ResourceVersion
+			// Potentially retried
+			_, err = clientSet.RbacV1().Roles(namespace).Update(role)
+			if err != nil {
+				return fmt.Errorf("failed to update pre-existing role %s : %v", role.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return true, err
+}
+
+func CreateOrUpdateRoleBinding(clientSet clientset.Interface, namespace string, roleBinding *rbacv1.RoleBinding) (bool, error) {
+	_, err := clientSet.RbacV1().RoleBindings(namespace).Create(roleBinding)
+	if err != nil && errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingRoleBinding, err := clientSet.RbacV1().RoleBindings(namespace).Get(roleBinding.Name, v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to retrieve pre-existing role binding %s : %v", roleBinding.Name, err)
+			}
+			roleBinding.ResourceVersion = existingRoleBinding.ResourceVersion
+			// Potentially retried
+			_, err = clientSet.RbacV1().RoleBindings(namespace).Update(roleBinding)
+			if err != nil {
+				return fmt.Errorf("failed to update pre-existing role binding %s : %v", roleBinding.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return true, err
+}

--- a/pkg/utils/createorupdate_test.go
+++ b/pkg/utils/createorupdate_test.go
@@ -1,0 +1,277 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extendedfakeclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+)
+
+var _ = Describe("CreateOrUpdateClusterRole", func() {
+	var (
+		clusterRole *rbacv1.ClusterRole
+		client      *fakeclientset.Clientset
+	)
+
+	BeforeEach(func() {
+		clusterRole = &rbacv1.ClusterRole{}
+		// TODO skitt add our own object
+		err := embeddedyamls.GetObject(embeddedyamls.Cluster_role_yaml, clusterRole)
+		Expect(err).ShouldNot(HaveOccurred())
+		client = fakeclientset.NewSimpleClientset()
+	})
+
+	When("When called", func() {
+		It("Should add the ClusterRole properly", func() {
+			created, err := CreateOrUpdateClusterRole(client, clusterRole)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdClusterRole, err := client.RbacV1().ClusterRoles().Get(clusterRole.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdClusterRole.ObjectMeta.Name).Should(Equal("submariner-operator:globalnet"))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the ClusterRole properly, and return false on second call", func() {
+			created, err := CreateOrUpdateClusterRole(client, clusterRole)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = CreateOrUpdateClusterRole(client, clusterRole)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("CreateOrUpdateClusterRoleBinding", func() {
+	var (
+		clusterRoleBinding *rbacv1.ClusterRoleBinding
+		client             *fakeclientset.Clientset
+	)
+
+	BeforeEach(func() {
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{}
+		// TODO skitt add our own object
+		err := embeddedyamls.GetObject(embeddedyamls.Cluster_role_binding_yaml, clusterRoleBinding)
+		Expect(err).ShouldNot(HaveOccurred())
+		client = fakeclientset.NewSimpleClientset()
+	})
+
+	When("When called", func() {
+		It("Should add the ClusterRoleBinding properly", func() {
+			created, err := CreateOrUpdateClusterRoleBinding(client, clusterRoleBinding)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdClusterRoleBinding, err := client.RbacV1().ClusterRoleBindings().Get(clusterRoleBinding.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdClusterRoleBinding.ObjectMeta.Name).Should(Equal("submariner-operator:globalnet"))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the ClusterRoleBinding properly, and return false on second call", func() {
+			created, err := CreateOrUpdateClusterRoleBinding(client, clusterRoleBinding)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = CreateOrUpdateClusterRoleBinding(client, clusterRoleBinding)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("CreateOrUpdateCRD", func() {
+	var (
+		crd    *apiextensionsv1beta1.CustomResourceDefinition
+		client *extendedfakeclientset.Clientset
+	)
+
+	BeforeEach(func() {
+		crd = &apiextensionsv1beta1.CustomResourceDefinition{}
+		err := embeddedyamls.GetObject(embeddedyamls.Crds_submariner_io_submariners_crd_yaml, crd)
+		Expect(err).ShouldNot(HaveOccurred())
+		client = extendedfakeclientset.NewSimpleClientset()
+	})
+
+	When("When called", func() {
+		It("Should add the CRD properly", func() {
+			created, err := CreateOrUpdateCRD(client, crd)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdCrd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdCrd.Spec.Names.Kind).Should(Equal("Submariner"))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the CRD properly, and return false on second call", func() {
+			created, err := CreateOrUpdateCRD(client, crd)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = CreateOrUpdateCRD(client, crd)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("CreateOrUpdateDeployment", func() {
+	var (
+		namespace  = "test-namespace"
+		name       = "test-deployment"
+		deployment *appsv1.Deployment
+		client     *fakeclientset.Clientset
+	)
+
+	BeforeEach(func() {
+		replicas := int32(1)
+		deployment = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": name}},
+			},
+		}
+		client = fakeclientset.NewSimpleClientset()
+	})
+
+	When("When called", func() {
+		It("Should add the Deployment properly", func() {
+			created, err := CreateOrUpdateDeployment(client, namespace, deployment)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdDeployment, err := client.AppsV1().Deployments(namespace).Get(deployment.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdDeployment.ObjectMeta.Name).Should(Equal(name))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the Deployment properly, and return false on second call", func() {
+			created, err := CreateOrUpdateDeployment(client, namespace, deployment)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = CreateOrUpdateDeployment(client, namespace, deployment)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("CreateOrUpdateRole", func() {
+	var (
+		namespace = "test-namespace"
+		role      *rbacv1.Role
+		client    *fakeclientset.Clientset
+	)
+
+	BeforeEach(func() {
+		role = &rbacv1.Role{}
+		// TODO skitt add our own object
+		err := embeddedyamls.GetObject(embeddedyamls.Role_yaml, role)
+		Expect(err).ShouldNot(HaveOccurred())
+		client = fakeclientset.NewSimpleClientset()
+	})
+
+	When("When called", func() {
+		It("Should add the Role properly", func() {
+			created, err := CreateOrUpdateRole(client, namespace, role)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdRole, err := client.RbacV1().Roles(namespace).Get(role.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdRole.ObjectMeta.Name).Should(Equal("submariner-operator"))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the Role properly, and return false on second call", func() {
+			created, err := CreateOrUpdateRole(client, namespace, role)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = CreateOrUpdateRole(client, namespace, role)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("CreateOrUpdateRoleBinding", func() {
+	var (
+		namespace   = "test-namespace"
+		roleBinding *rbacv1.RoleBinding
+		client      *fakeclientset.Clientset
+	)
+
+	BeforeEach(func() {
+		roleBinding = &rbacv1.RoleBinding{}
+		// TODO skitt add our own object
+		err := embeddedyamls.GetObject(embeddedyamls.Role_binding_yaml, roleBinding)
+		Expect(err).ShouldNot(HaveOccurred())
+		client = fakeclientset.NewSimpleClientset()
+	})
+
+	When("When called", func() {
+		It("Should add the RoleBinding properly", func() {
+			created, err := CreateOrUpdateRoleBinding(client, namespace, roleBinding)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			createdRoleBinding, err := client.RbacV1().RoleBindings(namespace).Get(roleBinding.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdRoleBinding.ObjectMeta.Name).Should(Equal("submariner-operator"))
+		})
+	})
+
+	When("When called twice", func() {
+		It("Should add the RoleBinding properly, and return false on second call", func() {
+			created, err := CreateOrUpdateRoleBinding(client, namespace, roleBinding)
+			Expect(created).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+			created, err = CreateOrUpdateRoleBinding(client, namespace, roleBinding)
+			Expect(created).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+func TestCreateOrUpdate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create or update handling")
+}


### PR DESCRIPTION
All Kubernetes update operations should be retried on conflicts,
i.e. the object being changed has changed on the server since it was
retrieved.

Fixes: #255
Signed-off-by: Stephen Kitt <skitt@redhat.com>