### PR TITLE
Add an upgrade test

### DIFF
--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -1,0 +1,41 @@
+---
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v**'
+
+name: Upgrade tests
+jobs:
+  upgrade-e2e:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        globalnet: ['', 'globalnet']
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - run: git fetch origin +refs/tags/*:refs/tags/*
+
+      - name: Reclaim free space!
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          df -h
+          free -h
+
+      - name: Install an old cluster, upgrade it and check it
+        run: |
+          make upgrade-e2e using="${{ matrix.globalnet }}"
+
+      - name: Post Mortem
+        if: failure()
+        run: |
+          df -h
+          free -h
+          make post-mortem

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ deploy: clusters preload-images
 e2e: deploy
 	scripts/kind-e2e/e2e.sh
 
+upgrade-e2e: upgrade e2e
+
+upgrade:
+	$(SCRIPTS_DIR)/clusters.sh --cluster_settings $(DAPPER_SOURCE)/scripts/upgrade/cluster_settings
+	curl -L get.submariner.io | VERSION=0.7.0-rc2 bash
+	~/.local/bin/subctl deploy-broker --kubeconfig output/kubeconfigs/kind-config-cluster1 --kubecontext cluster1
+	~/.local/bin/subctl join --kubeconfig output/kubeconfigs/kind-config-cluster1 --kubecontext cluster1 broker-info.subm
+	~/.local/bin/subctl join --kubeconfig output/kubeconfigs/kind-config-cluster2 --kubecontext cluster2 broker-info.subm
+
 clean:
 	rm -f $(BINARIES) $(CROSS_BINARIES) $(CROSS_TARBALLS)
 

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -121,7 +121,7 @@ var joinCmd = &cobra.Command{
 		fmt.Printf("* %s says broker is at: %s\n", args[0], subctlData.BrokerURL)
 		exitOnError("Error connecting to broker cluster", err)
 		config := getClientConfig(kubeConfig, kubeContext)
-		joinSubmarinerCluster(config, subctlData)
+		joinSubmarinerCluster(config, kubeContext, subctlData)
 	},
 }
 
@@ -134,7 +134,7 @@ func checkArgumentPassed(args []string) error {
 
 var status = cli.NewStatus()
 
-func joinSubmarinerCluster(config clientcmd.ClientConfig, subctlData *datafile.SubctlData) {
+func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, subctlData *datafile.SubctlData) {
 	// Missing information
 	var qs = []*survey.Question{}
 
@@ -142,7 +142,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, subctlData *datafile.S
 		rawConfig, err := config.RawConfig()
 		// This will be fatal later, no point in continuing
 		exitOnError("Error connecting to the target cluster", err)
-		clusterID = *getClusterName(rawConfig)
+		clusterID = *getClusterNameFromContext(rawConfig, contextName)
 	}
 
 	if valid, _ := isValidClusterID(clusterID); !valid {

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -101,11 +101,11 @@ func getClients(config *rest.Config) (dynamic.Interface, kubernetes.Interface, e
 	return dynClient, clientSet, nil
 }
 
-func getClusterName(rawConfig clientcmdapi.Config) *string {
-	return getClusterNameFromContext(rawConfig, rawConfig.CurrentContext)
-}
-
 func getClusterNameFromContext(rawConfig clientcmdapi.Config, overridesContext string) *string {
+	if overridesContext == "" {
+		// No context provided, use the current context
+		overridesContext = rawConfig.CurrentContext
+	}
 	context, ok := rawConfig.Contexts[overridesContext]
 	if !ok {
 		return nil

--- a/pkg/subctl/cmd/show.go
+++ b/pkg/subctl/cmd/show.go
@@ -90,13 +90,7 @@ func getClientConfigAndClusterName(rules *clientcmd.ClientConfigLoadingRules, ov
 		return restConfig{}, err
 	}
 
-	var clusterName *string
-
-	if overrides.CurrentContext != "" {
-		clusterName = getClusterNameFromContext(raw, overrides.CurrentContext)
-	} else {
-		clusterName = getClusterName(raw)
-	}
+	clusterName := getClusterNameFromContext(raw, overrides.CurrentContext)
 
 	if clusterName == nil {
 		return restConfig{}, fmt.Errorf("Could not obtain the cluster name from kube config: %#v", raw)

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -156,17 +156,17 @@ func configureTestingFramework(args []string) {
 
 	// Read the cluster names from the given kubeconfigs
 	for _, config := range args {
-		framework.TestContext.ClusterIDs = append(framework.TestContext.ClusterIDs, clusterNameFromConfig(config))
+		framework.TestContext.ClusterIDs = append(framework.TestContext.ClusterIDs, clusterNameFromConfig(config, ""))
 	}
 
 	config.DefaultReporterConfig.Verbose = verboseConnectivityVerification
 	config.DefaultReporterConfig.SlowSpecThreshold = 60
 }
 
-func clusterNameFromConfig(kubeConfigPath string) string {
+func clusterNameFromConfig(kubeConfigPath, kubeContext string) string {
 	rawConfig, err := getClientConfig(kubeConfigPath, "").RawConfig()
 	exitOnError(fmt.Sprintf("Error obtaining the kube config for path %q", kubeConfigPath), err)
-	cluster := getClusterName(rawConfig)
+	cluster := getClusterNameFromContext(rawConfig, kubeContext)
 	if cluster == nil {
 		exitWithErrorMsg(fmt.Sprintf("Could not obtain the cluster name from kube config: %#v", rawConfig))
 	}

--- a/pkg/subctl/operator/submarinercr/ensure.go
+++ b/pkg/subctl/operator/submarinercr/ensure.go
@@ -18,6 +18,7 @@ package submarinercr
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +78,7 @@ func createSubmariner(clientSet submarinerclientset.Interface, namespace string,
 			if err != nil {
 				return fmt.Errorf("failed to delete pre-existing cfg %s : %s", submarinerCR.Name, err)
 			}
+			time.Sleep(10 * time.Second)
 			_, err = clientSet.SubmarinerV1alpha1().Submariners(namespace).Create(submarinerCR)
 			if err != nil {
 				return fmt.Errorf("failed to create cfg  %s : %s", submarinerCR.Name, err)

--- a/scripts/upgrade/cluster_settings
+++ b/scripts/upgrade/cluster_settings
@@ -1,0 +1,10 @@
+. "${SCRIPTS_DIR}"/lib/source_only
+
+# We need a minimal setup to verify the deployment works
+clusters=('cluster1' 'cluster2')
+cluster_nodes['cluster1']="control-plane worker"
+cluster_nodes['cluster2']="control-plane worker"
+
+cluster_cni=( ['cluster1']="weave" ['cluster2']="weave" )
+
+cluster_subm=( ['cluster1']="true" ['cluster2']="true" )


### PR DESCRIPTION
This adds an upgrade test, based on the latest release of subctl (and
the components it deploys). The test deploys a simple pair of clusters
with one worker node each, then uses the released version of subctl to
deploy the broker and join the clusters. Once that’s done, it runs the
current e2e, which upgrades the cluster using the newly-built subctl.

Signed-off-by: Stephen Kitt <skitt@redhat.com>