### PR TITLE
Remove hard-coded override of cable driver flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CROSS_BINARIES := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,bin/subctl-$(VER
 CROSS_TARBALLS := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,dist/subctl-$(VERSION)-%.tar.xz,$(cross)))
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_settings
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
-override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_submariner_args '--cable-driver strongswan'
+override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
 export DEPLOY_ARGS
 override UNIT_TEST_ARGS += cmd pkg/internal
 override VALIDATE_ARGS += --skip-dirs pkg/client

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -35,7 +35,7 @@ function create_subm_vars() {
     subm_colorcodes=blue
     subm_debug=false
     subm_broker=k8s
-    subm_cabledriver=strongswan
+    subm_cabledriver=libreswan
     ce_ipsec_debug=false
     ce_ipsec_ikeport=500
     ce_ipsec_nattport=4500


### PR DESCRIPTION
Don't pass cable driver flag, instead use new Shipyard using= flag.

As a side effect, this will change the default cable driver in this repo
from strongswan to libreswan.

Relates-to: submariner-io/shipyard#364
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>