### PR TITLE
Check whether the CA trust chain is needed

### DIFF
--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -321,7 +321,10 @@ func ValidateGlobalnetConfiguration(subctlData *datafile.SubctlData, netconfig C
 
 func GetGlobalNetworks(subctlData *datafile.SubctlData) (map[string]*GlobalNetwork, error) {
 
-	brokerConfig := subctlData.GetBrokerAdministratorConfig()
+	brokerConfig, err := subctlData.GetBrokerAdministratorConfig()
+	if err != nil {
+		return nil, err
+	}
 	brokerSubmClient, err := submarinerClientset.NewForConfig(brokerConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -213,8 +213,10 @@ func joinSubmarinerCluster(config *rest.Config, subctlData *datafile.SubctlData)
 	}
 
 	status.Start("Creating SA for cluster")
-	brokerAdminClientset, err := kubernetes.NewForConfig(subctlData.GetBrokerAdministratorConfig())
+	brokerAdminConfig, err := subctlData.GetBrokerAdministratorConfig()
 	exitOnError("Error retrieving broker admin config", err)
+	brokerAdminClientset, err := kubernetes.NewForConfig(brokerAdminConfig)
+	exitOnError("Error retrieving broker admin connection", err)
 	clienttoken, err = broker.CreateSAForCluster(brokerAdminClientset, clusterID)
 	status.End(cli.CheckForError(err))
 	exitOnError("Error creating SA for cluster", err)


### PR DESCRIPTION
The ca.crt stored in the broker information file reflects the trust
chain of the token, not necessarily the trust chain of the API
endpoint; but we're using it for the latter.

This breaks setups where the API endpoint is rooted in a
publicly-available CA.

(This is a test to see what happens in non-public setups...)

Fixes: #451
Signed-off-by: Stephen Kitt <skitt@redhat.com>