### PR TITLE
build: migrate the CRDs to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ PKG_MAN_OPTS ?= $(PKG_FROM_VERSION) $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/submariner/submariner-operator:$(VERSION)
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+# Produce v1 CRDs, requiring Kubernetes 1.16 or later
+CRD_OPTIONS ?= "crd:crdVersions=v1,trivialVersions=false"
 # Semantic versioning regex
 PATTERN := ^([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)$
 
@@ -122,18 +122,18 @@ pkg/subctl/operator/common/embeddedyamls/yamls.go: pkg/subctl/operator/common/em
 
 # Operator CRDs
 deploy/crds/submariner.io_servicediscoveries.yaml: ./apis/submariner/v1alpha1/servicediscovery_types.go vendor/modules.txt
-	controller-gen crd paths="./..." output:crd:artifacts:config=deploy/crds
+	controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=deploy/crds
 
 deploy/crds/submariner.io_submariners.yaml: ./apis/submariner/v1alpha1/submariner_types.go vendor/modules.txt
-	controller-gen crd paths="./..." output:crd:artifacts:config=deploy/crds
+	controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=deploy/crds
 
 # Lighthouse CRDs
 deploy/lighthouse/crds/lighthouse.submariner.io_multiclusterservices.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceexports.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceimports.yaml: vendor/modules.txt
-	cd vendor/github.com/submariner-io/lighthouse && controller-gen crd paths="./..." output:crd:artifacts:config=../../../../deploy/lighthouse/crds
+	cd vendor/github.com/submariner-io/lighthouse && controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../../../../deploy/lighthouse/crds
 
 # Submariner CRDs
 deploy/submariner/crds/submariner.io_clusters.yaml deploy/submariner/crds/submariner.io_endpoints.yaml deploy/submariner/crds/submariner.io_gateways.yaml: vendor/modules.txt
-	cd vendor/github.com/submariner-io/submariner && controller-gen crd paths="./..." output:crd:artifacts:config=../../../../deploy/submariner/crds
+	cd vendor/github.com/submariner-io/submariner && controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../../../../deploy/submariner/crds
 
 # Generate the clientset for the Submariner APIs
 # It needs to be run when the Submariner APIs change

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,70 +15,69 @@ spec:
     plural: servicediscoveries
     singular: servicediscovery
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ServiceDiscovery is the Schema for the servicediscoveries API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceDiscoverySpec defines the desired state of ServiceDiscovery
-          properties:
-            brokerK8sApiServer:
-              type: string
-            brokerK8sApiServerToken:
-              type: string
-            brokerK8sCA:
-              type: string
-            brokerK8sRemoteNamespace:
-              type: string
-            clusterID:
-              type: string
-            customDomains:
-              items:
-                type: string
-              type: array
-              x-kubernetes-list-type: set
-            debug:
-              type: boolean
-            globalnetEnabled:
-              type: boolean
-            namespace:
-              type: string
-            repository:
-              type: string
-            version:
-              type: string
-          required:
-          - brokerK8sApiServer
-          - brokerK8sApiServerToken
-          - brokerK8sCA
-          - brokerK8sRemoteNamespace
-          - clusterID
-          - debug
-          - namespace
-          type: object
-        status:
-          description: ServiceDiscoveryStatus defines the observed state of ServiceDiscovery
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceDiscovery is the Schema for the servicediscoveries API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceDiscoverySpec defines the desired state of ServiceDiscovery
+            properties:
+              brokerK8sApiServer:
+                type: string
+              brokerK8sApiServerToken:
+                type: string
+              brokerK8sCA:
+                type: string
+              brokerK8sRemoteNamespace:
+                type: string
+              clusterID:
+                type: string
+              customDomains:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              debug:
+                type: boolean
+              globalnetEnabled:
+                type: boolean
+              namespace:
+                type: string
+              repository:
+                type: string
+              version:
+                type: string
+            required:
+            - brokerK8sApiServer
+            - brokerK8sApiServerToken
+            - brokerK8sCA
+            - brokerK8sRemoteNamespace
+            - clusterID
+            - debug
+            - namespace
+            type: object
+          status:
+            description: ServiceDiscoveryStatus defines the observed state of ServiceDiscovery
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,707 +15,712 @@ spec:
     plural: submariners
     singular: submariner
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Submariner is the Schema for the submariners API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SubmarinerSpec defines the desired state of Submariner
-          properties:
-            broker:
-              type: string
-            brokerK8sApiServer:
-              type: string
-            brokerK8sApiServerToken:
-              type: string
-            brokerK8sCA:
-              type: string
-            brokerK8sRemoteNamespace:
-              type: string
-            cableDriver:
-              type: string
-            ceIPSecDebug:
-              type: boolean
-            ceIPSecIKEPort:
-              type: integer
-            ceIPSecNATTPort:
-              type: integer
-            ceIPSecPSK:
-              type: string
-            clusterCIDR:
-              type: string
-            clusterID:
-              type: string
-            colorCodes:
-              type: string
-            customDomains:
-              items:
-                type: string
-              type: array
-              x-kubernetes-list-type: set
-            debug:
-              type: boolean
-            globalCIDR:
-              type: string
-            namespace:
-              type: string
-            natEnabled:
-              type: boolean
-            repository:
-              type: string
-            serviceCIDR:
-              type: string
-            serviceDiscoveryEnabled:
-              type: boolean
-            version:
-              type: string
-          required:
-          - broker
-          - brokerK8sApiServer
-          - brokerK8sApiServerToken
-          - brokerK8sCA
-          - brokerK8sRemoteNamespace
-          - ceIPSecDebug
-          - ceIPSecPSK
-          - clusterCIDR
-          - clusterID
-          - debug
-          - namespace
-          - natEnabled
-          - serviceCIDR
-          type: object
-        status:
-          description: SubmarinerStatus defines the observed state of Submariner
-          properties:
-            clusterCIDR:
-              type: string
-            clusterID:
-              type: string
-            colorCodes:
-              type: string
-            engineDaemonSetStatus:
-              properties:
-                lastResourceVersion:
-                  type: string
-                mismatchedContainerImages:
-                  type: boolean
-                nonReadyContainerStates:
-                  items:
-                    description: ContainerState holds a possible state of container.
-                      Only one of its members may be specified. If none of them is
-                      specified, the default one is ContainerStateWaiting.
-                    properties:
-                      running:
-                        description: Details about a running container
-                        properties:
-                          startedAt:
-                            description: Time at which the container was last (re-)started
-                            format: date-time
-                            type: string
-                        type: object
-                      terminated:
-                        description: Details about a terminated container
-                        properties:
-                          containerID:
-                            description: Container's ID in the format 'docker://<container_id>'
-                            type: string
-                          exitCode:
-                            description: Exit status from the last termination of
-                              the container
-                            format: int32
-                            type: integer
-                          finishedAt:
-                            description: Time at which the container last terminated
-                            format: date-time
-                            type: string
-                          message:
-                            description: Message regarding the last termination of
-                              the container
-                            type: string
-                          reason:
-                            description: (brief) reason from the last termination
-                              of the container
-                            type: string
-                          signal:
-                            description: Signal from the last termination of the container
-                            format: int32
-                            type: integer
-                          startedAt:
-                            description: Time at which previous execution of the container
-                              started
-                            format: date-time
-                            type: string
-                        required:
-                        - exitCode
-                        type: object
-                      waiting:
-                        description: Details about a waiting container
-                        properties:
-                          message:
-                            description: Message regarding why the container is not
-                              yet running.
-                            type: string
-                          reason:
-                            description: (brief) reason the container is not yet running.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                status:
-                  description: DaemonSetStatus represents the current status of a
-                    daemon set.
-                  properties:
-                    collisionCount:
-                      description: Count of hash collisions for the DaemonSet. The
-                        DaemonSet controller uses this field as a collision avoidance
-                        mechanism when it needs to create the name for the newest
-                        ControllerRevision.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Represents the latest available observations of
-                        a DaemonSet's current state.
-                      items:
-                        description: DaemonSetCondition describes the state of a DaemonSet
-                          at a certain point.
-                        properties:
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: A human readable message indicating details
-                              about the transition.
-                            type: string
-                          reason:
-                            description: The reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            type: string
-                          type:
-                            description: Type of DaemonSet condition.
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    currentNumberScheduled:
-                      description: 'The number of nodes that are running at least
-                        1 daemon pod and are supposed to run the daemon pod. More
-                        info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    desiredNumberScheduled:
-                      description: 'The total number of nodes that should be running
-                        the daemon pod (including nodes correctly running the daemon
-                        pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberAvailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and available (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    numberMisscheduled:
-                      description: 'The number of nodes that are running the daemon
-                        pod, but are not supposed to run the daemon pod. More info:
-                        https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberReady:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and ready.
-                      format: int32
-                      type: integer
-                    numberUnavailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have none of the daemon pod running and available
-                        (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    observedGeneration:
-                      description: The most recent generation observed by the daemon
-                        set controller.
-                      format: int64
-                      type: integer
-                    updatedNumberScheduled:
-                      description: The total number of nodes that are running updated
-                        daemon pod
-                      format: int32
-                      type: integer
-                  required:
-                  - currentNumberScheduled
-                  - desiredNumberScheduled
-                  - numberMisscheduled
-                  - numberReady
-                  type: object
-              required:
-              - mismatchedContainerImages
-              type: object
-            gateways:
-              items:
-                properties:
-                  connections:
-                    items:
-                      properties:
-                        endpoint:
-                          properties:
-                            backend:
-                              type: string
-                            backend_config:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            cable_name:
-                              type: string
-                            cluster_id:
-                              type: string
-                            hostname:
-                              type: string
-                            nat_enabled:
-                              type: boolean
-                            private_ip:
-                              type: string
-                            public_ip:
-                              type: string
-                            subnets:
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - backend
-                          - cable_name
-                          - cluster_id
-                          - hostname
-                          - nat_enabled
-                          - private_ip
-                          - public_ip
-                          - subnets
-                          type: object
-                        status:
-                          type: string
-                        statusMessage:
-                          type: string
-                      required:
-                      - endpoint
-                      - status
-                      - statusMessage
-                      type: object
-                    type: array
-                  haStatus:
-                    type: string
-                  localEndpoint:
-                    properties:
-                      backend:
-                        type: string
-                      backend_config:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      cable_name:
-                        type: string
-                      cluster_id:
-                        type: string
-                      hostname:
-                        type: string
-                      nat_enabled:
-                        type: boolean
-                      private_ip:
-                        type: string
-                      public_ip:
-                        type: string
-                      subnets:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - backend
-                    - cable_name
-                    - cluster_id
-                    - hostname
-                    - nat_enabled
-                    - private_ip
-                    - public_ip
-                    - subnets
-                    type: object
-                  statusFailure:
-                    type: string
-                  version:
-                    type: string
-                required:
-                - connections
-                - haStatus
-                - localEndpoint
-                - statusFailure
-                - version
-                type: object
-              type: array
-            globalCIDR:
-              type: string
-            globalnetDaemonSetStatus:
-              properties:
-                lastResourceVersion:
-                  type: string
-                mismatchedContainerImages:
-                  type: boolean
-                nonReadyContainerStates:
-                  items:
-                    description: ContainerState holds a possible state of container.
-                      Only one of its members may be specified. If none of them is
-                      specified, the default one is ContainerStateWaiting.
-                    properties:
-                      running:
-                        description: Details about a running container
-                        properties:
-                          startedAt:
-                            description: Time at which the container was last (re-)started
-                            format: date-time
-                            type: string
-                        type: object
-                      terminated:
-                        description: Details about a terminated container
-                        properties:
-                          containerID:
-                            description: Container's ID in the format 'docker://<container_id>'
-                            type: string
-                          exitCode:
-                            description: Exit status from the last termination of
-                              the container
-                            format: int32
-                            type: integer
-                          finishedAt:
-                            description: Time at which the container last terminated
-                            format: date-time
-                            type: string
-                          message:
-                            description: Message regarding the last termination of
-                              the container
-                            type: string
-                          reason:
-                            description: (brief) reason from the last termination
-                              of the container
-                            type: string
-                          signal:
-                            description: Signal from the last termination of the container
-                            format: int32
-                            type: integer
-                          startedAt:
-                            description: Time at which previous execution of the container
-                              started
-                            format: date-time
-                            type: string
-                        required:
-                        - exitCode
-                        type: object
-                      waiting:
-                        description: Details about a waiting container
-                        properties:
-                          message:
-                            description: Message regarding why the container is not
-                              yet running.
-                            type: string
-                          reason:
-                            description: (brief) reason the container is not yet running.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                status:
-                  description: DaemonSetStatus represents the current status of a
-                    daemon set.
-                  properties:
-                    collisionCount:
-                      description: Count of hash collisions for the DaemonSet. The
-                        DaemonSet controller uses this field as a collision avoidance
-                        mechanism when it needs to create the name for the newest
-                        ControllerRevision.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Represents the latest available observations of
-                        a DaemonSet's current state.
-                      items:
-                        description: DaemonSetCondition describes the state of a DaemonSet
-                          at a certain point.
-                        properties:
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: A human readable message indicating details
-                              about the transition.
-                            type: string
-                          reason:
-                            description: The reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            type: string
-                          type:
-                            description: Type of DaemonSet condition.
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    currentNumberScheduled:
-                      description: 'The number of nodes that are running at least
-                        1 daemon pod and are supposed to run the daemon pod. More
-                        info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    desiredNumberScheduled:
-                      description: 'The total number of nodes that should be running
-                        the daemon pod (including nodes correctly running the daemon
-                        pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberAvailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and available (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    numberMisscheduled:
-                      description: 'The number of nodes that are running the daemon
-                        pod, but are not supposed to run the daemon pod. More info:
-                        https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberReady:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and ready.
-                      format: int32
-                      type: integer
-                    numberUnavailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have none of the daemon pod running and available
-                        (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    observedGeneration:
-                      description: The most recent generation observed by the daemon
-                        set controller.
-                      format: int64
-                      type: integer
-                    updatedNumberScheduled:
-                      description: The total number of nodes that are running updated
-                        daemon pod
-                      format: int32
-                      type: integer
-                  required:
-                  - currentNumberScheduled
-                  - desiredNumberScheduled
-                  - numberMisscheduled
-                  - numberReady
-                  type: object
-              required:
-              - mismatchedContainerImages
-              type: object
-            natEnabled:
-              type: boolean
-            routeAgentDaemonSetStatus:
-              properties:
-                lastResourceVersion:
-                  type: string
-                mismatchedContainerImages:
-                  type: boolean
-                nonReadyContainerStates:
-                  items:
-                    description: ContainerState holds a possible state of container.
-                      Only one of its members may be specified. If none of them is
-                      specified, the default one is ContainerStateWaiting.
-                    properties:
-                      running:
-                        description: Details about a running container
-                        properties:
-                          startedAt:
-                            description: Time at which the container was last (re-)started
-                            format: date-time
-                            type: string
-                        type: object
-                      terminated:
-                        description: Details about a terminated container
-                        properties:
-                          containerID:
-                            description: Container's ID in the format 'docker://<container_id>'
-                            type: string
-                          exitCode:
-                            description: Exit status from the last termination of
-                              the container
-                            format: int32
-                            type: integer
-                          finishedAt:
-                            description: Time at which the container last terminated
-                            format: date-time
-                            type: string
-                          message:
-                            description: Message regarding the last termination of
-                              the container
-                            type: string
-                          reason:
-                            description: (brief) reason from the last termination
-                              of the container
-                            type: string
-                          signal:
-                            description: Signal from the last termination of the container
-                            format: int32
-                            type: integer
-                          startedAt:
-                            description: Time at which previous execution of the container
-                              started
-                            format: date-time
-                            type: string
-                        required:
-                        - exitCode
-                        type: object
-                      waiting:
-                        description: Details about a waiting container
-                        properties:
-                          message:
-                            description: Message regarding why the container is not
-                              yet running.
-                            type: string
-                          reason:
-                            description: (brief) reason the container is not yet running.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                status:
-                  description: DaemonSetStatus represents the current status of a
-                    daemon set.
-                  properties:
-                    collisionCount:
-                      description: Count of hash collisions for the DaemonSet. The
-                        DaemonSet controller uses this field as a collision avoidance
-                        mechanism when it needs to create the name for the newest
-                        ControllerRevision.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Represents the latest available observations of
-                        a DaemonSet's current state.
-                      items:
-                        description: DaemonSetCondition describes the state of a DaemonSet
-                          at a certain point.
-                        properties:
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: A human readable message indicating details
-                              about the transition.
-                            type: string
-                          reason:
-                            description: The reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            type: string
-                          type:
-                            description: Type of DaemonSet condition.
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    currentNumberScheduled:
-                      description: 'The number of nodes that are running at least
-                        1 daemon pod and are supposed to run the daemon pod. More
-                        info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    desiredNumberScheduled:
-                      description: 'The total number of nodes that should be running
-                        the daemon pod (including nodes correctly running the daemon
-                        pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberAvailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and available (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    numberMisscheduled:
-                      description: 'The number of nodes that are running the daemon
-                        pod, but are not supposed to run the daemon pod. More info:
-                        https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberReady:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and ready.
-                      format: int32
-                      type: integer
-                    numberUnavailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have none of the daemon pod running and available
-                        (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    observedGeneration:
-                      description: The most recent generation observed by the daemon
-                        set controller.
-                      format: int64
-                      type: integer
-                    updatedNumberScheduled:
-                      description: The total number of nodes that are running updated
-                        daemon pod
-                      format: int32
-                      type: integer
-                  required:
-                  - currentNumberScheduled
-                  - desiredNumberScheduled
-                  - numberMisscheduled
-                  - numberReady
-                  type: object
-              required:
-              - mismatchedContainerImages
-              type: object
-            serviceCIDR:
-              type: string
-          required:
-          - clusterID
-          - natEnabled
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Submariner is the Schema for the submariners API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SubmarinerSpec defines the desired state of Submariner
+            properties:
+              broker:
+                type: string
+              brokerK8sApiServer:
+                type: string
+              brokerK8sApiServerToken:
+                type: string
+              brokerK8sCA:
+                type: string
+              brokerK8sRemoteNamespace:
+                type: string
+              cableDriver:
+                type: string
+              ceIPSecDebug:
+                type: boolean
+              ceIPSecIKEPort:
+                type: integer
+              ceIPSecNATTPort:
+                type: integer
+              ceIPSecPSK:
+                type: string
+              clusterCIDR:
+                type: string
+              clusterID:
+                type: string
+              colorCodes:
+                type: string
+              customDomains:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              debug:
+                type: boolean
+              globalCIDR:
+                type: string
+              namespace:
+                type: string
+              natEnabled:
+                type: boolean
+              repository:
+                type: string
+              serviceCIDR:
+                type: string
+              serviceDiscoveryEnabled:
+                type: boolean
+              version:
+                type: string
+            required:
+            - broker
+            - brokerK8sApiServer
+            - brokerK8sApiServerToken
+            - brokerK8sCA
+            - brokerK8sRemoteNamespace
+            - ceIPSecDebug
+            - ceIPSecPSK
+            - clusterCIDR
+            - clusterID
+            - debug
+            - namespace
+            - natEnabled
+            - serviceCIDR
+            type: object
+          status:
+            description: SubmarinerStatus defines the observed state of Submariner
+            properties:
+              clusterCIDR:
+                type: string
+              clusterID:
+                type: string
+              colorCodes:
+                type: string
+              engineDaemonSetStatus:
+                properties:
+                  lastResourceVersion:
+                    type: string
+                  mismatchedContainerImages:
+                    type: boolean
+                  nonReadyContainerStates:
+                    items:
+                      description: ContainerState holds a possible state of container.
+                        Only one of its members may be specified. If none of them
+                        is specified, the default one is ContainerStateWaiting.
+                      properties:
+                        running:
+                          description: Details about a running container
+                          properties:
+                            startedAt:
+                              description: Time at which the container was last (re-)started
+                              format: date-time
+                              type: string
+                          type: object
+                        terminated:
+                          description: Details about a terminated container
+                          properties:
+                            containerID:
+                              description: Container's ID in the format 'docker://<container_id>'
+                              type: string
+                            exitCode:
+                              description: Exit status from the last termination of
+                                the container
+                              format: int32
+                              type: integer
+                            finishedAt:
+                              description: Time at which the container last terminated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message regarding the last termination
+                                of the container
+                              type: string
+                            reason:
+                              description: (brief) reason from the last termination
+                                of the container
+                              type: string
+                            signal:
+                              description: Signal from the last termination of the
+                                container
+                              format: int32
+                              type: integer
+                            startedAt:
+                              description: Time at which previous execution of the
+                                container started
+                              format: date-time
+                              type: string
+                          required:
+                          - exitCode
+                          type: object
+                        waiting:
+                          description: Details about a waiting container
+                          properties:
+                            message:
+                              description: Message regarding why the container is
+                                not yet running.
+                              type: string
+                            reason:
+                              description: (brief) reason the container is not yet
+                                running.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  status:
+                    description: DaemonSetStatus represents the current status of
+                      a daemon set.
+                    properties:
+                      collisionCount:
+                        description: Count of hash collisions for the DaemonSet. The
+                          DaemonSet controller uses this field as a collision avoidance
+                          mechanism when it needs to create the name for the newest
+                          ControllerRevision.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Represents the latest available observations
+                          of a DaemonSet's current state.
+                        items:
+                          description: DaemonSetCondition describes the state of a
+                            DaemonSet at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of DaemonSet condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentNumberScheduled:
+                        description: 'The number of nodes that are running at least
+                          1 daemon pod and are supposed to run the daemon pod. More
+                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      desiredNumberScheduled:
+                        description: 'The total number of nodes that should be running
+                          the daemon pod (including nodes correctly running the daemon
+                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberAvailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and available (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      numberMisscheduled:
+                        description: 'The number of nodes that are running the daemon
+                          pod, but are not supposed to run the daemon pod. More info:
+                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberReady:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and ready.
+                        format: int32
+                        type: integer
+                      numberUnavailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have none of the daemon pod running and available
+                          (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      observedGeneration:
+                        description: The most recent generation observed by the daemon
+                          set controller.
+                        format: int64
+                        type: integer
+                      updatedNumberScheduled:
+                        description: The total number of nodes that are running updated
+                          daemon pod
+                        format: int32
+                        type: integer
+                    required:
+                    - currentNumberScheduled
+                    - desiredNumberScheduled
+                    - numberMisscheduled
+                    - numberReady
+                    type: object
+                required:
+                - mismatchedContainerImages
+                type: object
+              gateways:
+                items:
+                  properties:
+                    connections:
+                      items:
+                        properties:
+                          endpoint:
+                            properties:
+                              backend:
+                                type: string
+                              backend_config:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              cable_name:
+                                type: string
+                              cluster_id:
+                                type: string
+                              hostname:
+                                type: string
+                              nat_enabled:
+                                type: boolean
+                              private_ip:
+                                type: string
+                              public_ip:
+                                type: string
+                              subnets:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - backend
+                            - cable_name
+                            - cluster_id
+                            - hostname
+                            - nat_enabled
+                            - private_ip
+                            - public_ip
+                            - subnets
+                            type: object
+                          status:
+                            type: string
+                          statusMessage:
+                            type: string
+                        required:
+                        - endpoint
+                        - status
+                        - statusMessage
+                        type: object
+                      type: array
+                    haStatus:
+                      type: string
+                    localEndpoint:
+                      properties:
+                        backend:
+                          type: string
+                        backend_config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        cable_name:
+                          type: string
+                        cluster_id:
+                          type: string
+                        hostname:
+                          type: string
+                        nat_enabled:
+                          type: boolean
+                        private_ip:
+                          type: string
+                        public_ip:
+                          type: string
+                        subnets:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - backend
+                      - cable_name
+                      - cluster_id
+                      - hostname
+                      - nat_enabled
+                      - private_ip
+                      - public_ip
+                      - subnets
+                      type: object
+                    statusFailure:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - connections
+                  - haStatus
+                  - localEndpoint
+                  - statusFailure
+                  - version
+                  type: object
+                type: array
+              globalCIDR:
+                type: string
+              globalnetDaemonSetStatus:
+                properties:
+                  lastResourceVersion:
+                    type: string
+                  mismatchedContainerImages:
+                    type: boolean
+                  nonReadyContainerStates:
+                    items:
+                      description: ContainerState holds a possible state of container.
+                        Only one of its members may be specified. If none of them
+                        is specified, the default one is ContainerStateWaiting.
+                      properties:
+                        running:
+                          description: Details about a running container
+                          properties:
+                            startedAt:
+                              description: Time at which the container was last (re-)started
+                              format: date-time
+                              type: string
+                          type: object
+                        terminated:
+                          description: Details about a terminated container
+                          properties:
+                            containerID:
+                              description: Container's ID in the format 'docker://<container_id>'
+                              type: string
+                            exitCode:
+                              description: Exit status from the last termination of
+                                the container
+                              format: int32
+                              type: integer
+                            finishedAt:
+                              description: Time at which the container last terminated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message regarding the last termination
+                                of the container
+                              type: string
+                            reason:
+                              description: (brief) reason from the last termination
+                                of the container
+                              type: string
+                            signal:
+                              description: Signal from the last termination of the
+                                container
+                              format: int32
+                              type: integer
+                            startedAt:
+                              description: Time at which previous execution of the
+                                container started
+                              format: date-time
+                              type: string
+                          required:
+                          - exitCode
+                          type: object
+                        waiting:
+                          description: Details about a waiting container
+                          properties:
+                            message:
+                              description: Message regarding why the container is
+                                not yet running.
+                              type: string
+                            reason:
+                              description: (brief) reason the container is not yet
+                                running.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  status:
+                    description: DaemonSetStatus represents the current status of
+                      a daemon set.
+                    properties:
+                      collisionCount:
+                        description: Count of hash collisions for the DaemonSet. The
+                          DaemonSet controller uses this field as a collision avoidance
+                          mechanism when it needs to create the name for the newest
+                          ControllerRevision.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Represents the latest available observations
+                          of a DaemonSet's current state.
+                        items:
+                          description: DaemonSetCondition describes the state of a
+                            DaemonSet at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of DaemonSet condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentNumberScheduled:
+                        description: 'The number of nodes that are running at least
+                          1 daemon pod and are supposed to run the daemon pod. More
+                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      desiredNumberScheduled:
+                        description: 'The total number of nodes that should be running
+                          the daemon pod (including nodes correctly running the daemon
+                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberAvailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and available (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      numberMisscheduled:
+                        description: 'The number of nodes that are running the daemon
+                          pod, but are not supposed to run the daemon pod. More info:
+                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberReady:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and ready.
+                        format: int32
+                        type: integer
+                      numberUnavailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have none of the daemon pod running and available
+                          (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      observedGeneration:
+                        description: The most recent generation observed by the daemon
+                          set controller.
+                        format: int64
+                        type: integer
+                      updatedNumberScheduled:
+                        description: The total number of nodes that are running updated
+                          daemon pod
+                        format: int32
+                        type: integer
+                    required:
+                    - currentNumberScheduled
+                    - desiredNumberScheduled
+                    - numberMisscheduled
+                    - numberReady
+                    type: object
+                required:
+                - mismatchedContainerImages
+                type: object
+              natEnabled:
+                type: boolean
+              routeAgentDaemonSetStatus:
+                properties:
+                  lastResourceVersion:
+                    type: string
+                  mismatchedContainerImages:
+                    type: boolean
+                  nonReadyContainerStates:
+                    items:
+                      description: ContainerState holds a possible state of container.
+                        Only one of its members may be specified. If none of them
+                        is specified, the default one is ContainerStateWaiting.
+                      properties:
+                        running:
+                          description: Details about a running container
+                          properties:
+                            startedAt:
+                              description: Time at which the container was last (re-)started
+                              format: date-time
+                              type: string
+                          type: object
+                        terminated:
+                          description: Details about a terminated container
+                          properties:
+                            containerID:
+                              description: Container's ID in the format 'docker://<container_id>'
+                              type: string
+                            exitCode:
+                              description: Exit status from the last termination of
+                                the container
+                              format: int32
+                              type: integer
+                            finishedAt:
+                              description: Time at which the container last terminated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message regarding the last termination
+                                of the container
+                              type: string
+                            reason:
+                              description: (brief) reason from the last termination
+                                of the container
+                              type: string
+                            signal:
+                              description: Signal from the last termination of the
+                                container
+                              format: int32
+                              type: integer
+                            startedAt:
+                              description: Time at which previous execution of the
+                                container started
+                              format: date-time
+                              type: string
+                          required:
+                          - exitCode
+                          type: object
+                        waiting:
+                          description: Details about a waiting container
+                          properties:
+                            message:
+                              description: Message regarding why the container is
+                                not yet running.
+                              type: string
+                            reason:
+                              description: (brief) reason the container is not yet
+                                running.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  status:
+                    description: DaemonSetStatus represents the current status of
+                      a daemon set.
+                    properties:
+                      collisionCount:
+                        description: Count of hash collisions for the DaemonSet. The
+                          DaemonSet controller uses this field as a collision avoidance
+                          mechanism when it needs to create the name for the newest
+                          ControllerRevision.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Represents the latest available observations
+                          of a DaemonSet's current state.
+                        items:
+                          description: DaemonSetCondition describes the state of a
+                            DaemonSet at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of DaemonSet condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentNumberScheduled:
+                        description: 'The number of nodes that are running at least
+                          1 daemon pod and are supposed to run the daemon pod. More
+                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      desiredNumberScheduled:
+                        description: 'The total number of nodes that should be running
+                          the daemon pod (including nodes correctly running the daemon
+                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberAvailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and available (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      numberMisscheduled:
+                        description: 'The number of nodes that are running the daemon
+                          pod, but are not supposed to run the daemon pod. More info:
+                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberReady:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and ready.
+                        format: int32
+                        type: integer
+                      numberUnavailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have none of the daemon pod running and available
+                          (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      observedGeneration:
+                        description: The most recent generation observed by the daemon
+                          set controller.
+                        format: int64
+                        type: integer
+                      updatedNumberScheduled:
+                        description: The total number of nodes that are running updated
+                          daemon pod
+                        format: int32
+                        type: integer
+                    required:
+                    - currentNumberScheduled
+                    - desiredNumberScheduled
+                    - numberMisscheduled
+                    - numberReady
+                    type: object
+                required:
+                - mismatchedContainerImages
+                type: object
+              serviceCIDR:
+                type: string
+            required:
+            - clusterID
+            - natEnabled
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/patches/cainjection_in_servicediscoveries.yaml
+++ b/config/crd/patches/cainjection_in_servicediscoveries.yaml
@@ -1,7 +1,7 @@
 ---
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_submariners.yaml
+++ b/config/crd/patches/cainjection_in_submariners.yaml
@@ -1,7 +1,7 @@
 ---
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_servicediscoveries.yaml
+++ b/config/crd/patches/webhook_in_servicediscoveries.yaml
@@ -1,17 +1,24 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: servicediscoveries.submariner.io
 spec:
   conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    # webhook is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhook:
+      # conversionReviewVersions indicates what ConversionReview versions are understood/preferred by the webhook.
+      # The first version in the list understood by the API server is sent to the webhook.
+      # The webhook must respond with a ConversionReview object in the same version it received.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_submariners.yaml
+++ b/config/crd/patches/webhook_in_submariners.yaml
@@ -1,18 +1,25 @@
 ---
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: submariners.submariner.io
 spec:
   conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    # webhook is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhook:
+      # conversionReviewVersions indicates what ConversionReview versions are understood/preferred by the webhook.
+      # The first version in the list understood by the API server is sent to the webhook.
+      # The webhook must respond with a ConversionReview object in the same version it received.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/controllers/submariner/submariner_controller_test.go
+++ b/controllers/submariner/submariner_controller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/versions"
 	appsv1 "k8s.io/api/apps/v1"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/deploy/mcsapi/crds/multicluster.x_k8s.io_serviceexports.yaml
+++ b/deploy/mcsapi/crds/multicluster.x_k8s.io_serviceexports.yaml
@@ -15,64 +15,64 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-  additionalPrinterColumns:
-    - name: Age
-      type: date
-      jsonPath: .metadata.creationTimestamp
-  "schema":
-    "openAPIV3Schema":
-      description: ServiceExport declares that the Service with the same name and
-        namespace as this export should be consumable from other clusters.
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-          of an object. Servers should convert recognized schemas to the latest
-          internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-          object represents. Servers may infer this from the endpoint the client
-          submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        status:
-          description: status describes the current state of an exported service.
-            Service configuration comes from the Service that had the same name
-            and namespace as this ServiceExport. Populated by the multi-cluster
-            service implementation's controller.
+      additionalPrinterColumns:
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          description: ServiceExport declares that the Service with the same name and
+            namespace as this export should be consumable from other clusters.
           type: object
           properties:
-            conditions:
-              type: array
-              items:
-                description: "ServiceExportCondition contains details for the current
-                condition of this service export. \n Once [KEP-1623](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions)
-                is implemented, this will be replaced by metav1.Condition."
-                type: object
-                required:
-                  - status
-                  - type
-                properties:
-                  lastTransitionTime:
-                    type: string
-                    format: date-time
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    description: Status is one of {"True", "False", "Unknown"}
-                    type: string
-                    enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                  type:
-                    description: ServiceExportConditionType identifies a specific
-                      condition.
-                    type: string
-              x-kubernetes-list-map-keys:
-                - type
-              x-kubernetes-list-type: map
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            status:
+              description: status describes the current state of an exported service.
+                Service configuration comes from the Service that had the same name
+                and namespace as this ServiceExport. Populated by the multi-cluster
+                service implementation's controller.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: "ServiceExportCondition contains details for the current
+                    condition of this service export. \n Once [KEP-1623](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions)
+                    is implemented, this will be replaced by metav1.Condition."
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        description: Status is one of {"True", "False", "Unknown"}
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: ServiceExportConditionType identifies a specific
+                          condition.
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map

--- a/deploy/mcsapi/crds/multicluster.x_k8s.io_serviceimports.yaml
+++ b/deploy/mcsapi/crds/multicluster.x_k8s.io_serviceimports.yaml
@@ -15,132 +15,132 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-  additionalPrinterColumns:
-    - name: Type
-      type: string
-      description: The type of this ServiceImport
-      jsonPath: .spec.type
-    - name: IP
-      type: string
-      description: The VIP for this ServiceImport
-      jsonPath: .spec.ips
-    - name: Age
-      type: date
-      jsonPath: .metadata.creationTimestamp
-  "schema":
-    "openAPIV3Schema":
-      description: ServiceImport describes a service imported from clusters in a
-        ClusterSet.
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-          of an object. Servers should convert recognized schemas to the latest
-          internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+      additionalPrinterColumns:
+        - name: Type
           type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-          object represents. Servers may infer this from the endpoint the client
-          submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: The type of this ServiceImport
+          jsonPath: .spec.type
+        - name: IP
           type: string
-        metadata:
+          description: The VIP for this ServiceImport
+          jsonPath: .spec.ips
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          description: ServiceImport describes a service imported from clusters in a
+            ClusterSet.
           type: object
-        spec:
-          description: spec defines the behavior of a ServiceImport.
-          type: object
-          required:
-            - ports
-            - type
           properties:
-            ips:
-              description: ip will be used as the VIP for this service when type
-                is ClusterSetIP.
-              type: array
-              maxItems: 1
-              items:
-                type: string
-            ports:
-              type: array
-              items:
-                description: ServicePort represents the port on which the service
-                  is exposed
-                type: object
-                required:
-                  - port
-                properties:
-                  appProtocol:
-                    description: The application protocol for this port. This field
-                      follows standard Kubernetes label syntax. Un-prefixed names
-                      are reserved for IANA standard service names (as per RFC-6335
-                      and http://www.iana.org/assignments/service-names). Non-standard
-                      protocols should use prefixed names such as mycompany.com/my-custom-protocol.
-                      Field can be enabled with ServiceAppProtocol feature gate.
-                    type: string
-                  name:
-                    description: The name of this port within the service. This
-                      must be a DNS_LABEL. All ports within a ServiceSpec must have
-                      unique names. When considering the endpoints for a Service,
-                      this must match the 'name' field in the EndpointPort. Optional
-                      if only one ServicePort is defined on this service.
-                    type: string
-                  port:
-                    description: The port that will be exposed by this service.
-                    type: integer
-                    format: int32
-                  protocol:
-                    description: The IP protocol for this port. Supports "TCP",
-                      "UDP", and "SCTP". Default is TCP.
-                    type: string
-              x-kubernetes-list-type: atomic
-            sessionAffinity:
-              description: 'Supports "ClientIP" and "None". Used to maintain session
-              affinity. Enable client IP based session affinity. Must be ClientIP
-              or None. Defaults to None. Ignored when type is Headless More info:
-              https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-            sessionAffinityConfig:
-              description: sessionAffinityConfig contains session affinity configuration.
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
+            spec:
+              description: spec defines the behavior of a ServiceImport.
+              type: object
+              required:
+                - ports
+                - type
               properties:
-                clientIP:
-                  description: clientIP contains the configurations of Client IP
-                    based session affinity.
+                ips:
+                  description: ip will be used as the VIP for this service when type
+                    is ClusterSetIP.
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: string
+                ports:
+                  type: array
+                  items:
+                    description: ServicePort represents the port on which the service
+                      is exposed
+                    type: object
+                    required:
+                      - port
+                    properties:
+                      appProtocol:
+                        description: The application protocol for this port. This field
+                          follows standard Kubernetes label syntax. Un-prefixed names
+                          are reserved for IANA standard service names (as per RFC-6335
+                          and http://www.iana.org/assignments/service-names). Non-standard
+                          protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                          Field can be enabled with ServiceAppProtocol feature gate.
+                        type: string
+                      name:
+                        description: The name of this port within the service. This
+                          must be a DNS_LABEL. All ports within a ServiceSpec must have
+                          unique names. When considering the endpoints for a Service,
+                          this must match the 'name' field in the EndpointPort. Optional
+                          if only one ServicePort is defined on this service.
+                        type: string
+                      port:
+                        description: The port that will be exposed by this service.
+                        type: integer
+                        format: int32
+                      protocol:
+                        description: The IP protocol for this port. Supports "TCP",
+                          "UDP", and "SCTP". Default is TCP.
+                        type: string
+                  x-kubernetes-list-type: atomic
+                sessionAffinity:
+                  description: 'Supports "ClientIP" and "None". Used to maintain session
+                  affinity. Enable client IP based session affinity. Must be ClientIP
+                  or None. Defaults to None. Ignored when type is Headless More info:
+                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                  type: string
+                sessionAffinityConfig:
+                  description: sessionAffinityConfig contains session affinity configuration.
                   type: object
                   properties:
-                    timeoutSeconds:
-                      description: timeoutSeconds specifies the seconds of ClientIP
-                        type session sticky time. The value must be >0 && <=86400(for
-                        1 day) if ServiceAffinity == "ClientIP". Default value is
-                        10800(for 3 hours).
-                      type: integer
-                      format: int32
-            type:
-              description: type defines the type of this service. Must be ClusterSetIP
-                or Headless.
-              type: string
-              enum:
-                - ClusterSetIP
-                - Headless
-        status:
-          description: status contains information about the exported services that
-            form the multi-cluster service referenced by this ServiceImport.
-          type: object
-          properties:
-            clusters:
-              description: clusters is the list of exporting clusters from which
-                this service was derived.
-              type: array
-              items:
-                description: ClusterStatus contains service configuration mapped
-                  to a specific source cluster
-                type: object
-                required:
-                  - cluster
-                properties:
-                  cluster:
-                    description: cluster is the name of the exporting cluster. Must
-                      be a valid RFC-1123 DNS label.
-                    type: string
-              x-kubernetes-list-map-keys:
-                - cluster
-              x-kubernetes-list-type: map
+                    clientIP:
+                      description: clientIP contains the configurations of Client IP
+                        based session affinity.
+                      type: object
+                      properties:
+                        timeoutSeconds:
+                          description: timeoutSeconds specifies the seconds of ClientIP
+                            type session sticky time. The value must be >0 && <=86400(for
+                            1 day) if ServiceAffinity == "ClientIP". Default value is
+                            10800(for 3 hours).
+                          type: integer
+                          format: int32
+                type:
+                  description: type defines the type of this service. Must be ClusterSetIP
+                    or Headless.
+                  type: string
+                  enum:
+                    - ClusterSetIP
+                    - Headless
+            status:
+              description: status contains information about the exported services that
+                form the multi-cluster service referenced by this ServiceImport.
+              type: object
+              properties:
+                clusters:
+                  description: clusters is the list of exporting clusters from which
+                    this service was derived.
+                  type: array
+                  items:
+                    description: ClusterStatus contains service configuration mapped
+                      to a specific source cluster
+                    type: object
+                    required:
+                      - cluster
+                    properties:
+                      cluster:
+                        description: cluster is the name of the exporting cluster. Must
+                          be a valid RFC-1123 DNS label.
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - cluster
+                  x-kubernetes-list-type: map

--- a/pkg/engine/crds.go
+++ b/pkg/engine/crds.go
@@ -19,7 +19,7 @@ package engine
 import (
 	"fmt"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"

--- a/pkg/subctl/operator/submarinerop/crds/ensure.go
+++ b/pkg/subctl/operator/submarinerop/crds/ensure.go
@@ -17,7 +17,7 @@ limitations under the License.
 package crds
 
 import (
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
@@ -43,8 +43,8 @@ func Ensure(restConfig *rest.Config) (bool, error) {
 	return utils.CreateOrUpdateCRD(crdUpdater, submarinerCrd)
 }
 
-func getSubmarinerCRD() (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{}
+func getSubmarinerCRD() (*apiextensions.CustomResourceDefinition, error) {
+	crd := &apiextensions.CustomResourceDefinition{}
 
 	if err := embeddedyamls.GetObject(embeddedyamls.Deploy_crds_submariner_io_submariners_yaml, crd); err != nil {
 		return nil, err

--- a/pkg/utils/crds/crdutils.go
+++ b/pkg/utils/crds/crdutils.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -28,9 +28,9 @@ import (
 )
 
 type CRDUpdater interface {
-	Create(*v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error)
-	Update(*v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error)
-	Get(name string, options v1.GetOptions) (*v1beta1.CustomResourceDefinition, error)
+	Create(*apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error)
+	Update(*apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error)
+	Get(name string, options v1.GetOptions) (*apiextensions.CustomResourceDefinition, error)
 }
 
 type controllerClientCreator struct {
@@ -46,7 +46,7 @@ func NewFromRestConfig(config *rest.Config) (CRDUpdater, error) {
 }
 
 func NewFromClientSet(cs clientset.Interface) CRDUpdater {
-	return cs.ApiextensionsV1beta1().CustomResourceDefinitions()
+	return cs.ApiextensionsV1().CustomResourceDefinitions()
 }
 
 func NewFromControllerClient(controllerClient client.Client) CRDUpdater {
@@ -55,18 +55,18 @@ func NewFromControllerClient(controllerClient client.Client) CRDUpdater {
 	}
 }
 
-func (c *controllerClientCreator) Create(crd *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
+func (c *controllerClientCreator) Create(crd *apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error) {
 	err := c.client.Create(context.TODO(), crd)
 	return crd, err
 }
 
-func (c *controllerClientCreator) Update(crd *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
+func (c *controllerClientCreator) Update(crd *apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error) {
 	err := c.client.Update(context.TODO(), crd)
 	return crd, err
 }
 
-func (c *controllerClientCreator) Get(name string, options v1.GetOptions) (*v1beta1.CustomResourceDefinition, error) {
-	crd := &v1beta1.CustomResourceDefinition{}
+func (c *controllerClientCreator) Get(name string, options v1.GetOptions) (*apiextensions.CustomResourceDefinition, error) {
+	crd := &apiextensions.CustomResourceDefinition{}
 	err := c.client.Get(context.TODO(), client.ObjectKey{Name: name}, crd)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/createorupdate.go
+++ b/pkg/utils/createorupdate.go
@@ -22,7 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -72,7 +72,7 @@ func CreateOrUpdateClusterRoleBinding(clientSet clientset.Interface, clusterRole
 	return false, err
 }
 
-func CreateOrUpdateCRD(updater crdutils.CRDUpdater, crd *apiextensionsv1beta1.CustomResourceDefinition) (bool, error) {
+func CreateOrUpdateCRD(updater crdutils.CRDUpdater, crd *apiextensions.CustomResourceDefinition) (bool, error) {
 	_, err := updater.Create(crd)
 	if err == nil {
 		return true, nil
@@ -93,7 +93,7 @@ func CreateOrUpdateCRD(updater crdutils.CRDUpdater, crd *apiextensionsv1beta1.Cu
 }
 
 func CreateOrUpdateEmbeddedCRD(updater crdutils.CRDUpdater, crdYaml string) (bool, error) {
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{}
+	crd := &apiextensions.CustomResourceDefinition{}
 
 	if err := embeddedyamls.GetObject(crdYaml, crd); err != nil {
 		return false, fmt.Errorf("Error extracting embedded CRD: %s", err)

--- a/pkg/utils/createorupdate_test.go
+++ b/pkg/utils/createorupdate_test.go
@@ -24,7 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extendedfakeclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -111,12 +111,12 @@ var _ = Describe("CreateOrUpdateClusterRoleBinding", func() {
 
 var _ = Describe("CreateOrUpdateCRD", func() {
 	var (
-		crd    *apiextensionsv1beta1.CustomResourceDefinition
+		crd    *apiextensions.CustomResourceDefinition
 		client *extendedfakeclientset.Clientset
 	)
 
 	BeforeEach(func() {
-		crd = &apiextensionsv1beta1.CustomResourceDefinition{}
+		crd = &apiextensions.CustomResourceDefinition{}
 		err := embeddedyamls.GetObject(embeddedyamls.Deploy_crds_submariner_io_submariners_yaml, crd)
 		Expect(err).ShouldNot(HaveOccurred())
 		client = extendedfakeclientset.NewSimpleClientset()
@@ -128,7 +128,7 @@ var _ = Describe("CreateOrUpdateCRD", func() {
 			Expect(created).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 
-			createdCrd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
+			createdCrd, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdCrd.Spec.Names.Kind).Should(Equal("Submariner"))
 		})


### PR DESCRIPTION
Use `controller-gen` to generate the CRDs in v1.

Signed-off-by: Steve Mattar <smattar@redhat.com>