### PR TITLE
Fix the operator cluster permissions for discovery

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,10 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: submariner-operator:lighthouse
+  name: submariner-operator
 rules:
   # submariner-operator updates the config map of core-dns to forward requests to
-  # supercluster.local to Lighthouse DNS
+  # supercluster.local to Lighthouse DNS, also looks at existing configmaps
+  # to figure out network settings
   - apiGroups:
       - ""
     resources:
@@ -14,6 +15,15 @@ rules:
       - list
       - watch
       - update
+  - apiGroups: # pods and services are looked up to figure out network settings
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -23,3 +33,10 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - network.openshift.io
+    resources:
+      - clusternetworks
+    verbs:
+      - get
+      - list

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: submariner-operator:lighthouse
+  name: submariner-operator
 subjects:
     - kind: ServiceAccount
       name: submariner-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: submariner-operator:lighthouse
+  name: submariner-operator


### PR DESCRIPTION
Discovery of the network looks at ClusterNetwork, and if that
fails it will look for specific configurations and generic
heuristics.

Fixes-Issue: #557

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>