### PR TITLE
Exclude openshift-monitoring namespace in Globalnet

### DIFF
--- a/pkg/controller/submariner/submariner_controller.go
+++ b/pkg/controller/submariner/submariner_controller.go
@@ -659,7 +659,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
-								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner-operator,kube-system,operators"},
+								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner-operator,kube-system,operators,openshift-monitoring"},
 							},
 						},
 					},


### PR DESCRIPTION
In an OCP Cluster, openshift-monitoring namespace has couple of
services and these are controlled by their respective operators.
When Globalnet is deployed on OCP, it was seen that globalip
annotation added to such services are periodically getting
deleted by the operators, so Globalnet tries to re-add the
annotation and this goes on forever. This will cause Globalnet
to consume CPU unnecessarily and could affect user-experience
with Submariner Globalnet. We have plans to enhance Globalnet
to improve its scalability, but until then we can exclude
annotating services in openshift-monitoring namespace.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>