### PR TITLE
Fix new linter

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -36,9 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	submopv1a1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"

--- a/pkg/controller/submariner/submariner_controller_test.go
+++ b/pkg/controller/submariner/submariner_controller_test.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 const (

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -132,7 +132,7 @@ func isValidGlobalnetConfig() (bool, error) {
 		return true, nil
 	}
 	defaultGlobalnetClusterSize, err = globalnet.GetValidClusterSize(globalnetCidrRange, defaultGlobalnetClusterSize)
-	if err != nil || defaultGlobalnetClusterSize <= 0 {
+	if err != nil || defaultGlobalnetClusterSize == 0 {
 		return false, err
 	}
 	return true, err

--- a/scripts/validate
+++ b/scripts/validate
@@ -19,4 +19,4 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
-golangci-lint run
+golangci-lint run --timeout 5m --skip-dirs pkg/client


### PR DESCRIPTION
Shipyard includes a new image of golint that timeouts in 1 minute
and complains for auto-generated go code (clientset).

This commit makes validation work with the new version of the linter.

also fixes the following errors:

```
pkg/controller/submariner/submariner_controller.go:41:2:
    SA1019: Package sigs.k8s.io/controller-runtime/pkg/runtime/log
            is deprecated: use pkg/log  (staticcheck)
	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
	^
pkg/controller/submariner/submariner_controller_test.go:24:2:
    SA1019: Package sigs.k8s.io/controller-runtime/pkg/runtime/log
            is deprecated: use pkg/log  (staticcheck)
	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
	^
pkg/subctl/cmd/deploybroker.go:135:19: SA4003: no value of type
        `uint` is less than `0` (staticcheck)
	if err != nil || defaultGlobalnetClusterSize <= 0 {
	                 ^

```