### PR TITLE
Highlight warning message format

### DIFF
--- a/pkg/internal/cli/status.go
+++ b/pkg/internal/cli/status.go
@@ -65,7 +65,7 @@ func StatusForLogger(l log.Logger) *Status {
 		logger:        l,
 		successFormat: " ✓ %s\n",
 		failureFormat: " ✗ %s\n",
-		warningFormat: " ⚠ %s\n",
+		warningFormat: " ⚠ WARNING %s\n",
 		successQueue:  []string{},
 		failureQueue:  []string{},
 		warningQueue:  []string{},
@@ -78,7 +78,7 @@ func StatusForLogger(l log.Logger) *Status {
 			// use colored success / failure / warning messages
 			s.successFormat = " \x1b[32m✓\x1b[0m %s\n"
 			s.failureFormat = " \x1b[31m✗\x1b[0m %s\n"
-			s.warningFormat = " \x1b[33m⚠\x1b[0m %s\n"
+			s.warningFormat = " \x1b[33m⚠ WARNING\x1b[0m %s\n"
 		}
 	}
 	return s


### PR DESCRIPTION
Warning sign doesn't pop out against black
background and green fonts. Highlight the
sign by adding "WARNING" text next to it.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

![Screenshot from 2020-05-19 10-42-41](https://user-images.githubusercontent.com/8556738/82287362-a2f42780-99bd-11ea-9e19-8646d6a63ebb.png)
