### PR TITLE
Install jq in the dapper Dockerfile

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,11 +4,15 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
     DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD GITHUB_SHA MAKEFLAGS CLUSTERS_ARGS DEPLOY_ARGS E2E_ARGS RELEASE_ARGS" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/submariner-operator DAPPER_DOCKER_SOCKET=true \
-    OPERATOR_SDK_VERSION=0.12.0 GOROOT=/usr/lib/golang
+    GOROOT=/usr/lib/golang \
+    JQ_VERSION=1.6 \
+    OPERATOR_SDK_VERSION=0.12.0
 ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output PATH=${DAPPER_SOURCE}/bin/:${PATH}
 
 RUN curl -Lo /usr/bin/operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu" && \
-    chmod a+x /usr/bin/operator-sdk
+    chmod a+x /usr/bin/operator-sdk && \
+    curl -Lo /usr/bin/jq "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" && \
+    chmod a+x /usr/bin/jq
 
 WORKDIR ${DAPPER_SOURCE}
 


### PR DESCRIPTION
This project is the only one using the `jq` tool, hence it makes sense
to install directly here instead of in the Shipyard base image.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>