### PR TITLE
Deploy a ServiceMonitor for the engine

### DIFF
--- a/controllers/helpers/helpers.go
+++ b/controllers/helpers/helpers.go
@@ -171,6 +171,10 @@ func ReconcileService(owner metav1.Object, service *corev1.Service, reqLogger lo
 		}}
 
 		result, err := controllerutil.CreateOrUpdate(context.TODO(), client, toUpdate, func() error {
+			if toUpdate.Spec.Type == corev1.ServiceTypeClusterIP {
+				// Make sure we don't lose the ClusterIP, see https://github.com/kubernetes/kubectl/issues/798
+				service.Spec.ClusterIP = toUpdate.Spec.ClusterIP
+			}
 			toUpdate.Spec = service.Spec
 			for k, v := range service.Labels {
 				toUpdate.Labels[k] = v

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -18,12 +18,13 @@ package submariner
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 
 	"github.com/go-logr/logr"
+	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	errorutil "github.com/pkg/errors"
-	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +49,7 @@ import (
 
 	submopv1a1 "github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/controllers/helpers"
+	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
@@ -59,6 +62,7 @@ var log = logf.Log.WithName("controller_submariner")
 func NewReconciler(mgr manager.Manager) *SubmarinerReconciler {
 	reconciler := &SubmarinerReconciler{
 		client:         mgr.GetClient(),
+		config:         mgr.GetConfig(),
 		log:            ctrl.Log.WithName("controllers").WithName("Submariner"),
 		scheme:         mgr.GetScheme(),
 		clientSet:      kubernetes.NewForConfigOrDie(mgr.GetConfig()),
@@ -78,6 +82,7 @@ type SubmarinerReconciler struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client         client.Client
+	config         *rest.Config
 	log            logr.Logger
 	scheme         *runtime.Scheme
 	clientSet      kubernetes.Interface
@@ -292,7 +297,12 @@ func (r *SubmarinerReconciler) retrieveGateways(owner metav1.Object, namespace s
 }
 
 func (r *SubmarinerReconciler) reconcileEngineDaemonSet(instance *submopv1a1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet, error) {
-	return helpers.ReconcileDaemonSet(instance, newEngineDaemonSet(instance), reqLogger, r.client, r.scheme)
+	daemonSet, err := helpers.ReconcileDaemonSet(instance, newEngineDaemonSet(instance), reqLogger, r.client, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+	_, err = r.setupMetrics(instance, daemonSet.GetLabels(), reqLogger)
+	return daemonSet, err
 }
 
 func (r *SubmarinerReconciler) reconcileNetworkPluginSyncerDeployment(instance *submopv1a1.Submariner,
@@ -362,6 +372,35 @@ func (r *SubmarinerReconciler) serviceDiscoveryReconciler(submariner *submopv1a1
 	return errorutil.WithMessagef(err, "error reconciling the Service Discovery CR")
 }
 
+func (r *SubmarinerReconciler) setupMetrics(instance *submopv1a1.Submariner, labels map[string]string,
+	reqLogger logr.Logger) (*corev1.Service, error) {
+	app, ok := labels["app"]
+	if !ok {
+		return nil, fmt.Errorf("No app label in the provided labels, %v", labels)
+	}
+	metricsService, err := helpers.ReconcileService(instance, newMetricsService(instance, app), reqLogger, r.client, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.config != nil {
+		services := []*corev1.Service{metricsService}
+		_, err = metrics.CreateServiceMonitors(r.config, instance.Namespace, services)
+		if err != nil {
+			log.Info("Could not create ServiceMonitor object", "error", err.Error())
+			// If this operator is deployed to a cluster without the prometheus-operator running, it will return
+			// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
+			if err == metrics.ErrServiceMonitorNotPresent {
+				log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+			} else if !errors.IsAlreadyExists(err) {
+				return nil, err
+			}
+		}
+	}
+
+	return metricsService, nil
+}
+
 func newEngineDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 	labels := map[string]string{
 		"app":       "submariner-engine",
@@ -392,6 +431,36 @@ func newEngineDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 	}
 
 	return deployment
+}
+
+// newMetricsService populates a Service providing access to metrics for the given application
+// The assumptions are:
+// - the application's resources are labeled with "app=" the given app name
+// - the metrics are exposed on port 8080 on "/metrics"
+// The Service is named after the application name, suffixed with "-metrics"
+func newMetricsService(cr *submopv1a1.Submariner, app string) *corev1.Service {
+	labels := map[string]string{
+		"app": app,
+	}
+
+	servicePorts := []corev1.ServicePort{
+		{Port: 8080, Name: "metrics", Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int,
+			IntVal: 8080}},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Namespace: cr.Namespace,
+			Name:      fmt.Sprintf("%s-metrics", app),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:    servicePorts,
+			Selector: labels,
+		},
+	}
+
+	return service
 }
 
 // newEnginePodTemplate returns a submariner pod with the same fields as the cr


### PR DESCRIPTION
This allows engine metrics to be automatically scraped when using the Prometheus operator.

Fixes: #905