### PR TITLE
Configure custom domains

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -367,7 +367,9 @@ func (r *ReconcileSubmariner) reconcileServiceDiscovery(submariner *submopv1a1.S
 					ClusterID:                submariner.Spec.ClusterID,
 					Namespace:                submariner.Spec.Namespace,
 					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
-					CustomDomains:            submariner.Spec.CustomDomains,
+				}
+				if len(submariner.Spec.CustomDomains) > 0 {
+					sd.Spec.CustomDomains = submariner.Spec.CustomDomains
 				}
 				return nil
 			})

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -36,6 +36,7 @@ var (
 	defaultGlobalnetClusterSize uint
 	serviceDiscovery            bool
 	GlobalCIDRConfigMap         *v1.ConfigMap
+	defaultCustomDomains        []string
 )
 
 func init() {
@@ -51,6 +52,9 @@ func init() {
 
 	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", true,
 		"Enable Multi-Cluster Service Discovery")
+
+	deployBroker.PersistentFlags().StringSliceVar(&defaultCustomDomains, "custom-domains", nil,
+		"List of domains to use for multicluster service discovery")
 
 	addKubeconfigFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
@@ -99,6 +103,10 @@ var deployBroker = &cobra.Command{
 		}
 
 		subctlData.ServiceDiscovery = serviceDiscovery
+
+		if len(defaultCustomDomains) > 0 {
+			subctlData.CustomDomains = &defaultCustomDomains
+		}
 
 		exitOnError("Error setting up service discovery information", err)
 

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -66,6 +66,7 @@ var (
 	cableDriver          string
 	clienttoken          *v1.Secret
 	globalnetClusterSize uint
+	customDomains        []string
 )
 
 func init() {
@@ -97,6 +98,8 @@ func addJoinFlags(cmd *cobra.Command) {
 		"Cluster size for GlobalCIDR allocated to this cluster (amount of global IPs)")
 	cmd.Flags().StringVar(&globalnetCIDR, "globalnet-cidr", "",
 		"GlobalCIDR to be allocated to the cluster")
+	cmd.Flags().StringSliceVar(&customDomains, "custom-domains", nil,
+		"List of domains to use for multicluster service discovery")
 }
 
 const (
@@ -419,6 +422,10 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		crClusterCIDR = netconfig.ClusterCIDR
 	}
 
+	if customDomains == nil && subctlData.CustomDomains != nil {
+		customDomains = *subctlData.CustomDomains
+	}
+
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,
 		Version:                  crImageVersion,
@@ -443,6 +450,9 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 	}
 	if netconfig.GlobalnetCIDR != "" {
 		submarinerSpec.GlobalCIDR = netconfig.GlobalnetCIDR
+	}
+	if len(customDomains) > 0 {
+		submarinerSpec.CustomDomains = customDomains
 	}
 	return submarinerSpec
 }

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -38,6 +38,7 @@ type SubctlData struct {
 	ClientToken      *v1.Secret `omitempty,json:"clientToken"`
 	IPSecPSK         *v1.Secret `omitempty,json:"ipsecPSK"`
 	ServiceDiscovery bool       `omitempty,json:"serviceDiscovery"`
+	CustomDomains    *[]string  `omitempty,json:"customDomains"`
 	// Todo (revisit): The following values are moved from the broker-info.subm file to configMap
 	// on the Broker. This needs to be revisited to support seamless upgrades.
 	// https://github.com/submariner-io/submariner-operator/issues/504


### PR DESCRIPTION
1. Adds `custom-domains` flag in `subctl`
2. Configure custom-domains parameter in submariner and
service-discovery specs.

Fixes https://github.com/submariner-io/lighthouse/issues/286

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>