### PR TITLE
Fix terminationGracePeriodSeconds in Submariner Pods

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -346,7 +346,7 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 		RunAsNonRoot:             &runAsNonRoot}
 
 	// Create Pod
-	terminationGracePeriodSeconds := int64(0)
+	terminationGracePeriodSeconds := int64(10)
 	podTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: labels,
@@ -438,7 +438,7 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 		RunAsNonRoot:             &runAsNonRoot,
 	}
 
-	terminationGracePeriodSeconds := int64(0)
+	terminationGracePeriodSeconds := int64(10)
 
 	routeAgentDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -510,7 +510,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 		RunAsNonRoot:             &runAsNonRoot,
 	}
 
-	terminationGracePeriodSeconds := int64(0)
+	terminationGracePeriodSeconds := int64(10)
 
 	globalnetDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -537,7 +537,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
-								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner,kube-system,operators"},
+								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner-operator,kube-system,operators"},
 							},
 						},
 					},

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -334,7 +334,7 @@ function verify_subm_routeagent_pod() {
     [[ $(jq -r ".spec.volumes[] | select(.name==\"host-slash\").hostPath.path" $json_file) = '/' ]]
     validate_equals '.status.phase' 'Running'
     validate_equals '.metadata.namespace' $subm_ns
-    validate_equals '.spec.terminationGracePeriodSeconds' '0'
+    validate_equals '.spec.terminationGracePeriodSeconds' '10'
   done
 }
 


### PR DESCRIPTION
In K8s the default termination grace period for a Pod is 30
secs. However, for Submariner Pods, we were configuring this as
0 secs, because of which, cleanup was not happening in a
consistent manner and we are seeing failures in CI jobs.

This PR modifies the terminationGracePeriodSeconds to 10 secs.

Along with this change, for the Globalnet Pod, it also uses the proper
namespace of submariner in the excluded namespaces.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/444

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>