### PR TITLE
Check the K8s version on the cluster

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -18,12 +18,14 @@ package cmd
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
+	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -94,6 +96,8 @@ func addJoinFlags(cmd *cobra.Command) {
 
 const (
 	SubmarinerNamespace = "submariner-operator" // We currently expect everything in submariner-operator
+	minK8sMajor         = 1                     // We need K8s 1.17 for endpoint slices
+	minK8sMinor         = 17
 )
 
 var joinCmd = &cobra.Command{
@@ -176,6 +180,18 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, subctlData *datafile.S
 	clientConfig, err := config.ClientConfig()
 	exitOnError("Error connecting to the target cluster", err)
 
+	failedRequirements, err := checkRequirements(clientConfig)
+	// We display failed requirements even if an error occurred
+	if len(failedRequirements) > 0 {
+		fmt.Println("The target cluster fails to meet Submariner's requirements:")
+		for i := range failedRequirements {
+			fmt.Printf("* %s\n", (failedRequirements)[i])
+		}
+		exitOnError("Unable to check all requirements", err)
+		os.Exit(1)
+	}
+	exitOnError("Unable to check requirements", err)
+
 	if !noLabel {
 		err := handleNodeLabels(clientConfig)
 		exitOnError("Unable to set the gateway node up", err)
@@ -228,6 +244,37 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, subctlData *datafile.S
 		status.End(cli.Failure)
 	}
 	exitOnError("Error deploying Submariner", err)
+}
+
+func checkRequirements(config *rest.Config) ([]string, error) {
+	failedRequirements := []string{}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return failedRequirements, errors.WithMessage(err, "error creating API server client")
+	}
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return failedRequirements, errors.WithMessage(err, "error obtaining API server version")
+	}
+	major, err := strconv.Atoi(serverVersion.Major)
+	if err != nil {
+		return failedRequirements, errors.WithMessagef(err, "error parsing API server major version %v", serverVersion.Major)
+	}
+	var minor int
+	if strings.HasSuffix(serverVersion.Minor, "+") {
+		minor, err = strconv.Atoi(serverVersion.Minor[0 : len(serverVersion.Minor)-1])
+	} else {
+		minor, err = strconv.Atoi(serverVersion.Minor)
+	}
+	if err != nil {
+		return failedRequirements, errors.WithMessagef(err, "error parsing API server minor version %v", serverVersion.Minor)
+	}
+	if major < minK8sMajor || (major == minK8sMajor && minor < minK8sMinor) {
+		failedRequirements = append(failedRequirements,
+			fmt.Sprintf("Submariner requires Kubernetes %d.%d; your cluster is running %s.%s",
+				minK8sMajor, minK8sMinor, serverVersion.Major, serverVersion.Minor))
+	}
+	return failedRequirements, nil
 }
 
 func AllocateAndUpdateGlobalCIDRConfigMap(brokerAdminClientset *kubernetes.Clientset, brokerNamespace string,


### PR DESCRIPTION
For endpoint slices we need 1.17, enforce that before deploying.

Fixes: #601
Signed-off-by: Stephen Kitt <skitt@redhat.com>