### PR TITLE
Add DCO signed-off-by GHA validation

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,17 @@
+name: DCO Check
+on: pull_request
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
Add GitHub Action validating presence of signed-off-by line to accept
the Developer Certificate of Origin, as required for CNCF.

Relates-to: submariner-io/submariner#666
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>