### PR TITLE
Migrate CRDs to apiextensions v1

### DIFF
--- a/deploy/crds/submariner.io_servicediscoveries_crd.yaml
+++ b/deploy/crds/submariner.io_servicediscoveries_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: servicediscoveries.submariner.io

--- a/deploy/crds/submariner.io_submariners_crd.yaml
+++ b/deploy/crds/submariner.io_submariners_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: submariners.submariner.io

--- a/deploy/lighthouse/crds/multiclusterservices_crd.yaml
+++ b/deploy/lighthouse/crds/multiclusterservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: multiclusterservices.lighthouse.submariner.io

--- a/deploy/lighthouse/crds/serviceexport_crd.yaml
+++ b/deploy/lighthouse/crds/serviceexport_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceexports.lighthouse.submariner.io

--- a/deploy/lighthouse/crds/serviceimport_crd.yaml
+++ b/deploy/lighthouse/crds/serviceimport_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceimports.lighthouse.submariner.io


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 version of CustomResourceDefinition
is deprecated in Kubernetes v1.16 and will no longer be served in
v1.19. Use apiextensions.k8s.io/v1 instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>