### PR TITLE
Set Globalnet_enabled flag in lighthouse agent env

### DIFF
--- a/pkg/controller/servicediscovery/servicediscovery_controller.go
+++ b/pkg/controller/servicediscovery/servicediscovery_controller.go
@@ -207,6 +207,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery) *appsv1.Deploym
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
 								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner,kube-system,operators"},
 								{Name: "SUBMARINER_DEBUG", Value: strconv.FormatBool(cr.Spec.Debug)},
+								{Name: "SUBMARINER_GLOBALNET_ENABLED", Value: strconv.FormatBool(cr.Spec.GlobalnetEnabled)},
 								{Name: "BROKER_K8S_APISERVER", Value: cr.Spec.BrokerK8sApiServer},
 								{Name: "BROKER_K8S_APISERVERTOKEN", Value: cr.Spec.BrokerK8sApiServerToken},
 								{Name: "BROKER_K8S_REMOTENAMESPACE", Value: cr.Spec.BrokerK8sRemoteNamespace},


### PR DESCRIPTION
PR #488 added Globalnet_Enabled flag to spec but missed setting it in env
variable for the Lighthouse agent PODs. So the flag is never available
to agent code running in the pod. This adds the env variable to POD spec
based on flag value in the Submariner spec.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>