### PR TITLE
Load versions for preload images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ generate-operator-api:
 preload-images:
 	source $(SCRIPTS_DIR)/lib/debug_functions; \
 	source $(SCRIPTS_DIR)/lib/deploy_funcs; \
+	source $(SCRIPTS_DIR)/lib/version; \
 	set -e; \
 	for image in submariner submariner-route-agent submariner-operator lighthouse-agent submariner-globalnet lighthouse-coredns; do \
 		import_image quay.io/submariner/$${image}; \


### PR DESCRIPTION
It's needed by the import_image function

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>