### PR TITLE
Avoid checking for EngineDeployment during reconcileEngineDaemonSet

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -265,28 +265,8 @@ func (r *ReconcileSubmariner) retrieveGateways(owner metav1.Object, namespace st
 	return &foundGateways.Items, nil
 }
 
-func (r *ReconcileSubmariner) deletePreExistingEngineDeployment(namespace string, reqLogger logr.Logger) error {
-	foundDeployment := &appsv1.Deployment{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: "submariner", Namespace: namespace}, foundDeployment)
-	if err != nil && errors.IsNotFound(err) {
-		return nil
-	}
-
-	if err != nil {
-		return err
-	}
-
-	reqLogger.Info("Deleting existing engine Deployment")
-	return r.client.Delete(context.TODO(), foundDeployment)
-}
-
 func (r *ReconcileSubmariner) reconcileEngineDaemonSet(instance *submopv1a1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet, error) {
-	daemonSet, err := helpers.ReconcileDaemonSet(instance, newEngineDaemonSet(instance), reqLogger, r.client, r.scheme)
-	if err == nil {
-		err = r.deletePreExistingEngineDeployment(instance.Namespace, reqLogger)
-	}
-
-	return daemonSet, err
+	return helpers.ReconcileDaemonSet(instance, newEngineDaemonSet(instance), reqLogger, r.client, r.scheme)
 }
 
 func (r *ReconcileSubmariner) reconcileRouteagentDaemonSet(instance *submopv1a1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet,

--- a/pkg/controller/submariner/submariner_controller_test.go
+++ b/pkg/controller/submariner/submariner_controller_test.go
@@ -196,26 +196,6 @@ func testReconciliation() {
 		})
 	})
 
-	When("a previous submariner engine Deployment exists", func() {
-		BeforeEach(func() {
-			initClientObjs = append(initClientObjs, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "submariner",
-					Namespace: submarinerNamespace,
-				},
-			})
-		})
-
-		It("should delete it", func() {
-			Expect(reconcileErr).To(Succeed())
-			Expect(reconcileResult.Requeue).To(BeFalse())
-			verifyEngineDaemonSet(withNetworkDiscovery(submariner, clusterNetwork), fakeClient)
-
-			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: "submariner", Namespace: submarinerNamespace}, &appsv1.Deployment{})
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "IsNotFound error")
-		})
-	})
-
 	When("the submariner route-agent DaemonSet doesn't exist", func() {
 		It("should create it", func() {
 			Expect(reconcileErr).To(Succeed())


### PR DESCRIPTION
During the initial releases of Submariner, submariner-gateway used to
be a Deployment. However, it was changed to a DaemonSet long ago and
many releases happened after that change. So we can remove the check
for deployment.

Related to: https://github.com/submariner-io/submariner-operator/issues/516

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>