### PR TITLE
Allow lighthouse access to gateways.submariner.io

### DIFF
--- a/deploy/lighthouse/cluster_role.yaml
+++ b/deploy/lighthouse/cluster_role.yaml
@@ -25,3 +25,11 @@ rules:
   - watch
   - update
   - delete
+- apiGroups:
+    - submariner.io
+  resources:
+    - "gateways"
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Adds following permissions to lighthouse clusterrole
for `gateways.submariner.io`
 - get
 - list
 - watch

This allows lighthouse to track changes to gateway status and know which
clusters are connected.

Fixes https://github.com/submariner-io/lighthouse/issues/113

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>