### PR TITLE
Add ServiceExport CRD

### DIFF
--- a/deploy/lighthouse/cluster_role.yaml
+++ b/deploy/lighthouse/cluster_role.yaml
@@ -17,7 +17,7 @@ rules:
 - apiGroups:
   - lighthouse.submariner.io
   resources:
-  - multiclusterservices
+  - "*"
   verbs:
   - create
   - get

--- a/deploy/lighthouse/crds/serviceexport_crd.yaml
+++ b/deploy/lighthouse/crds/serviceexport_crd.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.lighthouse.submariner.io
+spec:
+  group: lighthouse.submariner.io
+  version: v2alpha1
+  names:
+    kind: ServiceExport
+    plural: serviceexports
+    singular: serviceexport
+  scope: Namespaced

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -38,7 +38,7 @@ func Ensure(config *rest.Config) error {
 		return fmt.Errorf("error setting up the engine requirements: %s", err)
 	}
 
-	err = lighthouse.Ensure(config)
+	_, err = lighthouse.Ensure(config, lighthouse.BrokerCluster)
 	if err != nil {
 		return fmt.Errorf("error setting up the lighthouse requirements: %s", err)
 	}

--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -69,7 +69,7 @@ func NewBrokerAdminRole() *rbacv1.Role {
 			rbacv1.PolicyRule{
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"lighthouse.submariner.io"},
-				Resources: []string{"multiclusterservices"},
+				Resources: []string{"*"},
 			},
 		},
 	}
@@ -91,7 +91,7 @@ func NewBrokerClusterRole() *rbacv1.Role {
 			rbacv1.PolicyRule{
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"lighthouse.submariner.io"},
-				Resources: []string{"multiclusterservices"},
+				Resources: []string{"*"},
 			},
 		},
 	}

--- a/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
+++ b/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
@@ -38,6 +38,7 @@ var files = []string{
 	"submariner/globalnet_cluster_role.yaml",
 	"submariner/globalnet_cluster_role_binding.yaml",
 	"lighthouse/crds/multiclusterservices_crd.yaml",
+	"lighthouse/crds/serviceexport_crd.yaml",
 	"lighthouse/cluster_role_binding.yaml",
 	"lighthouse/cluster_role.yaml",
 }

--- a/pkg/utils/createorupdate.go
+++ b/pkg/utils/createorupdate.go
@@ -28,6 +28,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 )
 
 func CreateOrUpdateClusterRole(clientSet clientset.Interface, clusterRole *rbacv1.ClusterRole) (bool, error) {
@@ -97,6 +99,17 @@ func CreateOrUpdateCRD(clientSet extendedclientset.Interface, crd *apiextensions
 		return false, retryErr
 	}
 	return false, err
+}
+
+func CreateOrUpdateEmbeddedCRD(clientSet extendedclientset.Interface, crdYaml string) (bool, error) {
+
+	crd := &apiextensionsv1beta1.CustomResourceDefinition{}
+
+	if err := embeddedyamls.GetObject(crdYaml, crd); err != nil {
+		return false, fmt.Errorf("Error extracting embedded CRD: %s", err)
+	}
+
+	return CreateOrUpdateCRD(clientSet, crd)
 }
 
 func CreateOrUpdateDeployment(clientSet clientset.Interface, namespace string, deployment *appsv1.Deployment) (bool, error) {


### PR DESCRIPTION
Adds the ServiceExport CRD for lighthouse U/S alignment, only
on the clusters where the operator is installed, not the broker.

Related-Issue: https://github.com/submariner-io/lighthouse/issues/78