### PR TITLE
Stops packing subctl with upx and generates an tar.xz

### DIFF
--- a/.github/workflows/subctl_bin.yml
+++ b/.github/workflows/subctl_bin.yml
@@ -19,4 +19,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: 'bin/subctl-*'
+          args: 'bin/*.tar.xz'

--- a/.github/workflows/subctl_bleeding_edge.yml
+++ b/.github/workflows/subctl_bleeding_edge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Generate the Artifacts
         run: |
           make build-cross
-          echo "::set-env name=BINARIES::$(find bin/ -type f -printf '%p ')"
+          echo "::set-env name=BINARIES::$(find bin/ -type f -name "*.tar.xz" -printf '%p ')"
 
       - name: Update the Release
         uses: johnwbyrd/update-release@master

--- a/scripts/build-cross
+++ b/scripts/build-cross
@@ -7,6 +7,8 @@ cd $(dirname $0)
 
 ./generate-embeddedyamls
 
+export PACK_SUBCTL=true
+
 GOOS=linux GOARCH=amd64 ./build-subctl
 GOOS=linux GOARCH=386 ./build-subctl
 GOOS=darwin GOARCH=amd64 ./build-subctl

--- a/scripts/build-subctl
+++ b/scripts/build-subctl
@@ -6,17 +6,21 @@ source ${SCRIPTS_DIR}/lib/version
 
 cd ${DAPPER_SOURCE}
 
+PACK_SUBCTL="${PACK_SUBCTL:-false}"
+
 echo Building subctl version $VERSION for ${GOOS:=$(go env GOOS)}/${GOARCH:=$(go env GOARCH)}
 GIT_REF="$(git describe --tags)"
 ldflags="-X github.com/submariner-io/submariner-operator/pkg/version.Version=${VERSION} "
 ldflags="${ldflags} -X github.com/submariner-io/submariner-operator/pkg/version.GitRef=${GIT_REF}"
 
-# OSX does not seem to like upx compressed from linux, so disabled
-[ "$GOOS" != "darwin" ] || upxflag="--noupx"
-
 output=bin/subctl-${VERSION}-${GOOS}-${GOARCH}${GOEXE}
-${SCRIPTS_DIR}/compile.sh --ldflags "$ldflags" $upxflag $output ./pkg/subctl/main.go "$@"
+
+${SCRIPTS_DIR}/compile.sh --ldflags "$ldflags" --noupx $output ./pkg/subctl/main.go "$@"
 
 if [ "${GOARCH}" = "$(GOARCH= go env GOARCH)" ] && [ "${GOOS}" = "$(GOOS= go env GOOS)" ]; then
     ln -sf ${output#bin/} bin/subctl
+fi
+
+if [ "${PACK_SUBCTL}" = "true" ]; then
+  tar -cJf subctl-${VERSION}-${GOOS}-${GOARCH}.tar.xz --transform "s/^bin/subctl-${VERSION}/" ${output}
 fi


### PR DESCRIPTION
Under specific conditions (OSX, some types of mounts..) upx unpacking
of the executable generates a segmentation fault.

A decission was made to move into a tar packaged file, this will
also allow us to include more files in the future if necessary.

Extracting the files can be performed as:

```bash
$ tar xvf bin/subctl-dev-linux-amd64.tar.xz
subctl-dev-linux-amd64/subctl-dev-linux-amd64
```

Fixes-Issue: #335