### PR TITLE
subctl: Create MCS SIG ServiceExport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ci: generate-embeddedyamls golangci-lint markdownlint unit build images
 
 generate-embeddedyamls: generate pkg/subctl/operator/common/embeddedyamls/yamls.go
 
-pkg/subctl/operator/common/embeddedyamls/yamls.go: pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go deploy/crds/submariner.io_servicediscoveries.yaml deploy/crds/submariner.io_submariners.yaml deploy/lighthouse/crds/lighthouse.submariner.io_multiclusterservices.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceexports.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceimports.yaml deploy/submariner/crds/submariner.io_clusters.yaml deploy/submariner/crds/submariner.io_endpoints.yaml deploy/submariner/crds/submariner.io_gateways.yaml $(shell find deploy/ -name "*.yaml") vendor/modules.txt
+pkg/subctl/operator/common/embeddedyamls/yamls.go: pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go deploy/crds/submariner.io_servicediscoveries.yaml deploy/crds/submariner.io_submariners.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceexports.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceimports.yaml deploy/submariner/crds/submariner.io_clusters.yaml deploy/submariner/crds/submariner.io_endpoints.yaml deploy/submariner/crds/submariner.io_gateways.yaml $(shell find deploy/ -name "*.yaml") vendor/modules.txt
 	go generate pkg/subctl/operator/common/embeddedyamls/generate.go
 
 # Operator CRDs
@@ -128,7 +128,7 @@ deploy/crds/submariner.io_submariners.yaml: ./apis/submariner/v1alpha1/submarine
 	controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=deploy/crds
 
 # Lighthouse CRDs
-deploy/lighthouse/crds/lighthouse.submariner.io_multiclusterservices.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceexports.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceimports.yaml: vendor/modules.txt
+deploy/lighthouse/crds/lighthouse.submariner.io_serviceexports.yaml deploy/lighthouse/crds/lighthouse.submariner.io_serviceimports.yaml: vendor/modules.txt
 	cd vendor/github.com/submariner-io/lighthouse && controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../../../../deploy/lighthouse/crds
 
 # Submariner CRDs

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.8.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
-	github.com/submariner-io/admiral v0.7.0
+	github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf
 	github.com/submariner-io/lighthouse v0.7.1-0.20201119065422-6f359be31b8e
 	github.com/submariner-io/shipyard v0.7.3-0.20201105165619-4a6063d2b38c
 	github.com/submariner-io/submariner v0.7.1-0.20201119153223-9b682d6189dc

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.8.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
+	github.com/submariner-io/admiral v0.7.0
 	github.com/submariner-io/lighthouse v0.7.1-0.20201119065422-6f359be31b8e
 	github.com/submariner-io/shipyard v0.7.3-0.20201105165619-4a6063d2b38c
 	github.com/submariner-io/submariner v0.7.1-0.20201119153223-9b682d6189dc
@@ -27,6 +28,7 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe
 	sigs.k8s.io/controller-runtime v0.6.2
+	sigs.k8s.io/mcs-api v0.0.0-20200908023942-d26176718973
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -970,6 +970,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
@@ -997,6 +998,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/submariner-io/admiral v0.7.0 h1:1Ddjx8PvmeUjqO9+qMAPoFgkDSq8asmXl/tlsiTDlNE=
 github.com/submariner-io/admiral v0.7.0/go.mod h1:S5Aemqu4Ac2sZWW9AEfPIhSC4eMCWmCVQ/rSSEHRt2o=
 github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf/go.mod h1:CB0bBubRoDoYYJTpjAww+VwloKfLRU4U0roevyXkrXk=
 github.com/submariner-io/lighthouse v0.7.1-0.20201119065422-6f359be31b8e h1:koLT3PgdR3Ewhijz5CfN3R9DeXLmyhnqZ3SXEUEcGn8=

--- a/go.sum
+++ b/go.sum
@@ -1000,6 +1000,7 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.7.0 h1:1Ddjx8PvmeUjqO9+qMAPoFgkDSq8asmXl/tlsiTDlNE=
 github.com/submariner-io/admiral v0.7.0/go.mod h1:S5Aemqu4Ac2sZWW9AEfPIhSC4eMCWmCVQ/rSSEHRt2o=
+github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf h1:GVvrpEx82lqv/gUV8vr8gVB6LUJKQqWJQ7isa7mz0Ec=
 github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf/go.mod h1:CB0bBubRoDoYYJTpjAww+VwloKfLRU4U0roevyXkrXk=
 github.com/submariner-io/lighthouse v0.7.1-0.20201119065422-6f359be31b8e h1:koLT3PgdR3Ewhijz5CfN3R9DeXLmyhnqZ3SXEUEcGn8=
 github.com/submariner-io/lighthouse v0.7.1-0.20201119065422-6f359be31b8e/go.mod h1:VwCeWkNoRNQthdc+/IkZ0gD4gYLfIsLESRDInVJaFK0=

--- a/pkg/lighthouse/crds.go
+++ b/pkg/lighthouse/crds.go
@@ -17,12 +17,6 @@ const (
 // The resources handled here are the lighthouse CRDs: MultiClusterService,
 // ServiceImport, ServiceExport and ServiceDiscovery
 func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
-	installedMCS, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
-		embeddedyamls.Deploy_lighthouse_crds_lighthouse_submariner_io_multiclusterservices_yaml)
-	if err != nil {
-		return installedMCS, fmt.Errorf("Error creating the MultiClusterServices CRD: %s", err)
-	}
-
 	installedSI, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
 		embeddedyamls.Deploy_lighthouse_crds_lighthouse_submariner_io_serviceimports_yaml)
 	if err != nil {
@@ -38,7 +32,7 @@ func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
 
 	// The broker does not need the ServiceExport or ServiceDiscovery
 	if isBroker {
-		return installedMCS || installedMCSSI || installedSI, nil
+		return installedMCSSI || installedSI, nil
 	}
 
 	installedSE, err := utils.CreateOrUpdateEmbeddedCRD(crdUpdater,
@@ -60,5 +54,5 @@ func Ensure(crdUpdater crdutils.CRDUpdater, isBroker bool) (bool, error) {
 		return installedSD, err
 	}
 
-	return installedMCS || installedMCSSI || installedSI || installedSE || installedSD || installedMCSSE, nil
+	return installedMCSSI || installedSI || installedSE || installedSD || installedMCSSE, nil
 }

--- a/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
+++ b/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
@@ -31,7 +31,6 @@ var files = []string{
 	"deploy/submariner/crds/submariner.io_clusters.yaml",
 	"deploy/submariner/crds/submariner.io_endpoints.yaml",
 	"deploy/submariner/crds/submariner.io_gateways.yaml",
-	"deploy/lighthouse/crds/lighthouse.submariner.io_multiclusterservices.yaml",
 	"deploy/lighthouse/crds/lighthouse.submariner.io_serviceexports.yaml",
 	"deploy/lighthouse/crds/lighthouse.submariner.io_serviceimports.yaml",
 	"deploy/mcsapi/crds/multicluster.x_k8s.io_serviceexports.yaml",


### PR DESCRIPTION
Currently `subctl export service` creates
`serviceexports.lighthouse.submariner.io`
Change it to create `serviceexports.multicluster.x-k8s.io` instead,
inline with switch to MCS Sig API in Lighthouse.

Fixes #798

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>