### PR TITLE
Update versions.go for new RC1

### DIFF
--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -2,8 +2,8 @@ package versions
 
 const (
 	DefaultSubmarinerRepo            = "quay.io/submariner"
-	DefaultSubmarinerOperatorVersion = "0.2.0-rc0"
-	DefaultSubmarinerVersion         = "0.2.0-rc0"
+	DefaultSubmarinerOperatorVersion = "0.2.0-rc1"
+	DefaultSubmarinerVersion         = "0.2.0-rc1"
 	DefaultLighthouseVersion         = "0.2.0-rc0"
 	KubeFedVersion                   = "v0.1.0-rc3"
 )


### PR DESCRIPTION
Lighthouse is maintained on rc0 as it did't undergo any change.