### PR TITLE
Add golangci-lint config file, add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,52 @@
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - opinionated
+      #- performance
+      - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
+  gocyclo:
+    min-complexity: 20
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    #- dupl
+    - errcheck
+    - exportloopref
+    #- funlen
+    #- gochecknoglobals
+    #- gochecknoinits
+    #- gocritic
+    - gocyclo
+    #- gofmt
+    - goimports
+    #- golint
+    #- gosec
+    - gosimple
+    - govet
+    - ineffassign
+    #- interfacer
+    #- lll
+    #- maligned
+    #- misspell
+    - nakedret
+    - staticcheck
+    - structcheck
+    #- stylecheck
+    #- testpackage
+    - typecheck
+    - unconvert
+    #- unparam
+    - unused
+    - varcheck
+    #- whitespace


### PR DESCRIPTION
Explicitly enable linters to be run by golangci-lint. Makes testing more
explicit/consistent and also allows us to add non-default linters.

Enables these extra linters over the defaults:

* bodyclose: checks whether HTTP response body is closed successfully
* depguard: Go linter that checks if package imports are in a list of
  acceptable packages
* exportloopref: An analyzer that finds exporting pointers for loop
  variables
* gocyclo: Computes and checks the cyclomatic complexity of functions
* goimports: Goimports does everything that gofmt does. Additionally it
  checks unused imports
* nakedret: Finds naked returns in functions greater than a specified
  function length
* unconvert: Remove unnecessary type conversions

Other linters we may want to enable as we fix errors are included as
comments.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>