### PR TITLE
Drop GitRef, its info is present in VERSION

### DIFF
--- a/pkg/subctl/cmd/version.go
+++ b/pkg/subctl/cmd/version.go
@@ -45,5 +45,4 @@ func subctlVersion(cmd *cobra.Command, args []string) {
 
 func PrintSubctlVersion(w io.Writer) {
 	fmt.Fprintf(w, "subctl version: %s\n", version.Version)
-	fmt.Fprintf(w, "built from git ref: %s\n", version.GitRef)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,7 +3,4 @@ package version
 var (
 	// Version is updated by scripts/subctl-build at build time
 	Version = "was not built correctly"
-
-	// GitRef is updated by scripts/subctl-build
-	GitRef = ""
 )

--- a/scripts/build-subctl
+++ b/scripts/build-subctl
@@ -9,9 +9,7 @@ cd ${DAPPER_SOURCE}
 PACK_SUBCTL="${PACK_SUBCTL:-false}"
 
 echo Building subctl version $VERSION for ${GOOS:=$(go env GOOS)}/${GOARCH:=$(go env GOARCH)}
-GIT_REF="$(git describe --tags)"
-ldflags="-X github.com/submariner-io/submariner-operator/pkg/version.Version=${VERSION} "
-ldflags="${ldflags} -X github.com/submariner-io/submariner-operator/pkg/version.GitRef=${GIT_REF}"
+ldflags="-X github.com/submariner-io/submariner-operator/pkg/version.Version=${VERSION}"
 
 output=bin/subctl-${VERSION}-${GOOS}-${GOARCH}${GOEXE}
 


### PR DESCRIPTION
Commit 60745085fa34 ("Use `git describe` to get a coherent version")
includes the commit information (if relevant) in VERSION, so subctl no
longer needs a separate git ref.

Signed-off-by: Stephen Kitt <skitt@redhat.com>