### PR TITLE
Use the actual local operator image in E2E

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,7 +5,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
     DAPPER_ENV="REPO TAG CLUSTERS_ARGS DEPLOY_ARGS" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/submariner-operator DAPPER_DOCKER_SOCKET=true \
     OPERATOR_SDK_VERSION=0.12.0 GOROOT=/usr/lib/golang
-ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
+ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output PATH=${DAPPER_SOURCE}/bin/:${PATH}
 
 RUN curl -Lo /usr/bin/operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu" && \
     chmod a+x /usr/bin/operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION := $(shell . scripts/lib/version; echo $$VERSION)
 TARGETS := $(shell ls -p scripts | grep -v -e /)
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_settings
 CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
-DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_submariner_args '--cable-driver strongswan --operator-image quay.io/submariner/submariner-operator:$(VERSION)'
+DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_submariner_args '--cable-driver strongswan --operator-image localhost:5000/submariner-operator:local'
 
 clusters: build-all
 


### PR DESCRIPTION
The previous code would still use the one from quay (as it's not present
"inside" the KIND deployment), this should use the local one that was
built.

Resolves: #414