### PR TITLE
Mount the host file system in the engine

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -369,6 +369,9 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 					Image:           getImagePath(cr, engineImage),
 					Command:         []string{"submariner.sh"},
 					SecurityContext: &security_context_all_caps_privilaged,
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "host-slash", MountPath: "/host", ReadOnly: true},
+					},
 					Env: []corev1.EnvVar{
 						{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 						{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -398,6 +398,9 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 			RestartPolicy:                 corev1.RestartPolicyAlways,
 			DNSPolicy:                     corev1.DNSClusterFirst,
+			Volumes: []corev1.Volume{
+				{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
+			},
 		},
 	}
 	if cr.Spec.CeIPSecIKEPort != 0 {


### PR DESCRIPTION
... so that the engine container can use the host iptables.

Signed-off-by: Stephen Kitt <skitt@redhat.com>