### PR TITLE
Don't check CRD spec version

### DIFF
--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -142,7 +142,6 @@ function validate_crd() {
   validate_equals '.metadata.name' "$crd_name"
   validate_equals '.spec.scope' 'Namespaced'
   validate_equals '.spec.group' 'submariner.io'
-  validate_equals '.spec.version' "$version"
   validate_equals '.spec.names.kind' "$spec_name"
 }
 


### PR DESCRIPTION
Seems this field was deprecated in the API [1] and it's causing K8s 1.16+
to fail because it's not there anymore, so just removing this check.

[1] https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#customresourcedefinitionspec-v1beta1-apiextensions-k8s-io

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>