### PR TITLE
Ensure the Operator controls the DaemonSets

### DIFF
--- a/pkg/controller/helpers/helpers.go
+++ b/pkg/controller/helpers/helpers.go
@@ -37,7 +37,8 @@ func ReconcileDaemonSet(owner metav1.Object, daemonSet *appsv1.DaemonSet, reqLog
 			for k, v := range daemonSet.Labels {
 				toUpdate.Labels[k] = v
 			}
-			return nil
+			// Set the owner and controller
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme)
 		})
 
 		if err != nil {


### PR DESCRIPTION
If we don't set the controller in the reconciliation loop, we end up
with un-owned resources which aren't deleted when the corresponding
Submariner object is deleted.

Fixes: #749
Signed-off-by: Stephen Kitt <skitt@redhat.com>