### PR TITLE
Revert "Use the closest git reference instead of the commit hash"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
   - /^release-\d+.\d+.*$/
  
 git:
-  depth: false
+  depth: 1
 
 jobs:
   include:

--- a/pkg/subctl/cmd/version.go
+++ b/pkg/subctl/cmd/version.go
@@ -45,5 +45,5 @@ func subctlVersion(cmd *cobra.Command, args []string) {
 
 func PrintSubctlVersion(w io.Writer) {
 	fmt.Fprintf(w, "subctl version: %s\n", version.Version)
-	fmt.Fprintf(w, "built from git ref: %s\n", version.GitRef)
+	fmt.Fprintf(w, "built from git commit id: %s\n", version.Commit)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,6 +4,6 @@ var (
 	// Version is updated by scripts/subctl-build at build time
 	Version = "was not built correctly"
 
-	// GitRef is updated by scripts/subctl-build
-	GitRef = ""
+	// Commit is updated by scripts/subctl-build
+	Commit = ""
 )

--- a/scripts/build-subctl
+++ b/scripts/build-subctl
@@ -9,9 +9,9 @@ debug=${1:-false}
 cd $(dirname $0)/..
 mkdir -p bin
 echo Building subctl version $VERSION for ${GOOS:=$(go env GOOS)}/${GOARCH:=$(go env GOARCH)}
-GIT_REF="$(git describe --tags)"
+GIT_COMMIT="$(git rev-parse --verify 'HEAD^{commit}')"
 ldflags="-X github.com/submariner-io/submariner-operator/pkg/version.Version=${VERSION} "
-ldflags="${ldflags} -X github.com/submariner-io/submariner-operator/pkg/version.GitRef=${GIT_REF}"
+ldflags="${ldflags} -X github.com/submariner-io/submariner-operator/pkg/version.Commit=${GIT_COMMIT}"
 
 if [ "$debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"


### PR DESCRIPTION
This reverts commit 98f69a1b7cfc620d4770155b02eae202e73d0c9f.

It breaks the build of subctl in GH actions, which we use to push binaries to the release, I tried this:

https://github.com/submariner-io/submariner-operator/pull/371

But it doesn't work.