### PR TITLE
Use Shipyard devel image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-dapper-base
+FROM quay.io/submariner/shipyard-dapper-base:devel
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \


### PR DESCRIPTION
Since we moved to tag only the stable releases 'latest', we now need
to use the 'devel' tag to get the cutting edge Shipyard image.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>