### PR TITLE
fix: update image pull policy when using image override

### DIFF
--- a/controllers/helpers/helpers.go
+++ b/controllers/helpers/helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	errorutil "github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/pkg/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,4 +204,12 @@ func ReconcileService(owner metav1.Object, service *corev1.Service, reqLogger lo
 	}
 
 	return service, errorutil.WithMessagef(err, "error creating or updating Service %s/%s", service.Namespace, service.Name)
+}
+
+func GetPullPolicy(version, override string) corev1.PullPolicy {
+	if len(override) > 0 {
+		tag := strings.Split(override, ":")[1]
+		return images.GetPullPolicy(tag)
+	}
+	return images.GetPullPolicy(version)
 }

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -184,7 +184,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery) *appsv1.Deploym
 						{
 							Name:            "submariner-lighthouse-agent",
 							Image:           getImagePath(cr, names.ServiceDiscoveryImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.ServiceDiscoveryImage]),
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
@@ -270,7 +270,7 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 						{
 							Name:            lighthouseCoreDNSName,
 							Image:           getImagePath(cr, names.LighthouseCoreDNSImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSImage]),
 							Args: []string{
 								"-conf",
 								"/etc/coredns/Corefile",

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -522,7 +522,7 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 				{
 					Name:            "submariner",
 					Image:           getImagePath(cr, names.EngineImage),
-					ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+					ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.EngineImage]),
 					Command:         []string{"submariner.sh"},
 					SecurityContext: &security_context_all_caps_privileged,
 					VolumeMounts: []corev1.VolumeMount{
@@ -626,7 +626,7 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 						{
 							Name:            "submariner-routeagent",
 							Image:           getImagePath(cr, names.RouteAgentImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.RouteAgentImage]),
 							// FIXME: Should be entrypoint script, find/use correct file for routeagent
 							Command:         []string{"submariner-route-agent.sh"},
 							SecurityContext: &security_context_all_cap_allow_escal,
@@ -706,7 +706,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 						{
 							Name:            "submariner-globalnet",
 							Image:           getImagePath(cr, names.GlobalnetImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GlobalnetImage]),
 							SecurityContext: &security_context_all_cap_allow_escal,
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "host-slash", MountPath: "/host", ReadOnly: true},


### PR DESCRIPTION
The `ImagePullPolicy` will be set to the correct value according to the image tag
in case of using `ImageOverride` flag.

Signed-off-by: Steve Mattar <smattar@redhat.com>