### PR TITLE
Stop running subctl join twice

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -30,9 +30,6 @@ with_context "$broker" verify_subm_broker_secrets
 
 run_subm_clusters verify_subm_deployed
 
-echo "Running subctl a second time to verify if running subctl a second time works fine"
-with_context cluster2 subctl_install_subm
-
 if [[ "$lighthouse" == "true" ]]; then
     verify="--only service-discovery"
 else


### PR DESCRIPTION
e2e attempts to run subctl join a second time on cluster2, to check
that doing so doesn't break the cluster, but it doesn't have all the
information used in the initial deployment and can result in a cluster
deployed differently (e.g. strongSwan v. Libreswan).

This patch removes the test for now; if we re-introduce it, it should
probably be a separate test (but see also the upgrade tests).

Signed-off-by: Stephen Kitt <skitt@redhat.com>