### PR TITLE
Support detecting all networks in OpenShift

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -35,9 +35,9 @@ rules:
       - watch
       - update
   - apiGroups:
-      - network.openshift.io
+      - config.openshift.io
     resources:
-      - clusternetworks
+      - networks
     verbs:
       - get
       - list


### PR DESCRIPTION
Networks in config.openshift.io/v1 is exposed for both
OpenShiftSDN and OVNKubernetes, while ClusterNetworks
seems to be only used with the operator for OpenShift SDN.

```
[majopela@bluehat subm-demo]$ subctl join --kubeconfig cluster-a/auth/kubeconfig broker-info.subm --cable-driver libreswan
* broker-info.subm says broker is at: https://api.majopela-cluster-a-09-10-20-1599722826.devcluster.openshift.com:6443
...
⠈⠑ Discovering network details     Discovered network details:
        Network plugin:  OVNKubernetes
        Service CIDRs:   [172.30.0.0/16]
        Cluster CIDRs:   [10.128.0.0/14]
...

[majopela@bluehat subm-demo]$ subctl join --kubeconfig cluster-b/auth/kubeconfig broker-info.subm --cable-driver libreswan
* broker-info.subm says broker is at: https://api.majopela-cluster-a-09-10-20-1599722826.devcluster.openshift.com:6443
...
⠈⠑ Discovering network details     Discovered network details:
        Network plugin:  OpenShiftSDN
        Service CIDRs:   [172.31.0.0/16]
        Cluster CIDRs:   [10.132.0.0/14]
```

Related-Issue: #778