### PR TITLE
Update the verify command behaviour

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -36,9 +36,9 @@ echo "Running subctl a second time to verify if running subctl a second time wor
 with_context cluster3 subctl_install_subm
 
 if [[ "$lighthouse" == "true" ]]; then
-    verify="--verify-only service-discovery"
+    verify="--only service-discovery"
 else
-    verify="--verify-only connectivity"
+    verify="--only connectivity"
 fi
 
 subm_ns=""

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -36,7 +36,9 @@ echo "Running subctl a second time to verify if running subctl a second time wor
 with_context cluster3 subctl_install_subm
 
 if [[ "$lighthouse" == "true" ]]; then
-    verify="--service-discovery"
+    verify="--verify-only service-discovery"
+else
+    verify="--verify-only connectivity"
 fi
 
 subm_ns=""


### PR DESCRIPTION
The gateway-failover (redundancy) tests are added.

The new format is:
```
subctl verify k1 k2 [--enable-disruptive] [--only service-discovery,network-policy,...]
```

subctl will prompt for disruptive tests if --enable-disruptive is not enabled and any
disruptive test is expected to be executed, so the user is warned before execution
and excluded if the user does not want to perform those verifications.