### PR TITLE
Fix empty globalCidr in submariner-globalnet-info ConfigMap

### DIFF
--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -87,17 +87,14 @@ func isOverlappingCIDR(cidrList []string, cidr string) (bool, error) {
 }
 
 func NewCIDR(cidr string) (CIDR, error) {
-	clusterCidr := CIDR{}
 	_, network, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return clusterCidr, fmt.Errorf("invalid cidr %q passed as input", cidr)
+		return CIDR{}, fmt.Errorf("invalid cidr %q passed as input", cidr)
 	}
 	ones, total := network.Mask.Size()
 	size := total - ones
 	lastIp := LastIp(network)
-	clusterCidr.network = network
-	clusterCidr.size = size
-	clusterCidr.lastIp = lastIp
+	clusterCidr := CIDR{network: network, size: size, lastIp: lastIp}
 	return clusterCidr, nil
 }
 
@@ -114,8 +111,9 @@ func allocateByCidr(cidr string) (uint, error) {
 	if err != nil || !globalCidr.net.Contains(requestedIp) {
 		return 0, fmt.Errorf("%s not a valid subnet of %v\n", cidr, globalCidr.net)
 	}
-	clusterCidr, err := NewCIDR(cidr)
-	if err != nil {
+
+	var clusterCidr CIDR
+	if clusterCidr, err = NewCIDR(cidr); err != nil {
 		return 0, err
 	}
 

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -252,10 +252,10 @@ func AllocateAndUpdateGlobalCIDRConfigMap(brokerAdminClientset *kubernetes.Clien
 			}
 
 			if globalnetInfo.GlobalCidrInfo[clusterID] == nil ||
-				globalnetInfo.GlobalCidrInfo[clusterID].GlobalCIDRs[0] != globalnetCIDR {
+				globalnetInfo.GlobalCidrInfo[clusterID].GlobalCIDRs[0] != netconfig.GlobalnetCIDR {
 				var newClusterInfo broker.ClusterInfo
 				newClusterInfo.ClusterId = clusterID
-				newClusterInfo.GlobalCidr = []string{globalnetCIDR}
+				newClusterInfo.GlobalCidr = []string{netconfig.GlobalnetCIDR}
 
 				err = broker.UpdateGlobalnetConfigMap(brokerAdminClientset, brokerNamespace, globalnetConfigMap, newClusterInfo)
 				return err


### PR DESCRIPTION
As part of some recent changes, there is a regression
because of which an empty "global_cidr" is stored in
the submariner-globalnet-info configMap on Broker.
This PR fixes this issue and also the associated
segmentation fault which was the side-effect.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/561

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>