### PR TITLE
Use the closest git reference instead of the commit hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
   - /^release-\d+.\d+.*$/
  
 git:
-  depth: 1
+  depth: false
 
 jobs:
   include:

--- a/pkg/subctl/cmd/version.go
+++ b/pkg/subctl/cmd/version.go
@@ -45,5 +45,5 @@ func subctlVersion(cmd *cobra.Command, args []string) {
 
 func PrintSubctlVersion(w io.Writer) {
 	fmt.Fprintf(w, "subctl version: %s\n", version.Version)
-	fmt.Fprintf(w, "built from git commit id: %s\n", version.Commit)
+	fmt.Fprintf(w, "built from git ref: %s\n", version.GitRef)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,6 +4,6 @@ var (
 	// Version is updated by scripts/subctl-build at build time
 	Version = "was not built correctly"
 
-	// Commit is updated by scripts/subctl-build
-	Commit = ""
+	// GitRef is updated by scripts/subctl-build
+	GitRef = ""
 )

--- a/scripts/build-subctl
+++ b/scripts/build-subctl
@@ -9,9 +9,9 @@ debug=${1:-false}
 cd $(dirname $0)/..
 mkdir -p bin
 echo Building subctl version $VERSION for ${GOOS:=$(go env GOOS)}/${GOARCH:=$(go env GOARCH)}
-GIT_COMMIT="$(git rev-parse --verify 'HEAD^{commit}')"
+GIT_REF="$(git describe --tags)"
 ldflags="-X github.com/submariner-io/submariner-operator/pkg/version.Version=${VERSION} "
-ldflags="${ldflags} -X github.com/submariner-io/submariner-operator/pkg/version.Commit=${GIT_COMMIT}"
+ldflags="${ldflags} -X github.com/submariner-io/submariner-operator/pkg/version.GitRef=${GIT_REF}"
 
 if [ "$debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"


### PR DESCRIPTION
In subctl version, display the output of "git describe --tags" instead
of the full commit hash. On development versions, this will show the
closest tag, followed by the number of commits since the tag, and the
short hash of the current commit:

	$ bin/subctl version
	subctl version: dev
	built from git ref: v0.3.0-rc2-2-g95d2c84

When subctl is built from a commit which is itself tagged (i.e. when
building a release), it will only show the tag:

	$ bin/subctl version
	subctl version: v0.3.0
	built from git ref: v0.3.0

Fixes: #355
Signed-off-by: Stephen Kitt <skitt@redhat.com>