### PR TITLE
Install the CRDs in the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build: operator-image $(BINARIES)
 
 build-cross: $(CROSS_TARBALLS)
 
-operator-image: vendor/modules.txt
+operator-image: vendor/modules.txt pkg/subctl/operator/common/embeddedyamls/yamls.go
 # We check BUILD_ARGS since that's what the compile script uses
 ifeq (--debug,$(findstring --debug,$(BUILD_ARGS)))
 	operator-sdk build quay.io/submariner/submariner-operator:$(DEV_VERSION)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -29,6 +29,9 @@ import (
 
 	"github.com/submariner-io/submariner-operator/pkg/apis"
 	"github.com/submariner-io/submariner-operator/pkg/controller"
+	"github.com/submariner-io/submariner-operator/pkg/engine"
+	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -116,6 +119,23 @@ func main() {
 	}
 
 	log.Info("Registering Components.")
+
+	// Set up the CRDs we need
+	crdUpdater, err := crdutils.NewFromRestConfig(cfg)
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	log.Info("Creating the engine CRDs")
+	if err := engine.Ensure(crdUpdater); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	log.Info("Creating the Lighthouse CRDs")
+	if _, err := lighthouse.Ensure(crdUpdater, lighthouse.DataCluster); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -16,6 +16,16 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
   - apiGroups:  # pods and services are looked up to figure out network settings
       - ""
     resources:

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -26,6 +26,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/engine"
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
 	"github.com/submariner-io/submariner-operator/pkg/utils"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,12 +35,16 @@ import (
 )
 
 func Ensure(config *rest.Config) error {
-	err := engine.Ensure(config)
+	crdCreator, err := crdutils.NewFromRestConfig(config)
+	if err != nil {
+		return fmt.Errorf("error accessing the target cluster: %s", err)
+	}
+	err = engine.Ensure(crdCreator)
 	if err != nil {
 		return fmt.Errorf("error setting up the engine requirements: %s", err)
 	}
 
-	_, err = lighthouse.Ensure(config, lighthouse.BrokerCluster)
+	_, err = lighthouse.Ensure(crdCreator, lighthouse.BrokerCluster)
 	if err != nil {
 		return fmt.Errorf("error setting up the lighthouse requirements: %s", err)
 	}

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -47,9 +47,7 @@ import (
 	submopv1a1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/controller/helpers"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
-	"github.com/submariner-io/submariner-operator/pkg/engine"
 	"github.com/submariner-io/submariner-operator/pkg/images"
-	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 )
 
@@ -58,15 +56,6 @@ var log = logf.Log.WithName("controller_submariner")
 // Add creates a new Submariner Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	// Set up the CRDs we need
-	crdUpdater, err := crdutils.NewFromRestConfig(mgr.GetConfig())
-	if err != nil {
-		return err
-	}
-	if err := engine.Ensure(crdUpdater); err != nil {
-		return err
-	}
-
 	// These are required so that we can retrieve Gateway objects using the dynamic client
 	if err := submv1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -58,6 +58,15 @@ var log = logf.Log.WithName("controller_submariner")
 // Add creates a new Submariner Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	// Set up the CRDs we need
+	crdUpdater, err := crdutils.NewFromRestConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+	if err := engine.Ensure(crdUpdater); err != nil {
+		return err
+	}
+
 	// These are required so that we can retrieve Gateway objects using the dynamic client
 	if err := submv1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
@@ -162,11 +171,6 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
-	}
-
-	// Since we have a Submariner instance, assume we’re going to need the CRDs
-	if err := r.reconcileCRDs(); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -327,10 +331,6 @@ func (r *ReconcileSubmariner) retrieveDaemonSetContainerStatuses(daemonSet *apps
 		containerStatuses = append(containerStatuses, pods.Items[i].Status.ContainerStatuses...)
 	}
 	return &containerStatuses, nil
-}
-
-func (r *ReconcileSubmariner) reconcileCRDs() error {
-	return engine.Ensure(crdutils.NewFromControllerClient(r.client))
 }
 
 func (r *ReconcileSubmariner) retrieveGateways(owner metav1.Object, namespace string) (*[]submv1.Gateway, error) {

--- a/pkg/controller/submariner/submariner_controller_test.go
+++ b/pkg/controller/submariner/submariner_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/versions"
 	appsv1 "k8s.io/api/apps/v1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -65,6 +66,8 @@ func (c *failingClient) Update(ctx context.Context, obj runtime.Object, opts ...
 
 var _ = BeforeSuite(func() {
 	err := submariner_v1.AddToScheme(scheme.Scheme)
+	Expect(err).To(Succeed())
+	err = apiextensions.AddToScheme(scheme.Scheme)
 	Expect(err).To(Succeed())
 })
 

--- a/pkg/engine/crds.go
+++ b/pkg/engine/crds.go
@@ -23,24 +23,24 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/submariner-io/submariner-operator/pkg/utils"
 	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 // Ensure ensures that the required resources are deployed on the target system
 // The resources handled here are the engine CRDs: Cluster and Endpoint
 func Ensure(crdUpdater crdutils.CRDUpdater) error {
-	// We don’t yet need to update these CRDs, so skip updating if they already exist
-	_, err := crdUpdater.Create(newClustersCRD())
+	_, err := utils.CreateOrUpdateCRD(crdUpdater, newClustersCRD())
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("error creating the Cluster CRD: %s", err)
+		return fmt.Errorf("error provisioning the Cluster CRD: %s", err)
 	}
-	_, err = crdUpdater.Create(newEndpointsCRD())
+	_, err = utils.CreateOrUpdateCRD(crdUpdater, newEndpointsCRD())
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("error creating the Endpoint CRD: %s", err)
+		return fmt.Errorf("error provisioning the Endpoint CRD: %s", err)
 	}
