### PR TITLE
Avoid double creation attempts for the SD CR

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -284,24 +284,19 @@ func (r *ReconcileSubmariner) reconcileServiceDiscovery(submariner *submopv1a1.S
 		if isEnabled {
 			sd := newServiceDiscoveryCR(submariner.Namespace)
 			result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, sd, func() error {
-				_, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, sd, func() error {
-					sd.Spec = submopv1a1.ServiceDiscoverySpec{
-						Version:                  submariner.Spec.Version,
-						Repository:               submariner.Spec.Repository,
-						BrokerK8sCA:              submariner.Spec.BrokerK8sCA,
-						BrokerK8sRemoteNamespace: submariner.Spec.BrokerK8sRemoteNamespace,
-						BrokerK8sApiServerToken:  submariner.Spec.BrokerK8sApiServerToken,
-						BrokerK8sApiServer:       submariner.Spec.BrokerK8sApiServer,
-						Debug:                    submariner.Spec.Debug,
-						ClusterID:                submariner.Spec.ClusterID,
-						Namespace:                submariner.Spec.Namespace,
-					}
-					if submariner.Spec.GlobalCIDR != "" {
-						sd.Spec.GlobalnetEnabled = true
-					}
-					return nil
-				})
-				return err
+				sd.Spec = submopv1a1.ServiceDiscoverySpec{
+					Version:                  submariner.Spec.Version,
+					Repository:               submariner.Spec.Repository,
+					BrokerK8sCA:              submariner.Spec.BrokerK8sCA,
+					BrokerK8sRemoteNamespace: submariner.Spec.BrokerK8sRemoteNamespace,
+					BrokerK8sApiServerToken:  submariner.Spec.BrokerK8sApiServerToken,
+					BrokerK8sApiServer:       submariner.Spec.BrokerK8sApiServer,
+					Debug:                    submariner.Spec.Debug,
+					ClusterID:                submariner.Spec.ClusterID,
+					Namespace:                submariner.Spec.Namespace,
+					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
+				}
+				return nil
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
When we try to create or update the Service Discovery CR, we end up
trying to create it twice, which results in

"error reconciling the Service Discovery CR: resourceVersion should
not be set on objects to be created"

in the logs.

Signed-off-by: Stephen Kitt <skitt@redhat.com>