### PR TITLE
Enable maligned memory use linter, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,8 +37,8 @@ linters:
     - ineffassign
     #- interfacer
     #- lll
-    #- maligned
     - misspell
+    - maligned
     - nakedret
     - staticcheck
     - structcheck

--- a/pkg/apis/submariner/v1alpha1/servicediscovery_types.go
+++ b/pkg/apis/submariner/v1alpha1/servicediscovery_types.go
@@ -26,15 +26,15 @@ import (
 // ServiceDiscoverySpec defines the desired state of ServiceDiscovery
 // +k8s:openapi-gen=true
 type ServiceDiscoverySpec struct {
-	Version                  string `json:"version,omitempty"`
-	Repository               string `json:"repository,omitempty"`
+	BrokerK8sApiServer       string `json:"brokerK8sApiServer"`
+	BrokerK8sApiServerToken  string `json:"brokerK8sApiServerToken"`
 	BrokerK8sCA              string `json:"brokerK8sCA"`
 	BrokerK8sRemoteNamespace string `json:"brokerK8sRemoteNamespace"`
-	BrokerK8sApiServerToken  string `json:"brokerK8sApiServerToken"`
-	BrokerK8sApiServer       string `json:"brokerK8sApiServer"`
-	Debug                    bool   `json:"debug"`
 	ClusterID                string `json:"clusterID"`
 	Namespace                string `json:"namespace"`
+	Repository               string `json:"repository,omitempty"`
+	Version                  string `json:"version,omitempty"`
+	Debug                    bool   `json:"debug"`
 	GlobalnetEnabled         bool   `json:"globalnetEnabled,omitempty"`
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -57,11 +57,10 @@ type ServiceDiscoveryStatus struct {
 // +kubebuilder:resource:path=servicediscoveries,scope=Namespaced
 // +genclient
 type ServiceDiscovery struct {
-	metav1.TypeMeta   `json:",inline"`
+	Status            ServiceDiscoveryStatus `json:"status,omitempty"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   ServiceDiscoverySpec   `json:"spec,omitempty"`
-	Status ServiceDiscoveryStatus `json:"status,omitempty"`
+	Spec              ServiceDiscoverySpec `json:"spec,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner/v1alpha1/submariner_types.go
+++ b/pkg/apis/submariner/v1alpha1/submariner_types.go
@@ -31,26 +31,26 @@ import (
 // SubmarinerSpec defines the desired state of Submariner
 // +k8s:openapi-gen=true
 type SubmarinerSpec struct {
-	Version                  string `json:"version,omitempty"`
-	Repository               string `json:"repository,omitempty"`
-	CeIPSecNATTPort          int    `json:"ceIPSecNATTPort,omitempty"`
-	CeIPSecIKEPort           int    `json:"ceIPSecIKEPort,omitempty"`
-	CeIPSecDebug             bool   `json:"ceIPSecDebug"`
-	CeIPSecPSK               string `json:"ceIPSecPSK"`
+	Broker                   string `json:"broker"`
+	BrokerK8sApiServer       string `json:"brokerK8sApiServer"`
+	BrokerK8sApiServerToken  string `json:"brokerK8sApiServerToken"`
 	BrokerK8sCA              string `json:"brokerK8sCA"`
 	BrokerK8sRemoteNamespace string `json:"brokerK8sRemoteNamespace"`
-	BrokerK8sApiServerToken  string `json:"brokerK8sApiServerToken"`
-	BrokerK8sApiServer       string `json:"brokerK8sApiServer"`
-	Broker                   string `json:"broker"`
-	NatEnabled               bool   `json:"natEnabled"`
-	Debug                    bool   `json:"debug"`
-	ColorCodes               string `json:"colorCodes,omitempty"`
-	ClusterID                string `json:"clusterID"`
-	ServiceCIDR              string `json:"serviceCIDR"`
+	CableDriver              string `json:"cableDriver,omitempty"`
+	CeIPSecPSK               string `json:"ceIPSecPSK"`
 	ClusterCIDR              string `json:"clusterCIDR"`
+	ClusterID                string `json:"clusterID"`
+	ColorCodes               string `json:"colorCodes,omitempty"`
+	Repository               string `json:"repository,omitempty"`
+	ServiceCIDR              string `json:"serviceCIDR"`
 	GlobalCIDR               string `json:"globalCIDR,omitempty"`
 	Namespace                string `json:"namespace"`
-	CableDriver              string `json:"cableDriver,omitempty"`
+	Version                  string `json:"version,omitempty"`
+	CeIPSecIKEPort           int    `json:"ceIPSecIKEPort,omitempty"`
+	CeIPSecNATTPort          int    `json:"ceIPSecNATTPort,omitempty"`
+	CeIPSecDebug             bool   `json:"ceIPSecDebug"`
+	Debug                    bool   `json:"debug"`
+	NatEnabled               bool   `json:"natEnabled"`
 	ServiceDiscoveryEnabled  bool   `json:"serviceDiscoveryEnabled,omitempty"`
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -57,13 +57,13 @@ type CIDR struct {
 }
 
 type Config struct {
-	GlobalnetClusterSize    uint
+	ClusterCIDR             string
+	ClusterID               string
 	GlobalnetCIDR           string
 	ServiceCIDR             string
-	ServiceCIDRAutoDetected bool
-	ClusterCIDR             string
+	GlobalnetClusterSize    uint
 	ClusterCIDRAutoDetected bool
-	ClusterID               string
+	ServiceCIDRAutoDetected bool
 }
 
 var globalCidr = GlobalCIDR{allocatedCount: 0}

--- a/pkg/internal/cli/logger.go
+++ b/pkg/internal/cli/logger.go
@@ -32,9 +32,9 @@ import (
 // Logger is the kind cli's log.Logger implementation
 type Logger struct {
 	writer     io.Writer
+	bufferPool *bufferPool
 	writerMu   sync.Mutex
 	verbosity  log.Level
-	bufferPool *bufferPool
 	// kind special additions
 	isSmartWriter bool
 }


### PR DESCRIPTION
While re-ordering structs, also put their fields in alphabetical order
within memory-order constraints.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>