### PR TITLE
Increase e2e connection timeout

### DIFF
--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -161,8 +161,8 @@ func checkValidateArguments(args []string) error {
 		return fmt.Errorf("--connection-attempts must be >=1")
 	}
 
-	if connectionTimeout < 60 {
-		return fmt.Errorf("--connection-timeout must be >=60")
+	if connectionTimeout < 20 {
+		return fmt.Errorf("--connection-timeout must be >=20")
 	}
 	return nil
 }

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -45,7 +45,7 @@ if [[ -n "$SUBM_NS" ]]; then
 fi
 
 # run dataplane E2E tests between the two clusters
-${DAPPER_SOURCE}/bin/subctl verify ${verify} ${subm_ns} --verbose \
+${DAPPER_SOURCE}/bin/subctl verify ${verify} ${subm_ns} --verbose --connection-timeout 20 --connection-attempts 4 \
     ${KUBECONFIGS_DIR}/kind-config-cluster1 \
     ${KUBECONFIGS_DIR}/kind-config-cluster2
 


### PR DESCRIPTION
Currently, the e2e connection-attempts is set to 2 and this
can cause failures in GN jobs. This PR modifies connection-attempts
to 4 while decreasing the connection-timeout to 20 secs.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>