### PR TITLE
Remove unnecessary packages from the operator image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,11 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
+RUN rpm -e pinentry gnupg2 gpgme librepo libdnf microdnf pth \
+           shared-mime-info glib2 json-glib gobject-introspection libpeas \
+           librhsm pkgconfig libmodulemd libmount expat libsolv libyaml \
+           libsmartcols json-c libgcrypt libxml2 libblkid libassuan libuuid \
+           libgpg-error
+
 ENV OPERATOR=/usr/local/bin/submariner-operator \
     USER_UID=1001 \
     USER_NAME=submariner-operator


### PR DESCRIPTION
This shrinks the resulting image slightly, but more importantly,
reduces our security footprint (see
e.g. https://quay.io/repository/submariner/submariner-operator/manifest/sha256:174084b6fa69f2245a50284eddabf1d2e721a71993b133287ab4c7d254c8d673?tab=vulnerabilities
for one example). The published vulnerabilities so far don't affect
us, but it will simplify our users' experience if we avoid unnecessary
alerts.

Signed-off-by: Stephen Kitt <skitt@redhat.com>