### PR TITLE
Document the build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,13 @@ subctl join --kubecontext east --kubeconfig merged_kubeconfig broker-info.subm  
 ```
 
 # Development
- 
+
+## Prerequisites
+
+The build environment uses
+[Dapper](https://github.com/rancher/dapper), which requires a working
+Docker setup. You will also need GNU Make.
+
 ## Build Operator
  
  You can compile the operator image running:


### PR DESCRIPTION
Since we use Dapper, the build requires a working Docker setup.

Fixes: #319
Signed-off-by: Stephen Kitt <skitt@redhat.com>