### PR TITLE
Add globalnet-cluster-size option to join

### DIFF
--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -199,3 +199,31 @@ func uintToIP(ip uint) net.IP {
 	binary.BigEndian.PutUint32(netIp, uint32(ip))
 	return netIp
 }
+
+func GetValidClusterSize(cidrRange string, clusterSize uint) (uint, error) {
+
+	_, network, err := net.ParseCIDR(cidrRange)
+	if err != nil {
+		return 0, err
+	}
+	ones, totalbits := network.Mask.Size()
+	availableSize := 1 << uint(totalbits-ones)
+	userClusterSize := clusterSize
+	clusterSize = nextPowerOf2(uint32(clusterSize))
+	if clusterSize > uint(availableSize/2) {
+		return 0, fmt.Errorf("Cluster size %d, should be <= %d", userClusterSize, availableSize/2)
+	}
+	return clusterSize, nil
+}
+
+//Refer: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+func nextPowerOf2(n uint32) uint {
+	n--
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n++
+	return uint(n)
+}

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -50,7 +50,7 @@ func init() {
 	deployBroker.PersistentFlags().StringVar(&globalnetCidrRange, "globalnet-cidr-range", "169.254.0.0/16",
 		"Global CIDR supernet range for allocating GlobalCIDRs to each cluster")
 	deployBroker.PersistentFlags().UintVar(&defaultGlobalnetClusterSize, "globalnet-cluster-size", 8192,
-		"Default cluster size for GlobalCIDR allocated to each cluster")
+		"Default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
 	err := deployBroker.PersistentFlags().MarkHidden("no-dataplane")
 	// An error here indicates a programming error (the argument isn’t declared), panic
 	panicOnError(err)

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -97,7 +97,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&disableOpenShiftCVO, "disable-cvo", false,
 		"disable OpenShift's cluster version operator if necessary, without prompting")
 	cmd.Flags().UintVar(&globalnetClusterSize, "globalnet-cluster-size", 0,
-		"Cluster size for GlobalCIDR allocated to this cluster")
+		"Cluster size for GlobalCIDR allocated to this cluster (amount of global IPs)")
 }
 
 const (

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -61,10 +61,6 @@ function create_subm_vars() {
 
   declare_cidrs
   natEnabled=false
-  if [[ $globalnet = true ]]; then
-      global_CIDRs['cluster2']='169.254.0.0/19'
-      global_CIDRs['cluster3']='169.254.32.0/19'
-  fi
 
   subm_engine_image_repo="localhost:5000"
   subm_engine_image_tag=local

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -115,7 +115,6 @@ function verify_subm_cr() {
 
   validate_equals '.spec.serviceCIDR' ${service_CIDRs[$context]}
   validate_equals '.spec.clusterCIDR' ${cluster_CIDRs[$context]}
-  [[ $globalnet != 'true' ]] || validate_equals '.spec.globalCIDR' ${global_CIDRs[$context]}
 }
 
 function verify_subm_op_pod() {


### PR DESCRIPTION
Currently --globalnet-cluster-size can be specified only during broker
installation. This adds option to give a different size during join.

Closes #268