### PR TITLE
Move network discovery to the operator

### DIFF
--- a/pkg/apis/submariner/v1alpha1/submariner_types.go
+++ b/pkg/apis/submariner/v1alpha1/submariner_types.go
@@ -63,8 +63,8 @@ type SubmarinerStatus struct {
 	NatEnabled                bool                    `json:"natEnabled"`
 	ColorCodes                string                  `json:"colorCodes,omitempty"`
 	ClusterID                 string                  `json:"clusterID"`
-	ServiceCIDR               string                  `json:"serviceCIDR"`
-	ClusterCIDR               string                  `json:"clusterCIDR"`
+	ServiceCIDR               string                  `json:"serviceCIDR,omitempty"`
+	ClusterCIDR               string                  `json:"clusterCIDR,omitempty"`
 	GlobalCIDR                string                  `json:"globalCIDR,omitempty"`
 	EngineDaemonSetStatus     *appsv1.DaemonSetStatus `json:"engineDaemonSetStatus,omitempty"`
 	RouteAgentDaemonSetStatus *appsv1.DaemonSetStatus `json:"routeAgentDaemonSetStatus,omitempty"`

--- a/pkg/apis/submariner/v1alpha1/submariner_types.go
+++ b/pkg/apis/submariner/v1alpha1/submariner_types.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+
+	"github.com/submariner-io/submariner-operator/pkg/versions"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -99,4 +101,21 @@ type SubmarinerList struct {
 
 func init() {
 	SchemeBuilder.Register(&Submariner{}, &SubmarinerList{})
+}
+
+func (submariner *Submariner) SetDefaults() {
+
+	if submariner.Spec.Repository == "" {
+		// An empty field is converted to the default upstream submariner repository where all images live
+		submariner.Spec.Repository = versions.DefaultSubmarinerRepo
+	}
+
+	if submariner.Spec.Version == "" {
+		submariner.Spec.Version = versions.DefaultSubmarinerVersion
+	}
+
+	if submariner.Spec.ColorCodes == "" {
+		submariner.Spec.ColorCodes = "blue"
+	}
+
 }

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -145,7 +145,7 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	setSubmarinerDefaults(instance)
+	instance.SetDefaults()
 	if err = r.client.Update(context.TODO(), instance); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -604,25 +604,6 @@ func newServiceDiscoveryCR(namespace string) *submopv1a1.ServiceDiscovery {
 			Name:      ServiceDiscoveryCrName,
 		},
 	}
-}
-
-//TODO: move to a method on the API definitions, as the example shown by the etcd operator here :
-//      https://github.com/coreos/etcd-operator/blob/8347d27afa18b6c76d4a8bb85ad56a2e60927018/pkg/apis/etcd/v1beta2/cluster.go#L185
-func setSubmarinerDefaults(submariner *submopv1a1.Submariner) {
-
-	if submariner.Spec.Repository == "" {
-		// An empty field is converted to the default upstream submariner repository where all images live
-		submariner.Spec.Repository = versions.DefaultSubmarinerRepo
-	}
-
-	if submariner.Spec.Version == "" {
-		submariner.Spec.Version = versions.DefaultSubmarinerVersion
-	}
-
-	if submariner.Spec.ColorCodes == "" {
-		submariner.Spec.ColorCodes = "blue"
-	}
-
 }
 
 const (

--- a/pkg/controller/submariner/submariner_networkdiscovery.go
+++ b/pkg/controller/submariner/submariner_networkdiscovery.go
@@ -1,0 +1,85 @@
+package submariner
+
+import (
+	"fmt"
+
+	submopv1a1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
+)
+
+func (r *ReconcileSubmariner) getClusterNetwork(submariner *submopv1a1.Submariner) (*network.ClusterNetwork, error) {
+
+	const UnknownPlugin = "unknown"
+
+	// If a previously cached discovery exists, use that
+	if r.clusterNetwork != nil && r.clusterNetwork.NetworkPlugin != UnknownPlugin {
+		return r.clusterNetwork, nil
+	}
+
+	clusterNetwork, err := network.Discover(r.dynClient, r.clientSet, r.submClient, submariner.Namespace)
+
+	if clusterNetwork != nil {
+		r.clusterNetwork = clusterNetwork
+		log.Info("Cluster network discovered")
+		clusterNetwork.Log(log)
+	} else {
+		r.clusterNetwork = &network.ClusterNetwork{NetworkPlugin: UnknownPlugin}
+		log.Info("No cluster network discovered")
+	}
+
+	return r.clusterNetwork, err
+}
+
+func (r *ReconcileSubmariner) discoverNetwork(submariner *submopv1a1.Submariner) (err error) {
+
+	clusterNetwork, err := r.getClusterNetwork(submariner)
+	submariner.Status.ClusterCIDR = getCIDR(
+		"Cluster",
+		submariner.Spec.ClusterCIDR,
+		clusterNetwork.PodCIDRs)
+
+	submariner.Status.ServiceCIDR = getCIDR(
+		"Service",
+		submariner.Spec.ServiceCIDR,
+		clusterNetwork.ServiceCIDRs)
+
+	//TODO: globalCIDR allocation if no global CIDR is assigned and enabled.
+	//      currently the clusterNetwork discovers any existing operator setting,
+	//      but that's not really helpful here
+	return err
+}
+
+func getCIDR(CIDRtype string, currentCIDR string, detectedCIDRs []string) string {
+
+	detected := getFirstCIDR(CIDRtype, detectedCIDRs)
+
+	if currentCIDR == "" {
+		if detected != "" {
+			log.Info("Using detected CIDR", "type", CIDRtype, "CIDR", detected)
+		} else {
+			log.Info("No detected CIDR", "type", CIDRtype)
+		}
+		return detected
+	}
+
+	if detected != "" && detected != currentCIDR {
+		log.Error(
+			fmt.Errorf("there is a mismatch between the detected and configured CIDRs"),
+			"The configured CIDR will take precedence",
+			"type", CIDRtype, "configured", currentCIDR, "detected", detected)
+	}
+	return currentCIDR
+}
+
+func getFirstCIDR(CIDRtype string, detectedCIDRs []string) string {
+	CIDRlen := len(detectedCIDRs)
+
+	if CIDRlen > 1 {
+		log.Error(fmt.Errorf("detected > 1 CIDRs"),
+			"we currently support only one", "detectedCIDRs", detectedCIDRs)
+	}
+	if CIDRlen > 0 {
+		return detectedCIDRs[0]
+	}
+	return ""
+}

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -57,11 +57,13 @@ type CIDR struct {
 }
 
 type Config struct {
-	GlobalnetClusterSize uint
-	GlobalnetCIDR        string
-	ServiceCIDR          string
-	ClusterCIDR          string
-	ClusterID            string
+	GlobalnetClusterSize    uint
+	GlobalnetCIDR           string
+	ServiceCIDR             string
+	ServiceCIDRAutoDetected bool
+	ClusterCIDR             string
+	ClusterCIDRAutoDetected bool
+	ClusterID               string
 }
 
 var globalCidr = GlobalCIDR{allocatedCount: 0}

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -19,6 +19,7 @@ package network
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -48,6 +49,13 @@ func (cn *ClusterNetwork) Show() {
 	}
 }
 
