### PR TITLE
Remove flaky test failure automatic reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_failure_automated.md
+++ b/.github/ISSUE_TEMPLATE/flaky_failure_automated.md
@@ -1,3 +1,0 @@
-Periodic end-to-end tests against the main branch failed, which might mean there was a flaky failure.
-
-Please check the [Flake Finder workflow](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3A%22Flake+Finder%22).

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -38,11 +38,3 @@ jobs:
           df -h
           free -h
           make post-mortem
-
-      - name: Raise an issue to report flaky test failure
-        if: ${{ failure() }}
-        uses: peter-evans/create-issue-from-file@v2.3.2
-        with:
-          title: Flaky Failure make e2e using="${{ matrix.cable_driver }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }}"
-          content-filepath: .github/ISSUE_TEMPLATE/flaky_failure_automated.md
-          labels: automated, flaky failure


### PR DESCRIPTION
There are currently frequent flaky failures, which are causing this
reporting logic to spam our GH issues. Disable it for now, consider
reverting once flaky failures are rare.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>