### PR TITLE
Ensure that files/directories don’t hide Dapper targets

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -10,10 +10,16 @@
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper
 
+invoke_dapper = ./.dapper -m bind make $1 $(MAKEFLAGS)
+
 %: .dapper
-	./.dapper -m bind $(MAKE) $@ $(MAKEFLAGS)
+	$(call invoke_dapper,$@)
+
+# Ensure that files in the current directory don't hide Dapper targets
+$(wildcard [^M]*): .dapper
+	$(call invoke_dapper,$@)
 
 shell: .dapper
 	./.dapper -m bind -s
 
-.PHONY: shell
+.PHONY: shell $(wildcard [^M]*)


### PR DESCRIPTION
Targets offered by the in-Dapper Makefile are hidden by files or
directories of the same name, for example “deploy”. This patch marks
all such files/directories, apart from those starting with “M” (to
avoid problems with the Makefiles themselves), as phony, with an
explicit build target.

This allows

	make deploy

to work even though there’s a deploy directory.

Signed-off-by: Stephen Kitt <skitt@redhat.com>