-	_, err = crdUpdater.Create(newGatewaysCRD())
+	_, err = utils.CreateOrUpdateCRD(crdUpdater, newGatewaysCRD())
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("error creating the Gateway CRD: %s", err)
+		return fmt.Errorf("error provisioning the Gateway CRD: %s", err)
 	}
 	return nil
 }

--- a/pkg/engine/crds.go
+++ b/pkg/engine/crds.go
@@ -20,24 +20,21 @@ import (
 	"fmt"
 
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
+
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 // Ensure ensures that the required resources are deployed on the target system
 // The resources handled here are the engine CRDs: Cluster and Endpoint
-func Ensure(config *rest.Config) error {
-	apiext, err := clientset.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("error creating the api extensions client: %s", err)
-	}
-	_, err = apiext.ApiextensionsV1beta1().CustomResourceDefinitions().Create(newClustersCRD())
+func Ensure(crdUpdater crdutils.CRDUpdater) error {
+	// We don’t yet need to update these CRDs, so skip updating if they already exist
+	_, err := crdUpdater.Create(newClustersCRD())
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("error creating the Cluster CRD: %s", err)
 	}
-	_, err = apiext.ApiextensionsV1beta1().CustomResourceDefinitions().Create(newEndpointsCRD())
+	_, err = crdUpdater.Create(newEndpointsCRD())
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("error creating the Endpoint CRD: %s", err)
 	}

--- a/pkg/engine/crds.go
+++ b/pkg/engine/crds.go
@@ -38,6 +38,10 @@ func Ensure(crdUpdater crdutils.CRDUpdater) error {
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("error creating the Endpoint CRD: %s", err)
 	}
+	_, err = crdUpdater.Create(newGatewaysCRD())
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("error creating the Gateway CRD: %s", err)
+	}
 	return nil
 }
 
@@ -77,6 +81,35 @@ func newClustersCRD() *apiextensions.CustomResourceDefinition {
 				Kind:     "Cluster",
 			},
 			Version: "v1",
+		},
+	}
+
+	return crd
+}
+
+func newGatewaysCRD() *apiextensions.CustomResourceDefinition {
+	crd := &apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gateways.submariner.io",
+		},
+		Spec: apiextensions.CustomResourceDefinitionSpec{
+			Group: "submariner.io",
+			Scope: apiextensions.NamespaceScoped,
+			Names: apiextensions.CustomResourceDefinitionNames{
+				Plural:   "gateways",
+				Singular: "gateway",
+				ListKind: "GatewayList",
+				Kind:     "Gateway",
+			},
+			Version: "v1",
+			AdditionalPrinterColumns: []apiextensions.CustomResourceColumnDefinition{
+				{
+					Name:        "ha-status",
+					Type:        "string",
+					Description: "High availability status of the Gateway",
+					JSONPath:    ".status.haStatus",
+				},
+			},
 		},
 	}
 

--- a/pkg/lighthouse/crds.go
+++ b/pkg/lighthouse/crds.go
@@ -14,7 +14,8 @@ const (
 )
 
 // Ensure ensures that the required resources are deployed on the target system
-// The resources handled here are the lighthouse CRDs: MultiClusterService and ServiceExport
+// The resources handled here are the lighthouse CRDs: MultiClusterService,
+// ServiceImport, ServiceExport and ServiceDiscovery
 func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
 	installedMCS, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
 		embeddedyamls.Lighthouse_crds_multiclusterservices_crd_yaml)
