### PR TITLE
Remove left-over cable driver status handling

### DIFF
--- a/deploy/crds/submariner.io_submariners_crd.yaml
+++ b/deploy/crds/submariner.io_submariners_crd.yaml
@@ -91,8 +91,6 @@ spec:
         status:
           description: SubmarinerStatus defines the observed state of Submariner
           properties:
-            cableDriver:
-              type: string
             clusterCIDR:
               type: string
             clusterID:

--- a/pkg/apis/submariner/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/submariner/v1alpha1/zz_generated.openapi.go
@@ -370,12 +370,6 @@ func schema_pkg_apis_submariner_v1alpha1_SubmarinerStatus(ref common.ReferenceCa
 							Format: "",
 						},
 					},
-					"cableDriver": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"engineDaemonSetStatus": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/apps/v1.DaemonSetStatus"),


### PR DESCRIPTION
The Submariner status cableDriver member was removed in 75e93516fb1e
but the operator wasn’t re-generated. This fixes that.

Signed-off-by: Stephen Kitt <skitt@redhat.com>