### PR TITLE
Drop 32-bit arches, add arm64

### DIFF
--- a/scripts/build-cross
+++ b/scripts/build-cross
@@ -10,7 +10,6 @@ cd $(dirname $0)
 export PACK_SUBCTL=true
 
 GOOS=linux GOARCH=amd64 ./build-subctl
-GOOS=linux GOARCH=386 ./build-subctl
+GOOS=linux GOARCH=arm64 ./build-subctl
 GOOS=darwin GOARCH=amd64 ./build-subctl
 GOOS=windows GOARCH=amd64 ./build-subctl
-GOOS=windows GOARCH=386 ./build-subctl


### PR DESCRIPTION
As pointed out by Mike Kolesnik, we probably don’t have any 32-bit
users.

Since we’re “freeing up” some build capacity, let’s add arm64.

Signed-off-by: Stephen Kitt <skitt@redhat.com>