### PR TITLE
Tolerate Submariner taints in Globalnet Pods

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -669,6 +669,8 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					Volumes: []corev1.Volume{
 						{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
 					},
+					// The Globalnet Pod must be able to run on any flagged node, regardless of existing taints
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},
 			},
 		},


### PR DESCRIPTION
Recently a change was made [*] which allows reserving nodes for
submariner gateway with a taint such that Submariner pods can be
scheduled on that nodes. However, the corresponding toleration
was missed for Globalnet pod. This PR fixes it.

[*] https://github.com/submariner-io/submariner-operator/pull/710

Fixes-Issue: https://github.com/submariner-io/submariner/issues/866
Related-Issue: https://github.com/submariner-io/submariner-operator/issues/147

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>