### PR TITLE
Rely on the default KUBECONFIG handling

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -57,32 +56,13 @@ func init() {
 }
 
 func addKubeconfigFlag(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", kubeConfigFile(), "absolute path(s) to the kubeconfig file(s)")
+	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path(s) to the kubeconfig file(s)")
 	cmd.PersistentFlags().StringVar(&kubeContext, "kubecontext", "", "kubeconfig context to use")
 }
 
 const (
 	OperatorNamespace = "submariner-operator"
 )
-
-func kubeConfigFile() string {
-	var kubeconfig string
-	if kubeconfig = os.Getenv("KUBECONFIG"); kubeconfig != "" {
-		return kubeconfig
-	}
-	if home := homeDir(); home != "" {
-		return filepath.Join(home, ".kube", "config")
-	} else {
-		return ""
-	}
-}
-
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
-}
 
 func panicOnError(err error) {
 	if err != nil {


### PR DESCRIPTION
client-go knows how to deal with multiple kubeconfigs in a KUBECONFIG,
but we lose that by doing our own default handling. Using client-go
ensures that we get any fixes there, and provides cross-platform
default path handling as well as coping with multiple kubeconfigs.

This doesn’t quite fix #384, since the intention of the client-go
handling is context-based: it will look in all the kubeconfigs to find
the requested (or default) context, it won’t allow iterating over all
the kubeconfigs to access multiple clusters.

Signed-off-by: Stephen Kitt <skitt@redhat.com>