### PR TITLE
Bump submariner and operator versions to 0.3.0-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/shipyard v0.0.0-20200424120554-752db6dc1c90
-	github.com/submariner-io/submariner v0.3.0-rc1
+	github.com/submariner-io/submariner v0.3.0-rc2
 	go.opencensus.io v0.22.1 // indirect
 	go.uber.org/zap v1.12.0 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/go.sum
+++ b/go.sum
@@ -660,6 +660,8 @@ github.com/submariner-io/submariner v0.2.0-rc0.0.20200415152156-e31a5cff1992 h1:
 github.com/submariner-io/submariner v0.2.0-rc0.0.20200415152156-e31a5cff1992/go.mod h1:7SaG9ZYBQzDDggLNU2FFb3MbtK9oPpKUWA5DoJt0Hv8=
 github.com/submariner-io/submariner v0.3.0-rc1 h1:ik3RTHHX+9Ukl04WEnlFwdlmmybTqOq/tesdilD/b5E=
 github.com/submariner-io/submariner v0.3.0-rc1/go.mod h1:3gKfQELxRRvKYCkPAuqgcNVtYZN5DBBdcgsElDRGkao=
+github.com/submariner-io/submariner v0.3.0-rc2 h1:s1T/b9DQKC+ZrdopRSM7uHpS17VmXRpfeKRR0IJBGMc=
+github.com/submariner-io/submariner v0.3.0-rc2/go.mod h1:3gKfQELxRRvKYCkPAuqgcNVtYZN5DBBdcgsElDRGkao=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -2,7 +2,7 @@ package versions
 
 const (
 	DefaultSubmarinerRepo            = "quay.io/submariner"
-	DefaultSubmarinerOperatorVersion = "0.3.0-rc1"
-	DefaultSubmarinerVersion         = "0.3.0-rc1"
+	DefaultSubmarinerOperatorVersion = "0.3.0-rc2"
+	DefaultSubmarinerVersion         = "0.3.0-rc2"
 	DefaultLighthouseVersion         = "0.3.0-rc1"
 )


### PR DESCRIPTION
Lighthouse hasn't changed the go code.