### PR TITLE
Run verify-connectivity for globalnet

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -54,13 +54,10 @@ with_context cluster3 deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 
 with_context cluster2 connectivity_tests
 
-# dataplane E2E need to be modified for globalnet
-if [[ "${globalnet}" != "true" ]]; then
-    # run dataplane E2E tests between the two clusters
-    ${DAPPER_SOURCE}/bin/subctl verify-connectivity --verbose \
-        ${KUBECONFIGS_DIR}/kind-config-cluster2 \
-        ${KUBECONFIGS_DIR}/kind-config-cluster3
-fi
+# run dataplane E2E tests between the two clusters
+${DAPPER_SOURCE}/bin/subctl verify-connectivity --verbose \
+    ${KUBECONFIGS_DIR}/kind-config-cluster2 \
+    ${KUBECONFIGS_DIR}/kind-config-cluster3
 
 print_clusters_message
 


### PR DESCRIPTION
Globalnet support was fixed in subctl v0.3.1, and
verify-connectivity now works for globalnet.

Found by @vthapar 