### PR TITLE
Tolerate Taints in Nodes

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -509,6 +509,8 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 			Volumes: []corev1.Volume{
 				{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
 			},
+			// The gateway engine must be able to run on any flagged node, regardless of existing taints
+			Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 		},
 	}
 	if cr.Spec.CeIPSecIKEPort != 0 {
@@ -596,6 +598,8 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					Volumes: []corev1.Volume{
 						{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
 					},
+					// The route agent engine on all nodes, regardless of existing taints
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},
 			},
 		},

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -367,7 +367,6 @@ function verify_subm_engine_container() {
   kubectl exec $subm_engine_pod_name --namespace=$subm_ns -- env | tee $env_file
 
   # Verify SubM Engine pod environment variables
-  grep "HOSTNAME=$cluster-worker" $env_file
   grep "BROKER_K8S_APISERVER=$SUBMARINER_BROKER_URL" $env_file
   grep "SUBMARINER_NAMESPACE=$subm_ns" $env_file
   grep "SUBMARINER_BROKER=$subm_broker" $env_file
@@ -412,7 +411,6 @@ function verify_subm_routeagent_container() {
 
     # Verify SubM Routeagent pod environment variables
     grep "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" $env_file
-    grep "HOSTNAME=$cluster-worker" $env_file
     grep "SUBMARINER_NAMESPACE=$subm_ns" $env_file
     grep "SUBMARINER_DEBUG=$subm_debug" $env_file
     grep "SUBMARINER_SERVICECIDR=${service_CIDRs[$cluster]}" $env_file


### PR DESCRIPTION
The route-agent and submariner-gateway pods are now configured
as infrastructure pods which will ignore any existing taints.

Without this route-agent does not run on nodes reserved to
specific workloads via node taints, precluding such workloads
to talk to remote clusters.

This patch also allows reserving nodes just for the submariner
gateway with a submariner taint, and the submariner-gateway
will run in such nodes as long as the submariner.io/gateway
label is set.

Fixes-Issue: https://github.com/submariner-io/submariner/issues/828
Related-Issue: https://github.com/submariner-io/submariner-operator/issues/147

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>