### PR TITLE
Add subctl cross-compiling for arm32 (rpi raspbian)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEV_VERSION := $(shell . ${SCRIPTS_DIR}/lib/version; echo $$DEV_VERSION)
 
 export VERSION DEV_VERSION
 
-CROSS_TARGETS := linux-amd64 linux-arm64 windows-amd64.exe darwin-amd64
+CROSS_TARGETS := linux-amd64 linux-arm64 linux-arm windows-amd64.exe darwin-amd64
 BINARIES := bin/subctl
 CROSS_BINARIES := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,bin/subctl-$(VERSION)-%,$(cross)))
 CROSS_TARBALLS := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,dist/subctl-$(VERSION)-%.tar.xz,$(cross)))


### PR DESCRIPTION
```bash
pi@rpi4:~ $ ./subctl-v0.7.0-17-g4719f69-dev-linux-arm deploy-broker --kubeconfig ./k3s.yaml
 ✓ Deploying broker
 ✓ Creating broker-info.subm file
 ✓ A new IPsec PSK will be generated for broker-info.subm
```

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>