### PR TITLE
Import the submariner e2e framework in verify-connectivity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/shipyard v0.0.0-20200424120554-752db6dc1c90
-	github.com/submariner-io/submariner v0.3.0
+	github.com/submariner-io/submariner v0.3.1-0.20200515132708-8214b2793bbd
 	go.opencensus.io v0.22.1 // indirect
 	go.uber.org/zap v1.12.0 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,8 @@ github.com/submariner-io/submariner v0.3.0-rc2 h1:s1T/b9DQKC+ZrdopRSM7uHpS17VmXR
 github.com/submariner-io/submariner v0.3.0-rc2/go.mod h1:3gKfQELxRRvKYCkPAuqgcNVtYZN5DBBdcgsElDRGkao=
 github.com/submariner-io/submariner v0.3.0 h1:7qYiKvFQTGiM/QqRdXtgHMnwaIVebOVvNn3BXSZ48CA=
 github.com/submariner-io/submariner v0.3.0/go.mod h1:3gKfQELxRRvKYCkPAuqgcNVtYZN5DBBdcgsElDRGkao=
+github.com/submariner-io/submariner v0.3.1-0.20200515132708-8214b2793bbd h1:W6T3tOJ5WkfczhZiklckzAzSauAY9Av5Oucgoey2qRU=
+github.com/submariner-io/submariner v0.3.1-0.20200515132708-8214b2793bbd/go.mod h1:3gKfQELxRRvKYCkPAuqgcNVtYZN5DBBdcgsElDRGkao=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/subctl/cmd/verify_connectivity.go
+++ b/pkg/subctl/cmd/verify_connectivity.go
@@ -26,6 +26,7 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
+	_ "github.com/submariner-io/submariner/test/e2e/framework"
 )
 
 var (


### PR DESCRIPTION
Otherwise the globalnet detection is not triggered and
verify-connectivy will not work when globalnet is enabled.

Fixes-Issue: #381
Depends-On: https://github.com/submariner-io/submariner/pull/566
