### PR TITLE
Operators track reconciliations, no need to do it

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -144,8 +144,6 @@ type ReconcileSubmariner struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	recordReconciliation()
-
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Submariner")
 

--- a/pkg/controller/submariner/submariner_metrics.go
+++ b/pkg/controller/submariner/submariner_metrics.go
@@ -30,12 +30,6 @@ const (
 )
 
 var (
-	reconciliationsCounter = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "submariner_reconciliations",
-			Help: "Number of reconciliations processed",
-		},
-	)
 	gatewaysGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "submariner_gateways",
@@ -57,11 +51,7 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister(reconciliationsCounter, gatewaysGauge, connectionsGauge)
-}
-
-func recordReconciliation() {
-	reconciliationsCounter.Inc()
+	metrics.Registry.MustRegister(gatewaysGauge, connectionsGauge)
 }
 
 func recordGateways(count int) {


### PR DESCRIPTION
Operators already count reconciliations, with more information than we
provide, so there’s no point in having our own reconciliation metric.

Signed-off-by: Stephen Kitt <skitt@redhat.com>