### PR TITLE
Add broker roles to access multicluster.x-k8s.io

### DIFF
--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -73,6 +73,11 @@ func NewBrokerAdminRole() *rbacv1.Role {
 			},
 			{
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
+				APIGroups: []string{"multicluster.x-k8s.io"},
+				Resources: []string{"*"},
+			},
+			{
+				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"discovery.k8s.io"},
 				Resources: []string{"endpointslices"},
 			},
@@ -95,6 +100,11 @@ func NewBrokerClusterRole() *rbacv1.Role {
 			{
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"lighthouse.submariner.io"},
+				Resources: []string{"*"},
+			},
+			{
+				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
+				APIGroups: []string{"multicluster.x-k8s.io"},
 				Resources: []string{"*"},
 			},
 			{


### PR DESCRIPTION
The Lighthouse agents needs to access ServiceImports on the broker.
Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>