### PR TITLE
Avoid crashing on missing cluster names

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -142,7 +142,10 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 		rawConfig, err := config.RawConfig()
 		// This will be fatal later, no point in continuing
 		exitOnError("Error connecting to the target cluster", err)
-		clusterID = *getClusterNameFromContext(rawConfig, contextName)
+		clusterName := getClusterNameFromContext(rawConfig, contextName)
+		if clusterName != nil {
+			clusterID = *clusterName
+		}
 	}
 
 	if valid, _ := isValidClusterID(clusterID); !valid {


### PR DESCRIPTION
kubeconfigs don't always give cluster names, so we mustn't assume that
they do. If they don't, fall back to asking the user as before.

Fixes: #770
Signed-off-by: Stephen Kitt <skitt@redhat.com>