### PR TITLE
Fix release job, avoid deprecated set-env

### DIFF
--- a/.github/workflows/subctl_bleeding_edge.yml
+++ b/.github/workflows/subctl_bleeding_edge.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate the Artifacts
         run: |
           make build-cross VERSION=devel
-          echo "::set-env name=BINARIES::$(find dist/ -type f -name '*.tar.xz' -printf '%p ')"
+          echo "BINARIES=$(find dist/ -type f -name '*.tar.xz' -printf '%p ')" >> $GITHUB_ENV
 
       - name: Bump the devel tag
         uses: richardsimko/update-tag@v1.0.3


### PR DESCRIPTION
The process for setting environment variables in GitHub Actions has
changed due to a security issue.

See:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-
set-env-and-add-path-commands/

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>