+func (cn *ClusterNetwork) Log(logger logr.Logger) {
+	logger.Info("Discovered K8s network details",
+		"plugin", cn.NetworkPlugin,
+		"clusterCIDRs", cn.PodCIDRs,
+		"serviceCIDRs", cn.ServiceCIDRs)
+}
+
 func (cn *ClusterNetwork) IsComplete() bool {
 	return cn != nil && len(cn.ServiceCIDRs) > 0 && len(cn.PodCIDRs) > 0
 }
@@ -56,6 +64,7 @@ func Discover(dynClient dynamic.Interface, clientSet kubernetes.Interface, submC
 	discovery, err := networkPluginsDiscovery(dynClient, clientSet)
 
 	if err == nil && discovery != nil {
+		// TODO: The other branch of this if will not try to find the globalCIDRs
 		globalCIDR, _ := getGlobalCIDRs(submClient, operatorNamespace)
 		discovery.GlobalCIDR = globalCIDR
 		if discovery.IsComplete() {

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -83,6 +83,8 @@ function verify_subm_deployed() {
     # FIXME: Rename all of these submariner-engine or engine, vs submariner
     # Verify SubM CR
     verify_subm_cr
+    # Verify Subm CR status
+    verify_subm_cr_status_with_retries
     # Verify SubM Engine Deployment
     verify_subm_engine_deployment
     # Verify SubM Engine Pod
@@ -158,6 +160,28 @@ function verify_clusters_crd() {
   validate_equals '.status.acceptedNames.kind' 'Cluster'
 }
 
+# retries are necessary for the status field, which can take some seconds to fill up
+# properly by the operator
+function verify_subm_cr_status_with_retries() {
+  function verify_subm_cr_status_() {
+    if ! verify_subm_cr_status; then
+      sleep 5 && return 1
+    fi
+    return 0
+  }
+  with_retries 5 verify_subm_cr_status_
+}
+
+function verify_subm_cr_status() {
+
+  json_file=/tmp/${deployment_name}.${cluster}.json
+  kubectl get submariner $deployment_name --namespace=$subm_ns -o json > $json_file
+
+  validate_equals '.status.serviceCIDR' ${service_CIDRs[$cluster]}
+  validate_equals '.status.clusterCIDR' ${cluster_CIDRs[$cluster]}
+
+}
+
 function verify_subm_cr() {
   # TODO: Use $engine_deployment_name here?
 
@@ -190,8 +214,6 @@ function verify_subm_cr() {
   validate_equals '.spec.namespace' $subm_ns
   validate_equals '.spec.natEnabled' $natEnabled
 
-  validate_equals '.spec.serviceCIDR' ${service_CIDRs[$cluster]}
-  validate_equals '.spec.clusterCIDR' ${cluster_CIDRs[$cluster]}
 }
 
 function verify_subm_op_pod() {


### PR DESCRIPTION
This pull requests moves the network discovery to the operator.

This allows for configuring the operator with empty cluster and service CIDRs.
Subctl will still try to discover the details to make sure that the operator will be able
to figure out those details, and if it is not possible, it will prompt the user and write
those values in the operator CR.

