### PR TITLE
Allow the operator to retrieve Gateway objects

### DIFF
--- a/pkg/apis/submariner/v1alpha1/submariner_types.go
+++ b/pkg/apis/submariner/v1alpha1/submariner_types.go
@@ -67,7 +67,7 @@ type SubmarinerStatus struct {
 	EngineDaemonSetStatus     *appsv1.DaemonSetStatus `json:"engineDaemonSetStatus,omitempty"`
 	RouteAgentDaemonSetStatus *appsv1.DaemonSetStatus `json:"routeAgentDaemonSetStatus,omitempty"`
 	GlobalnetDaemonSetStatus  *appsv1.DaemonSetStatus `json:"globalnetDaemonSetStatus,omitempty"`
-	GatewayList               *submv1.GatewayList     `json:"gatewayList,omitempty"`
+	Gateways                  *[]submv1.Gateway       `json:"gateways,omitempty"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html

--- a/pkg/apis/submariner/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/submariner/v1alpha1/zz_generated.deepcopy.go
@@ -214,10 +214,16 @@ func (in *SubmarinerStatus) DeepCopyInto(out *SubmarinerStatus) {
 		*out = new(v1.DaemonSetStatus)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.GatewayList != nil {
-		in, out := &in.GatewayList, &out.GatewayList
-		*out = new(submarineriov1.GatewayList)
-		(*in).DeepCopyInto(*out)
+	if in.Gateways != nil {
+		in, out := &in.Gateways, &out.Gateways
+		*out = new([]submarineriov1.Gateway)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]submarineriov1.Gateway, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
+		}
 	}
 	return
 }

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
@@ -52,6 +53,10 @@ var log = logf.Log.WithName("controller_submariner")
 // Add creates a new Submariner Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	// These are required so that we can retrieve Gateway objects using the dynamic client
+	mgr.GetScheme().AddKnownTypeWithName(schema.FromAPIVersionAndKind("submariner.io/v1", "Gateway"), &submv1.Gateway{})
+	mgr.GetScheme().AddKnownTypeWithName(schema.FromAPIVersionAndKind("submariner.io/v1", "GatewayList"), &submv1.GatewayList{})
+	mgr.GetScheme().AddKnownTypeWithName(schema.FromAPIVersionAndKind("submariner.io/v1", "ListOptions"), &metav1.ListOptions{})
 	return add(mgr, newReconciler(mgr))
 }
 
@@ -160,7 +165,7 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 	gateways, err := r.retrieveGateways(instance, request.Namespace)
 	if err != nil {
 		// Not fatal
-		log.Error(err, "error retrieving gateway")
+		log.Error(err, "error retrieving gateways")
 	}
 
 	// Update the status
@@ -171,7 +176,7 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 		ServiceCIDR: instance.Spec.ServiceCIDR,
 		ClusterCIDR: instance.Spec.ClusterCIDR,
 		GlobalCIDR:  instance.Spec.GlobalCIDR,
-		GatewayList: gateways,
+		Gateways:    gateways,
 	}
 	if engineDaemonSet != nil {
 		status.EngineDaemonSetStatus = &engineDaemonSet.Status
@@ -197,7 +202,7 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileSubmariner) retrieveGateways(owner metav1.Object, namespace string) (*submv1.GatewayList, error) {
+func (r *ReconcileSubmariner) retrieveGateways(owner metav1.Object, namespace string) (*[]submv1.Gateway, error) {
 	foundGateways := &submv1.GatewayList{}
 	err := r.client.List(context.TODO(), foundGateways, client.InNamespace(namespace))
 	if err != nil && errors.IsNotFound(err) {
@@ -212,7 +217,7 @@ func (r *ReconcileSubmariner) retrieveGateways(owner metav1.Object, namespace st
 			return nil, err
 		}
 	}
-	return foundGateways, nil
+	return &foundGateways.Items, nil
 }
 
 func (r *ReconcileSubmariner) deletePreExistingEngineDeployment(namespace string, reqLogger logr.Logger) error {


### PR DESCRIPTION
Currently the Gateway types aren’t registered; this fixes that. It
turns out we also need to fill in the GatewayList meta-data if we want
to add it as-is to the status, so this also changes the status to
include the Gateway slice instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>