### PR TITLE
Revert "Handle Lighthouse CRDs in the operator"

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -29,9 +29,6 @@ import (
 
 	"github.com/submariner-io/submariner-operator/pkg/apis"
 	"github.com/submariner-io/submariner-operator/pkg/controller"
-	"github.com/submariner-io/submariner-operator/pkg/engine"
-	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
-	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 	"github.com/submariner-io/submariner-operator/pkg/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -121,23 +118,6 @@ func main() {
 	}
 
 	log.Info("Registering Components.")
-
-	// Set up the CRDs we need
-	crdUpdater, err := crdutils.NewFromRestConfig(cfg)
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-	log.Info("Creating the engine CRDs")
-	if err := engine.Ensure(crdUpdater); err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-	log.Info("Creating the Lighthouse CRDs")
-	if _, err := lighthouse.Ensure(crdUpdater, lighthouse.DataCluster); err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {

--- a/pkg/controller/servicediscovery/servicediscovery_controller.go
+++ b/pkg/controller/servicediscovery/servicediscovery_controller.go
@@ -15,6 +15,8 @@ import (
 	submarinerv1alpha1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/controller/helpers"
 	"github.com/submariner-io/submariner-operator/pkg/images"
+	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -71,6 +73,15 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Set up the CRDs we need
+	crdUpdater, err := crdutils.NewFromRestConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+	if _, err := lighthouse.Ensure(crdUpdater, lighthouse.DataCluster); err != nil {
+		return err
+	}
+
 	// Create a new controller
 	c, err := controller.New("servicediscovery-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {

--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -47,7 +47,9 @@ import (
 	submopv1a1 "github.com/submariner-io/submariner-operator/pkg/apis/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/controller/helpers"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
+	"github.com/submariner-io/submariner-operator/pkg/engine"
 	"github.com/submariner-io/submariner-operator/pkg/images"
+	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 )
 
@@ -56,6 +58,15 @@ var log = logf.Log.WithName("controller_submariner")
 // Add creates a new Submariner Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	// Set up the CRDs we need
+	crdUpdater, err := crdutils.NewFromRestConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+	if err := engine.Ensure(crdUpdater); err != nil {
+		return err
+	}
+
 	// These are required so that we can retrieve Gateway objects using the dynamic client
 	if err := submv1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/pkg/subctl/operator/lighthouse/ensure.go
+++ b/pkg/subctl/operator/lighthouse/ensure.go
@@ -20,11 +20,18 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/crds"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/scc"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/serviceaccount"
 )
 
 func Ensure(status *cli.Status, config *rest.Config, operatorNamespace string) (bool, error) {
+	if created, err := crds.Ensure(config); err != nil {
+		return created, err
+	} else if created {
+		status.QueueSuccessMessage("Created lighthouse CRDs")
+	}
+
 	if created, err := serviceaccount.Ensure(config, operatorNamespace); err != nil {
 		return created, err
 	} else if created {


### PR DESCRIPTION
This reverts commit f47dc5105e7acf97bd4a327a775471005c61c111.

Attempting to create the ServiceDiscovery CRD from the operator fails:
the operator starts, creates the CRD, then the manager starts, and
doesn't find the CRD; the operator then stops, is restarted, and
finally finds the CRD. It seems better to require the CRD to be
available before the operator starts.

Fixes: #733
Signed-off-by: Stephen Kitt <skitt@redhat.com>