### PR TITLE
If OCP4 network discovery fails, log the error

### DIFF
--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -43,8 +43,8 @@ func discoverOpenShift4Network(dynClient dynamic.Interface) (*ClusterNetwork, er
 
 	cr, err := crClient.Get("default", metav1.GetOptions{})
 	if err != nil {
-		klog.Info("Attempted network discovery for OpenShift4, no clusternetworks CRD")
-		return nil, nil
+		klog.Infof("Attempted network discovery for OpenShift4, no clusternetworks CRD: %v", err)
+		return nil, err
 	}
 
 	return parseOS4ClusterNetwork(cr)


### PR DESCRIPTION
Currently if OCP4 network discovery fails, the details of the error
aren’t logged, which complicates debugging related issues on OCP4.

This patch ensures the error is logged and returns the error (which
doesn’t change the caller’s behaviour).

Signed-off-by: Stephen Kitt <skitt@redhat.com>