### PR TITLE
Ensure that helpers set ownership correctly

### DIFF
--- a/pkg/controller/helpers/helpers.go
+++ b/pkg/controller/helpers/helpers.go
@@ -82,7 +82,8 @@ func ReconcileDeployment(owner metav1.Object, deployment *appsv1.Deployment, req
 			for k, v := range deployment.Labels {
 				toUpdate.Labels[k] = v
 			}
-			return nil
+			// Set the owner and controller
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme)
 		})
 
 		if err != nil {
@@ -127,7 +128,8 @@ func ReconcileConfigMap(owner metav1.Object, configMap *corev1.ConfigMap, reqLog
 			for k, v := range configMap.Labels {
 				toUpdate.Labels[k] = v
 			}
-			return nil
+			// Set the owner and controller
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme)
 		})
 
 		if err != nil {
@@ -172,7 +174,8 @@ func ReconcileService(owner metav1.Object, service *corev1.Service, reqLogger lo
 			for k, v := range service.Labels {
 				toUpdate.Labels[k] = v
 			}
-			return nil
+			// Set the owner and controller
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme)
 		})
 
 		if err != nil {


### PR DESCRIPTION
Helpers for ConfigMap, Deployment and Service need to set the
ownership when handling conflicts. This ensures that the updated
objects are correctly owned and garbage-collected when the owning
object is deleted.

The DaemonSet helper is handled in #752.

Fixes: #753
Signed-off-by: Stephen Kitt <skitt@redhat.com>