### PR TITLE
Operator: Add role for globalnet controller to annotate a node

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -10,17 +10,12 @@ rules:
   - pods
   - services
   - namespaces
+  - nodes
   verbs:
   - get
   - list
   - watch
   - update
-- apiGroups:
-  - '*'
-  resources:
-  - nodes
-  verbs:
-  - 'get'
 - apiGroups:
   - submariner.io
   resources:


### PR DESCRIPTION
As part of supporting connectivity from HostNetwork to remoteClusters, globalnet
controller annotates a node with globalIP. This PR adds the necessary roles for
globalnetController.

Fixes Issue: https://github.com/submariner-io/submariner-operator/issues/305

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>