### PR TITLE
Test built container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 include $(SHIPYARD_DIR)/Makefile.inc
 
+VERSION := $(shell . scripts/lib/version; echo $$VERSION)
+
 TARGETS := $(shell ls -p scripts | grep -v -e /)
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_settings
 CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
-DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_submariner_args '--cable-driver strongswan'
+DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_submariner_args '--cable-driver strongswan --operator-image quay.io/submariner/submariner-operator:$(VERSION)'
 
 clusters: build-all
 

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -341,26 +341,8 @@ function verify_subm_routeagent_pod() {
 function verify_subm_operator_container() {
   subm_operator_pod_name=$(kubectl get pods --namespace=$subm_ns -l name=submariner-operator -o=jsonpath='{.items..metadata.name}')
 
-  # Show SubM Operator pod environment variables
-  env_file=/tmp/${subm_operator_pod_name}.env
-  kubectl exec $subm_operator_pod_name --namespace=$subm_ns -- env | tee $env_file
-
-  # Verify SubM Operator pod environment variables
-  grep "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" $env_file
-  grep "HOSTNAME=$subm_operator_pod_name" $env_file
-  grep "OPERATOR=/usr/local/bin/submariner-operator" $env_file
-  grep "USER_UID=1001" $env_file
-  grep "USER_NAME=submariner-operator" $env_file
-  grep "WATCH_NAMESPACE=$subm_ns" $env_file
-  grep "POD_NAME=$subm_operator_pod_name" $env_file
-  grep "OPERATOR_NAME=submariner-operator" $env_file
-  grep "HOME=/" $env_file
-
-  # Verify the operator binary is in the expected place and in PATH
-  kubectl exec $subm_operator_pod_name --namespace=$subm_ns -- command -v submariner-operator | grep /usr/local/bin/submariner-operator
-
-  # Verify the operator entry script is in the expected place and in PATH
-  kubectl exec $subm_operator_pod_name --namespace=$subm_ns -- command -v entrypoint | grep /usr/local/bin/entrypoint
+  # The operator container only contains the operator binary now,
+  # there's nothing to verify
 }
 
 function verify_subm_engine_container() {


### PR DESCRIPTION
This drops the failing e2e checks (which are no longer possible since we only ship the operator binary in the container), and deploys the newly-built container image.

Fixes: #398.