### PR TITLE
Rename IPSEC->IPsec in outputs

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -56,7 +56,7 @@ func init() {
 	panicOnError(err)
 
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
-		"Import IPSEC PSK from existing submariner broker file, like broker-info.subm")
+		"Import IPsec PSK from existing submariner broker file, like broker-info.subm")
 
 	addKubeconfigFlag(deployBroker)
 	addJoinFlags(deployBroker)
@@ -88,13 +88,13 @@ var deployBroker = &cobra.Command{
 
 		status.Start(fmt.Sprintf("Creating %s file", brokerDetailsFilename))
 
-		// If deploy-broker is retried we will attempt to re-use the existing IPSEC PSK secret
+		// If deploy-broker is retried we will attempt to re-use the existing IPsec PSK secret
 		if ipsecSubmFile == "" {
 			if _, err := datafile.NewFromFile(brokerDetailsFilename); err == nil {
 				ipsecSubmFile = brokerDetailsFilename
-				status.QueueSuccessMessage(fmt.Sprintf("Reusing IPSEC PSK from existing %s", brokerDetailsFilename))
+				status.QueueSuccessMessage(fmt.Sprintf("Reusing IPsec PSK from existing %s", brokerDetailsFilename))
 			} else {
-				status.QueueSuccessMessage(fmt.Sprintf("A new IPSEC PSK will be generated for %s", brokerDetailsFilename))
+				status.QueueSuccessMessage(fmt.Sprintf("A new IPsec PSK will be generated for %s", brokerDetailsFilename))
 			}
 		}
 

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -103,7 +103,7 @@ func newFromCluster(clientSet clientset.Interface, brokerNamespace, ipsecSubmFil
 	if ipsecSubmFile != "" {
 		datafile, err := NewFromFile(ipsecSubmFile)
 		if err != nil {
-			return nil, fmt.Errorf("Error happened trying to import IPSEC PSK from subm file: %s: %s", ipsecSubmFile,
+			return nil, fmt.Errorf("Error happened trying to import IPsec PSK from subm file: %s: %s", ipsecSubmFile,
 				err.Error())
 		}
 		subctlData.IPSecPSK = datafile.IPSecPSK


### PR DESCRIPTION
While copying the output of `subctl deploy-broker -h` into the website
subctl docs, it was noted during review that this output's useage of
IPSEC over IPsec  was inconsitenat with the norms of the website. After
digging, it also became apparent the correct format is IPsec (from
Wikipedia and RFC 4301).

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>