### PR TITLE
Reset terminationGracePeriodSeconds for SM Engine and RouteAgent Pods

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -354,7 +354,7 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 		RunAsNonRoot:             &runAsNonRoot}
 
 	// Create Pod
-	terminationGracePeriodSeconds := int64(10)
+	terminationGracePeriodSeconds := int64(1)
 	podTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: labels,
@@ -446,7 +446,7 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 		RunAsNonRoot:             &runAsNonRoot,
 	}
 
-	terminationGracePeriodSeconds := int64(10)
+	terminationGracePeriodSeconds := int64(1)
 
 	routeAgentDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -518,7 +518,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 		RunAsNonRoot:             &runAsNonRoot,
 	}
 
-	terminationGracePeriodSeconds := int64(10)
+	terminationGracePeriodSeconds := int64(2)
 
 	globalnetDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -334,7 +334,7 @@ function verify_subm_routeagent_pod() {
     [[ $(jq -r ".spec.volumes[] | select(.name==\"host-slash\").hostPath.path" $json_file) = '/' ]]
     validate_equals '.status.phase' 'Running'
     validate_equals '.metadata.namespace' $subm_ns
-    validate_equals '.spec.terminationGracePeriodSeconds' '10'
+    validate_equals '.spec.terminationGracePeriodSeconds' '1'
   done
 }
 


### PR DESCRIPTION
In one of the earlier PRs, we modified the terminationGracePeriodSeconds
to 10 secs. However, its seen that this is causing more CI failures
during e2e redundancy tests. Ideally, once the Pods are terminated,
it should cleanup itself ASAP but it is seen that SM Pods are sometimes
taking time to exit and during this Period since there is no active SM
Pod running, this is triggering some failures.

Until we figure out the exact reason why the Pods are taking time for
cleanup, this PR resets the terminationGracePeriodSeconds.

Related to: https://github.com/submariner-io/submariner-operator/issues/444
Related to: https://github.com/submariner-io/submariner-operator/pull/445

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>