### PR TITLE
Drop $(TARGETS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ CROSS_TARGETS := linux-amd64 linux-arm64 windows-amd64.exe darwin-amd64
 BINARIES := bin/subctl
 CROSS_BINARIES := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,bin/subctl-$(VERSION)-%,$(cross)))
 CROSS_TARBALLS := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,dist/subctl-$(VERSION)-%.tar.xz,$(cross)))
-TARGETS := $(shell ls -p scripts | grep -v -e /)
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_settings
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_submariner_args '--cable-driver strongswan --operator-image localhost:5000/submariner-operator:local'
@@ -42,9 +41,6 @@ e2e: deploy
 	scripts/kind-e2e/e2e.sh
 
 test: unit-test
-
-$(TARGETS): vendor/modules.txt
-	./scripts/$@
 
 clean:
 	rm -f $(BINARIES) $(CROSS_BINARIES) $(CROSS_TARBALLS)
@@ -108,7 +104,7 @@ preload-images:
 		import_image quay.io/submariner/$${image}; \
 	done
 
-.PHONY: $(TARGETS) test validate build ci clean generate-clientset generate-embeddedyamls generate-operator-api operator-image preload-images
+.PHONY: test validate build ci clean generate-clientset generate-embeddedyamls generate-operator-api operator-image preload-images
 
 else
 


### PR DESCRIPTION
Now that we no longer have any build scripts in scripts, we no longer
need to load them as Make targets.

Signed-off-by: Stephen Kitt <skitt@redhat.com>