### PR TITLE
Disable the Openshift log message for discovery

### DIFF
--- a/pkg/discovery/network/canal.go
+++ b/pkg/discovery/network/canal.go
@@ -19,10 +19,12 @@ package network
 import (
 	"encoding/json"
 
+	"github.com/submariner-io/submariner-operator/pkg/log"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 )
 
 func discoverCanalFlannelNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, error) {
@@ -35,6 +37,9 @@ func discoverCanalFlannelNetwork(clientSet kubernetes.Interface) (*ClusterNetwor
 	//        name: flannel-cfg
 	cm, err := clientSet.CoreV1().ConfigMaps("kube-system").Get("canal-config", metav1.GetOptions{})
 	if err != nil {
+
+		klog.V(log.TRACE).Infof("Looking up for canal: %s", err)
+
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/discovery/network/generic.go
+++ b/pkg/discovery/network/generic.go
@@ -18,6 +18,9 @@ package network
 
 import (
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner-operator/pkg/log"
 )
 
 func discoverGenericNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, error) {
@@ -28,12 +31,14 @@ func discoverGenericNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, er
 
 	podIPRange, err := findPodIPRangeKubeController(clientSet)
 	if err != nil {
+		klog.V(log.TRACE).Infof("looking up for ClusterCIDR range from kube controller: %s", err)
 		return nil, err
 	}
 
 	if podIPRange == "" {
 		podIPRange, err = findPodIPRangeKubeProxy(clientSet)
 		if err != nil {
+			klog.V(log.TRACE).Infof("finding for ClusterCIDR from kube proxy: %s", err)
 			return nil, err
 		}
 	}
@@ -48,6 +53,7 @@ func discoverGenericNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, er
 	clusterIPRange, err := findClusterIPRange(clientSet)
 
 	if err != nil {
+		klog.V(log.TRACE).Infof("looking up for ServiceCIDR range: %s", err)
 		return nil, err
 	}
 

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner-operator/pkg/log"
 )
 
 var (
@@ -43,8 +45,10 @@ func discoverOpenShift4Network(dynClient dynamic.Interface) (*ClusterNetwork, er
 	crClient := dynClient.Resource(openshift4clusterNetworkGVR)
 
 	cr, err := crClient.Get("default", metav1.GetOptions{})
+
 	if err != nil {
-		klog.Info("Attempted network discovery for OpenShift4, no clusternetworks CRD")
+		klog.V(log.TRACE).Infof("Attempted network discovery for OpenShift4, no clusternetworks CRD: %s", err)
+
 		return nil, nil
 	}
 

--- a/pkg/discovery/network/weavenet.go
+++ b/pkg/discovery/network/weavenet.go
@@ -18,6 +18,9 @@ package network
 
 import (
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner-operator/pkg/log"
 )
 
 func discoverWeaveNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, error) {
@@ -25,6 +28,7 @@ func discoverWeaveNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, erro
 	weaveNetPod, err := findPod(clientSet, "name=weave-net")
 
 	if err != nil || weaveNetPod == nil {
+		klog.V(log.TRACE).Infof("looking up for weave-net pod: %s", err)
 		return nil, err
 	}
 
@@ -48,6 +52,7 @@ func discoverWeaveNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, erro
 
 	clusterIPRange, err := findClusterIPRange(clientSet)
 	if err == nil && clusterIPRange != "" {
+		klog.V(log.TRACE).Infof("looking up for ClusterIP range for weave-net: %s", err)
 		clusterNetwork.ServiceCIDRs = []string{clusterIPRange}
 	}
 

--- a/pkg/log/loglevels.go
+++ b/pkg/log/loglevels.go
@@ -1,0 +1,25 @@
+package log
+
+// Log levels defined for use with:
+//   klog.V(__).Info
+
+const (
+	// INFO : This level is for anything which does not happen very often, and while
+	//        not being an error, is important information and helpful to be in the
+	//        logs, eg:
+	//          * startup information
+	//          * HA failovers
+	//          * re-connections/disconnections
+	//          * ...
+	//        This level is not specifically defined as you would use the
+	//        klog.Info helpers
+	//
+	// DEBUG : used to provide logs for often occurring events that could be helpful
+	//        for debugging errors.
+	DEBUG = 2
+	// TRACE : used for logging that occurs often or may dump a lot of information
+	//         which generally would be less useful for debugging but can be useful
+	//         in some cases, for example tracing function entry/exit, parameters,
+	//         structures, etc..
+	TRACE = 3
+)


### PR DESCRIPTION
When this is ran on non-openshift that log message appears on console,
when it's actually irrelevant. All discovery mechanism are tried
one after another until we find one that works.

```
[majopela@bluehat submariner-operator]$ bin/subctl show networks
I0626 11:06:21.463397    3263 openshift4.go:47] Attempted network discovery for OpenShift4, no clusternetworks CRD
    Discovered network details:
        Network plugin:  weave-net
        Service CIDRs:   [100.93.0.0/16]
        Cluster CIDRs:   [10.243.0.0/16]
```