### PR TITLE
Add submariner-namespace to verify-connectivity

### DIFF
--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -37,6 +37,7 @@ var (
 	connectionTimeout               uint
 	connectionAttempts              uint
 	reportDirectory                 string
+	submarinerNamespace             string
 )
 
 func init() {
@@ -53,7 +54,7 @@ func addVerifyFlags(cmd *cobra.Command) {
 	cmd.Flags().UintVar(&connectionTimeout, "connection-timeout", 60, "The timeout in seconds per connection attempt ")
 	cmd.Flags().UintVar(&connectionAttempts, "connection-attempts", 2, "The maximum number of connection attempts")
 	cmd.Flags().StringVar(&reportDirectory, "report-dir", ".", "XML report directory")
-
+	cmd.Flags().StringVar(&submarinerNamespace, "submariner-namespace", "submariner-operator", "Namespace in which submariner is deployed")
 }
 
 var verifyCmd = &cobra.Command{
@@ -68,6 +69,7 @@ var verifyCmd = &cobra.Command{
 			verifyconnectivity.RunE2E(&testing.T{})
 		}
 		if verifyServiceDiscovery || verifyAll {
+			config.GinkgoConfig.FocusString = "discovery"
 			verifyservicediscovery.RunE2E(&testing.T{})
 		}
 	},
@@ -81,6 +83,7 @@ func configureTestingFramework(args []string) {
 	framework.TestContext.ConnectionAttempts = connectionAttempts
 	framework.TestContext.ReportDir = reportDirectory
 	framework.TestContext.ReportPrefix = "subctl"
+	framework.TestContext.SubmarinerNamespace = submarinerNamespace
 
 	// For some tests this is only printing, but in some of them they need those to be
 	// the cluster IDs that will be registered in the Cluster CRDs by submariner

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -41,8 +41,13 @@ if [[ "$lighthouse" == "true" ]]; then
 fi
 echo "Verify is set to: $verify"
 
+subm_ns=""
+if [[ -n "$SUBM_NS" ]]; then
+    subm_ns="--submariner-namespace=$SUBM_NS"
+fi
+
 # run dataplane E2E tests between the two clusters
-${DAPPER_SOURCE}/bin/subctl verify ${verify} --verbose \
+${DAPPER_SOURCE}/bin/subctl verify ${verify} ${subm_ns} --verbose \
     ${KUBECONFIGS_DIR}/kind-config-cluster2 \
     ${KUBECONFIGS_DIR}/kind-config-cluster3
 


### PR DESCRIPTION
Submariner E2E requires submariner namespace for some of its
validations. Currently `verify-connectivity` doesn't specify any value
for it which causes E2E to fail. This adds a new option
`submariner-namespace` to `verify-connectivity`

Fixes #420