### PR TITLE
Exclude openshift-dns namespace in Globalnet

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -613,7 +613,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
-								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner-operator,kube-system,operators,openshift-monitoring"},
+								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner-operator,kube-system,operators,openshift-monitoring,openshift-dns"},
 							},
 						},
 					},


### PR DESCRIPTION
In an OCP Cluster, openshift-dns namespace has dns-default
service and this is controlled by its operator.
When Globalnet is deployed on OCP, it was seen that globalip
annotation added to it is periodically getting deleted by the
operator, so Globalnet tries to re-add the annotation and this
goes on forever. This will cause Globalnet to consume CPU
unnecessarily and could affect user-experience with Submariner
Globalnet. We have plans to enhance Globalnet to improve its
scalability, but until then we can exclude annotating services
in openshift-dns namespace.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>