@@ -28,7 +29,7 @@ func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
 		return installedSI, fmt.Errorf("Error creating the ServiceImport CRD: %s", err)
 	}
 
-	// The broker does not need the ServiceExport
+	// The broker does not need the ServiceExport or ServiceDiscovery
 	if isBroker {
 		return installedMCS, nil
 	}
@@ -40,5 +41,10 @@ func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
 		return installedSE, fmt.Errorf("Error creating the ServiceExport CRD: %s", err)
 	}
 
-	return installedMCS || installedSE, nil
+	installedSD, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater, embeddedyamls.Crds_submariner_io_servicediscoveries_crd_yaml)
+	if err != nil {
+		return installedSD, err
+	}
+
+	return installedMCS || installedSE || installedSD, nil
 }

--- a/pkg/lighthouse/crds.go
+++ b/pkg/lighthouse/crds.go
@@ -3,11 +3,9 @@ package lighthouse
 import (
 	"fmt"
 
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/rest"
-
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	"github.com/submariner-io/submariner-operator/pkg/utils"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 const (
@@ -17,19 +15,14 @@ const (
 
 // Ensure ensures that the required resources are deployed on the target system
 // The resources handled here are the lighthouse CRDs: MultiClusterService and ServiceExport
-func Ensure(config *rest.Config, isBroker bool) (bool, error) {
-	clientSet, err := clientset.NewForConfig(config)
-	if err != nil {
-		return false, fmt.Errorf("error creating the api extensions client: %s", err)
-	}
-
-	installedMCS, err := utils.CreateOrUpdateEmbeddedCRD(clientSet,
+func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
+	installedMCS, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
 		embeddedyamls.Lighthouse_crds_multiclusterservices_crd_yaml)
 	if err != nil {
 		return installedMCS, fmt.Errorf("Error creating the MultiClusterServices CRD: %s", err)
 	}
 
-	installedSI, err := utils.CreateOrUpdateEmbeddedCRD(clientSet,
+	installedSI, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
 		embeddedyamls.Lighthouse_crds_serviceimport_crd_yaml)
 	if err != nil {
 		return installedSI, fmt.Errorf("Error creating the ServiceImport CRD: %s", err)
@@ -40,7 +33,7 @@ func Ensure(config *rest.Config, isBroker bool) (bool, error) {
 		return installedMCS, nil
 	}
 
-	installedSE, err := utils.CreateOrUpdateEmbeddedCRD(clientSet,
+	installedSE, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
 		embeddedyamls.Lighthouse_crds_serviceexport_crd_yaml)
 
 	if err != nil {

--- a/pkg/subctl/operator/lighthouse/crds/ensure.go
+++ b/pkg/subctl/operator/lighthouse/crds/ensure.go
@@ -18,8 +18,6 @@ package crds
 
 import (
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
-	"github.com/submariner-io/submariner-operator/pkg/utils"
 	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 
 	"fmt"
@@ -33,15 +31,5 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 		return false, fmt.Errorf("error creating the api extensions client: %s", err)
 	}
 
-	serviceDiscoveryResult, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater, embeddedyamls.Crds_submariner_io_servicediscoveries_crd_yaml)
-	if err != nil {
-		return serviceDiscoveryResult, err
-	}
-
-	installed, err := lighthouse.Ensure(crdUpdater, lighthouse.DataCluster)
-	if err != nil {
-		return installed, err
-	}
-
-	return (serviceDiscoveryResult || installed), err
+	return lighthouse.Ensure(crdUpdater, lighthouse.DataCluster)
 }

--- a/pkg/subctl/operator/lighthouse/crds/ensure.go
+++ b/pkg/subctl/operator/lighthouse/crds/ensure.go
@@ -20,32 +20,28 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	"github.com/submariner-io/submariner-operator/pkg/utils"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 
 	"fmt"
 
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/rest"
 )
 
 func Ensure(restConfig *rest.Config) (bool, error) {
-	serviceDiscoveryResult, err := ensureServiceDiscoveryCRD(restConfig)
+	crdUpdater, err := crdutils.NewFromRestConfig(restConfig)
+	if err != nil {
+		return false, fmt.Errorf("error creating the api extensions client: %s", err)
+	}
+
+	serviceDiscoveryResult, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater, embeddedyamls.Crds_submariner_io_servicediscoveries_crd_yaml)
 	if err != nil {
 		return serviceDiscoveryResult, err
 	}
 
-	installed, err := lighthouse.Ensure(restConfig, lighthouse.DataCluster)
+	installed, err := lighthouse.Ensure(crdUpdater, lighthouse.DataCluster)
 	if err != nil {
 		return installed, err
 	}
 
 	return (serviceDiscoveryResult || installed), err
-}
-
-func ensureServiceDiscoveryCRD(config *rest.Config) (bool, error) {
-	clientSet, err := clientset.NewForConfig(config)
-	if err != nil {
-		return false, fmt.Errorf("error creating the api extensions client: %s", err)
-	}
-
-	return utils.CreateOrUpdateEmbeddedCRD(clientSet, embeddedyamls.Crds_submariner_io_servicediscoveries_crd_yaml)
 }

--- a/pkg/subctl/operator/lighthouse/ensure.go
+++ b/pkg/subctl/operator/lighthouse/ensure.go
@@ -20,18 +20,11 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/crds"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/scc"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/serviceaccount"
 )
 
 func Ensure(status *cli.Status, config *rest.Config, operatorNamespace string) (bool, error) {
-	if created, err := crds.Ensure(config); err != nil {
-		return created, err
-	} else if created {
-		status.QueueSuccessMessage("Created lighthouse CRDs")
-	}
-
 	if created, err := serviceaccount.Ensure(config, operatorNamespace); err != nil {
 		return created, err
 	} else if created {

--- a/pkg/subctl/operator/submarinercr/ensure.go
+++ b/pkg/subctl/operator/submarinercr/ensure.go
@@ -27,8 +27,6 @@ import (
 
 	submariner "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
-	"github.com/submariner-io/submariner-operator/pkg/engine"
-	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 const (
@@ -36,15 +34,6 @@ const (
 )
 
 func Ensure(config *rest.Config, namespace string, submarinerSpec submariner.SubmarinerSpec) error {
-	crdUpdater, err := crdutils.NewFromRestConfig(config)
-	if err != nil {
-		return fmt.Errorf("error connecting to the target cluster: %s", err)
-	}
-	err = engine.Ensure(crdUpdater)
-	if err != nil {
-		return fmt.Errorf("error setting up the engine requirements: %s", err)
-	}
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return fmt.Errorf("error creating the core kubernetes clientset: %s", err)

--- a/pkg/subctl/operator/submarinercr/ensure.go
+++ b/pkg/subctl/operator/submarinercr/ensure.go
@@ -28,6 +28,7 @@ import (
 	submariner "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/engine"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 const (
@@ -35,7 +36,11 @@ const (
 )
 
 func Ensure(config *rest.Config, namespace string, submarinerSpec submariner.SubmarinerSpec) error {
-	err := engine.Ensure(config)
+	crdUpdater, err := crdutils.NewFromRestConfig(config)
+	if err != nil {
+		return fmt.Errorf("error connecting to the target cluster: %s", err)
+	}
+	err = engine.Ensure(crdUpdater)
 	if err != nil {
 		return fmt.Errorf("error setting up the engine requirements: %s", err)
 	}

--- a/pkg/subctl/operator/submarinerop/crds/ensure.go
+++ b/pkg/subctl/operator/submarinerop/crds/ensure.go
@@ -18,17 +18,17 @@ package crds
 
 import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	"github.com/submariner-io/submariner-operator/pkg/utils"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 // Ensure functions updates or installs the operator CRDs in the cluster
 func Ensure(restConfig *rest.Config) (bool, error) {
-	clientSet, err := clientset.NewForConfig(restConfig)
+	crdUpdater, err := crdutils.NewFromRestConfig(restConfig)
 	if err != nil {
 		return false, err
 	}
@@ -41,12 +41,12 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	// Attempt to update or create the CRD definition
 	// TODO(majopela): In the future we may want to report when we have updated the existing
 	//                 CRD definition with new versions
-	submarinerResult, err := utils.CreateOrUpdateCRD(clientSet, submarinerCrd)
+	submarinerResult, err := utils.CreateOrUpdateCRD(crdUpdater, submarinerCrd)
 	if err != nil {
 		return submarinerResult, err
 	}
 
-	gatewaysResult, err := utils.CreateOrUpdateCRD(clientSet, getGatewaysCRD())
+	gatewaysResult, err := utils.CreateOrUpdateCRD(crdUpdater, getGatewaysCRD())
 	return (submarinerResult || gatewaysResult), err
 }
 

--- a/pkg/subctl/operator/submarinerop/crds/ensure.go
+++ b/pkg/subctl/operator/submarinerop/crds/ensure.go
@@ -18,7 +18,6 @@ package crds
 
 import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
@@ -41,13 +40,7 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	// Attempt to update or create the CRD definition
 	// TODO(majopela): In the future we may want to report when we have updated the existing
 	//                 CRD definition with new versions
-	submarinerResult, err := utils.CreateOrUpdateCRD(crdUpdater, submarinerCrd)
-	if err != nil {
-		return submarinerResult, err
-	}
-
-	gatewaysResult, err := utils.CreateOrUpdateCRD(crdUpdater, getGatewaysCRD())
-	return (submarinerResult || gatewaysResult), err
+	return utils.CreateOrUpdateCRD(crdUpdater, submarinerCrd)
 }
 
 func getSubmarinerCRD() (*apiextensionsv1beta1.CustomResourceDefinition, error) {
@@ -58,34 +51,4 @@ func getSubmarinerCRD() (*apiextensionsv1beta1.CustomResourceDefinition, error) 
 	}
 
 	return crd, nil
-}
-
-// TODO Move this to the operator
-func getGatewaysCRD() *apiextensionsv1beta1.CustomResourceDefinition {
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "gateways.submariner.io",
-		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group: "submariner.io",
-			Scope: apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "gateways",
-				Singular: "gateway",
-				ListKind: "GatewayList",
-				Kind:     "Gateway",
-			},
-			Version: "v1",
-			AdditionalPrinterColumns: []apiextensionsv1beta1.CustomResourceColumnDefinition{
-				{
-					Name:        "ha-status",
-					Type:        "string",
-					Description: "High availability status of the Gateway",
-					JSONPath:    ".status.haStatus",
-				},
-			},
-		},
-	}
-
-	return crd
 }

--- a/pkg/utils/crds/crdutils.go
+++ b/pkg/utils/crds/crdutils.go
@@ -1,0 +1,75 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdutils
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CRDUpdater interface {
+	Create(*v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error)
+	Update(*v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error)
+	Get(name string, options v1.GetOptions) (*v1beta1.CustomResourceDefinition, error)
+}
+
+type controllerClientCreator struct {
+	client client.Client
+}
+
+func NewFromRestConfig(config *rest.Config) (CRDUpdater, error) {
+	apiext, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the api extensions client: %s", err)
+	}
+	return NewFromClientSet(apiext), nil
+}
+
+func NewFromClientSet(cs clientset.Interface) CRDUpdater {
+	return cs.ApiextensionsV1beta1().CustomResourceDefinitions()
+}
+
+func NewFromControllerClient(controllerClient client.Client) CRDUpdater {
+	return &controllerClientCreator{
+		client: controllerClient,
+	}
+}
+
+func (c *controllerClientCreator) Create(crd *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
+	err := c.client.Create(context.TODO(), crd)
+	return crd, err
+}
+
+func (c *controllerClientCreator) Update(crd *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
+	err := c.client.Update(context.TODO(), crd)
+	return crd, err
+}
+
+func (c *controllerClientCreator) Get(name string, options v1.GetOptions) (*v1beta1.CustomResourceDefinition, error) {
+	crd := &v1beta1.CustomResourceDefinition{}
+	err := c.client.Get(context.TODO(), client.ObjectKey{Name: name}, crd)
+	if err != nil {
+		return nil, err
+	}
+	return crd, nil
+}

--- a/pkg/utils/createorupdate_test.go
+++ b/pkg/utils/createorupdate_test.go
@@ -30,6 +30,7 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 )
 
 var _ = Describe("CreateOrUpdateClusterRole", func() {
@@ -123,7 +124,7 @@ var _ = Describe("CreateOrUpdateCRD", func() {
 
 	When("When called", func() {
 		It("Should add the CRD properly", func() {
-			created, err := CreateOrUpdateCRD(client, crd)
+			created, err := CreateOrUpdateCRD(crdutils.NewFromClientSet(client), crd)
 			Expect(created).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -135,10 +136,11 @@ var _ = Describe("CreateOrUpdateCRD", func() {
 
 	When("When called twice", func() {
 		It("Should add the CRD properly, and return false on second call", func() {
-			created, err := CreateOrUpdateCRD(client, crd)
+			crdUpdater := crdutils.NewFromClientSet(client)
+			created, err := CreateOrUpdateCRD(crdUpdater, crd)
 			Expect(created).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
-			created, err = CreateOrUpdateCRD(client, crd)
+			created, err = CreateOrUpdateCRD(crdUpdater, crd)
 			Expect(created).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
Instead of relying on subctl, Helm charts or OLM to install CRDs other
than the Submariner CRD, take care of everything in the operator.

Signed-off-by: Stephen Kitt <skitt@redhat.com>