### PR TITLE
Add periodic E2E tests to find flaky failures

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_failure_automated.md
+++ b/.github/ISSUE_TEMPLATE/flaky_failure_automated.md
@@ -1,0 +1,7 @@
+---
+title: Flaky Failure: make e2e using="{{ env.FLAKY_CABLE_DRIVER }},{{ env.FLAKY_GLOBALNET }},{{ env.FLAKY_LIGHTHOUSE }}" {{ date | date('YYYY-MM-DD HH:mm') }}
+---
+
+The periodic end-to-end tests meant to find flaky failures failed, which might mean there was a flaky failure.
+
+Please check the {{ workflow }} workflow, {{ action }} job in the {{ repo }} repository.

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -3,7 +3,8 @@ name: Flake Finder
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0,1,2 * * *"
+    - cron: "0 0/2 * * 6"
 
 jobs:
   e2e:

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -37,3 +37,18 @@ jobs:
           df -h
           free -h
           make post-mortem
+
+      - name: Raise an issue to report flaky test failure
+        id: create-issue
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLAKY_CABLE_DRIVER: ${{ matrix.cable_driver }}
+          FLAKY_GLOBALNET: ${{ matrix.globalnet }}
+          FLAKY_LIGHTHOUSE: ${{ matrix.lighthouse }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/broken-link.md
+
+      - name: Provide issue URL
+        run: 'echo Created issue to record flaky failure: ${{ steps.create-issue.outputs.url }}'

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -1,0 +1,39 @@
+---
+name: Flake Finder
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  e2e:
+    name: E2E
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cable_driver: ['libreswan', 'strongswan', 'wireguard']
+        globalnet: ['', 'globalnet']
+        lighthouse: ['', 'lighthouse']
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Reclaim free space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          df -h
+          free -h
+
+      - name: Run E2E deployment and tests
+        run: |
+          make e2e using="${{ matrix.cable_driver }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }}"
+
+      - name: Post mortem
+        if: failure()
+        run: |
+          df -h
+          free -h
+          make post-mortem


### PR DESCRIPTION
Because this runs against code that has already passed CI to be merged
to the main branch, any failures are likely to be sporadic flakes.

The frequency of this job should be turned up or down depending on how
actively we're hunting for flaky failures

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>