### PR TITLE
Remove unused code for deploy-broker

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -120,9 +120,6 @@ var deployBroker = &cobra.Command{
 		status.End(err == nil)
 		exitOnError("Error writing the broker information", err)
 
-		err = lighthouse.HandleCommand(status, config, true, kubeConfig, kubeContext)
-		exitOnError("Error setting up service discovery", err)
-
 		if enableDataplane {
 			joinSubmarinerCluster(config, subctlData)
 		}

--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -52,16 +52,6 @@ func Validate() error {
 	return nil
 }
 
-func HandleCommand(status *cli.Status, config *rest.Config, isController bool, kubeConfig string, kubeContext string) error {
-	if serviceDiscovery {
-		status.Start("Deploying Service Discovery controller")
-		err := Ensure(status, config, imageRepo, imageVersion, isController, kubeConfig, kubeContext)
-		status.End(err == nil)
-		return err
-	}
-	return nil
-}
-
 func Ensure(status *cli.Status, config *rest.Config, repo string, version string, isController bool,
 	kubeConfig string, kubeContext string) error {
 	repo, version = canonicaliseRepoVersion(repo, version)


### PR DESCRIPTION
Setup Service Discovery step of deploy-broker gives incorrect status
msg. We no longer deploy controller on broker, or do anything on broker
from subctl. Broker installation is handled by operator.