### PR TITLE
This commit adds the ha-status printable column to the gateway CRD

### DIFF
--- a/pkg/subctl/operator/submarinerop/crds/ensure.go
+++ b/pkg/subctl/operator/submarinerop/crds/ensure.go
@@ -78,6 +78,14 @@ func getGatewaysCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 				Kind:     "Gateway",
 			},
 			Version: "v1",
+			AdditionalPrinterColumns: []apiextensionsv1beta1.CustomResourceColumnDefinition{
+				{
+					Name:        "ha-status",
+					Type:        "string",
+					Description: "High availability status of the Gateway",
+					JSONPath:    ".status.haStatus",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Whe the gateways are listed via
```
kubectl get Gateways -A
```

This detail of the object will be printed.