### PR TITLE
Release binaries in "Bleeding edge" release

### DIFF
--- a/.github/workflows/subctl_bleeding_edge.yml
+++ b/.github/workflows/subctl_bleeding_edge.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches: [master]
+name: Release Subctl Bleeding Edge
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - run: git fetch origin +refs/tags/*:refs/tags/*
+
+      - name: Generate the Artifacts
+        run: |
+          make build-cross
+          echo "::set-env name=BINARIES::$(find bin/ -type f -printf '%p ')"
+
+      - name: Update the Release
+        uses: johnwbyrd/update-release@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release: Bleeding edge
+          tag: latest
+          files: ${{ env.BINARIES }}


### PR DESCRIPTION
This GitHub Action should upload updated binaries to the "Bleeding edge"
release each time a new commit is merged to master.