### PR TITLE
Fix subctl verify/benchmark with tainted nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/lighthouse v0.6.2-0.20200901111022-07c1673eef8e
-	github.com/submariner-io/shipyard v0.6.2-0.20200915094412-c6f2491c1840
+	github.com/submariner-io/shipyard v0.6.2-0.20200925155850-32eb28fd56f3
 	github.com/submariner-io/submariner v0.6.1
 	k8s.io/api v0.18.0-rc.1
 	k8s.io/apiextensions-apiserver v0.17.8

--- a/go.sum
+++ b/go.sum
@@ -941,8 +941,8 @@ github.com/submariner-io/shipyard v0.6.0 h1:i1I2ZDCkU8aeL1KGmidac9L00UFhyaK2J0Jr
 github.com/submariner-io/shipyard v0.6.0/go.mod h1:9H9ctEv+K61bMy5teo/fG2azZswmXsPVfFTVdk8ZGk0=
 github.com/submariner-io/shipyard v0.6.1 h1:jkZc9WJpK+ZKjHmuDOM7BT0rkp41pOAsEGJtPAqFs14=
 github.com/submariner-io/shipyard v0.6.1/go.mod h1:9H9ctEv+K61bMy5teo/fG2azZswmXsPVfFTVdk8ZGk0=
-github.com/submariner-io/shipyard v0.6.2-0.20200915094412-c6f2491c1840 h1:xagcqq/9meDX5X3+gqqBq5MjnuH6YpQ34jV3EQsHk/8=
-github.com/submariner-io/shipyard v0.6.2-0.20200915094412-c6f2491c1840/go.mod h1:m2Gs15WS6bCDMY2QUjjeC3p4Q95H+pG2UW4k2S9rhQc=
+github.com/submariner-io/shipyard v0.6.2-0.20200925155850-32eb28fd56f3 h1:THjqFEYQHoROB2qE5Yx3f/JAjtdtJOdzby2j2bW8zDc=
+github.com/submariner-io/shipyard v0.6.2-0.20200925155850-32eb28fd56f3/go.mod h1:m2Gs15WS6bCDMY2QUjjeC3p4Q95H+pG2UW4k2S9rhQc=
 github.com/submariner-io/submariner v0.6.1 h1:xXThs7DEVXZofK9QKYadUBblafK87kb5hPJXhq5VQY4=
 github.com/submariner-io/submariner v0.6.1/go.mod h1:DQO40kP1/jRKk/Xh3yY+9neiFFChpansI8U7JbAXN2U=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=


### PR DESCRIPTION
Tainted nodes are used for reserving nodes specifically for
workloads. In this case we are supporing the case where
the Gateway node is tainted just for submariner,
and we need the e2e framework pods to run in those nodes.

Related-Issue: #147

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>