### PR TITLE
Enable ServiceDiscovery by default on subctl

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -49,8 +49,8 @@ func init() {
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
 		"Import IPsec PSK from existing submariner broker file, like broker-info.subm")
 
-	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", false,
-		"Enable Multi Cluster Service Discovery")
+	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", true,
+		"Enable Multi-Cluster Service Discovery")
 
 	addKubeconfigFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)


### PR DESCRIPTION
This patch enables service discovery on deployments by default,
now that we implement the upstream API and we have a stable implementation
it's a good time to make this feature enabled by default.