### PR TITLE
Ensure all ClusterRoles are updated on upgrade

### DIFF
--- a/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
@@ -121,16 +121,17 @@ func ensureClusterRole(clientSet *clientset.Clientset, namespace string) (bool, 
 	if err != nil {
 		return false, fmt.Errorf("ClusterRole update or create failed: %s", err)
 	}
-	result, err := utils.CreateOrUpdateClusterRole(clientSet, clusterRole)
-	if err != nil || !result {
-		return false, err
+	clusterRoleResult, err := utils.CreateOrUpdateClusterRole(clientSet, clusterRole)
+	if err != nil {
+		return clusterRoleResult, err
 	}
 
 	lighthouseClusterRole, err := getLighthouseOperatorClusterRole()
 	if err != nil {
 		return false, fmt.Errorf("lighthouseClusterRole update or create failed: %s", err)
 	}
-	return utils.CreateOrUpdateClusterRole(clientSet, lighthouseClusterRole)
+	lighthouseClusterRoleResult, err := utils.CreateOrUpdateClusterRole(clientSet, lighthouseClusterRole)
+	return clusterRoleResult || lighthouseClusterRoleResult, err
 }
 
 func ensureClusterRoleBinding(clientSet *clientset.Clientset, namespace string) (bool, error) {


### PR DESCRIPTION
When upgrading a cluster, if the first operator ClusterRole we look at
doesn’t need updating, we stop there and skip the other operator
ClusterRole. This patch changes the behaviour so that both
ClusterRoles are checked.

(Ultimately we should clean up our ClusterRoles, but this will fix an
issue seen in production in the short term.)

Fixes: #609
Signed-off-by: Stephen Kitt <skitt@redhat.com>