### PR TITLE
Remove --service-discovery-repo and --service-discovery-version

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -33,10 +33,10 @@ var (
 	globalnetEnable             bool
 	globalnetCidrRange          string
 	defaultGlobalnetClusterSize uint
+	serviceDiscovery            bool
 )
 
 func init() {
-	lighthouse.AddFlags(deployBroker, "service-discovery")
 
 	deployBroker.PersistentFlags().BoolVar(&globalnetEnable, "globalnet", false,
 		"Enable support for Overlapping CIDRs in connecting clusters (default disabled)")
@@ -47,6 +47,9 @@ func init() {
 
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
 		"Import IPsec PSK from existing submariner broker file, like broker-info.subm")
+
+	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", false,
+		"Enable Multi Cluster Service Discovery")
 
 	addKubeconfigFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
@@ -97,7 +100,8 @@ var deployBroker = &cobra.Command{
 			status.QueueSuccessMessage(fmt.Sprintf("Backed up previous %s to %s", brokerDetailsFilename, newFilename))
 		}
 
-		err = lighthouse.FillSubctlData(subctlData)
+		subctlData.ServiceDiscovery = serviceDiscovery
+
 		exitOnError("Error setting up service discovery information", err)
 
 		if globalnetEnable {

--- a/pkg/subctl/lighthouse/deploy/ensure.go
+++ b/pkg/subctl/lighthouse/deploy/ensure.go
@@ -19,34 +19,12 @@ package lighthouse
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	lighthousedns "github.com/submariner-io/submariner-operator/pkg/subctl/lighthouse/dns"
 	"github.com/submariner-io/submariner-operator/pkg/versions"
 )
-
-var (
-	serviceDiscovery bool
-	imageRepo        string
-	imageVersion     string
-)
-
-func AddFlags(cmd *cobra.Command, prefix string) {
-	cmd.PersistentFlags().BoolVar(&serviceDiscovery, prefix, false,
-		"Enable Multi Cluster Service Discovery")
-	cmd.PersistentFlags().StringVar(&imageRepo, prefix+"-repo", versions.DefaultSubmarinerRepo,
-		"Service Discovery Image repository")
-	cmd.PersistentFlags().StringVar(&imageVersion, prefix+"-version", versions.DefaultLighthouseVersion,
-		"Service Discovery Image version")
-}
-
-func FillSubctlData(subctlData *datafile.SubctlData) error {
-	subctlData.ServiceDiscovery = serviceDiscovery
-	return nil
-}
 
 func Validate() error {
 	return nil


### PR DESCRIPTION
Those flags were not used anymore, and we use the general repository
and version parameters.

This commit also moves the Flag logic for --service-discovery back
into deploy broker as we do for all flags.