### PR TITLE
Network discovery: only access discovery if non-nil

### DIFF
--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -54,10 +54,10 @@ func (cn *ClusterNetwork) IsComplete() bool {
 
 func Discover(dynClient dynamic.Interface, clientSet kubernetes.Interface, submClient submarinerclientset.Interface, operatorNamespace string) (*ClusterNetwork, error) {
 	discovery, err := networkPluginsDiscovery(dynClient, clientSet)
-	globalCIDR, _ := getGlobalCIDRs(submClient, operatorNamespace)
-	discovery.GlobalCIDR = globalCIDR
 
 	if err == nil && discovery != nil {
+		globalCIDR, _ := getGlobalCIDRs(submClient, operatorNamespace)
+		discovery.GlobalCIDR = globalCIDR
 		if discovery.IsComplete() {
 			return discovery, nil
 		} else {


### PR DESCRIPTION
networkPluginsDiscovery can return nil, which leads to a SIGSEGV when
we try to set GlobalCIDR in the returned object. Only update discovery
after checking its non-nil.

Signed-off-by: Stephen Kitt <skitt@redhat.com>