### PR TITLE
Apply consistent casing to help texts

### DIFF
--- a/apis/submariner/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/submariner/v1alpha1/zz_generated.deepcopy.go
@@ -2,7 +2,7 @@
 
 /*
 
-© 2020 Red Hat, Inc. and others.
+© 2021 Red Hat, Inc. and others.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -49,8 +49,8 @@ func init() {
 }
 
 func addBenchmarkFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVar(&intraCluster, "intra-cluster", false, "Runs the test within a single cluster")
-	cmd.PersistentFlags().BoolVar(&benchmark.Verbose, "verbose", false, "Produce verbose logs during benchmark tests")
+	cmd.PersistentFlags().BoolVar(&intraCluster, "intra-cluster", false, "run the test within a single cluster")
+	cmd.PersistentFlags().BoolVar(&benchmark.Verbose, "verbose", false, "produce verbose logs during benchmark tests")
 }
 
 func checkBenchmarkArguments(args []string, intraCluster bool) error {

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -41,20 +41,20 @@ var (
 
 func init() {
 	deployBroker.PersistentFlags().BoolVar(&globalnetEnable, "globalnet", false,
-		"Enable support for Overlapping CIDRs in connecting clusters (default disabled)")
+		"enable support for Overlapping CIDRs in connecting clusters (default disabled)")
 	deployBroker.PersistentFlags().StringVar(&globalnetCidrRange, "globalnet-cidr-range", "169.254.0.0/16",
-		"Global CIDR supernet range for allocating GlobalCIDRs to each cluster")
+		"GlobalCIDR supernet range for allocating GlobalCIDRs to each cluster")
 	deployBroker.PersistentFlags().UintVar(&defaultGlobalnetClusterSize, "globalnet-cluster-size", 8192,
-		"Default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
+		"default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
 
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
-		"Import IPsec PSK from existing submariner broker file, like broker-info.subm")
+		"import IPsec PSK from existing submariner broker file, like broker-info.subm")
 
 	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", true,
-		"Enable Multi-Cluster Service Discovery")
+		"enable multi-cluster service discovery")
 
 	deployBroker.PersistentFlags().StringSliceVar(&defaultCustomDomains, "custom-domains", nil,
-		"List of domains to use for multicluster service discovery")
+		"list of domains to use for multicluster service discovery")
 
 	addKubeconfigFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
@@ -64,7 +64,7 @@ const brokerDetailsFilename = "broker-info.subm"
 
 var deployBroker = &cobra.Command{
 	Use:   "deploy-broker",
-	Short: "set the broker up",
+	Short: "Set the broker up",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		if valid, err := isValidGlobalnetConfig(); !valid {

--- a/pkg/subctl/cmd/export.go
+++ b/pkg/subctl/cmd/export.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 func addServiceExportFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&serviceNamespace, "namespace", "n", "", "Namespace of the service to be exported")
+	cmd.Flags().StringVarP(&serviceNamespace, "namespace", "n", "", "namespace of the service to be exported")
 }
 
 func exportService(cmd *cobra.Command, args []string) {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -90,19 +90,19 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
 	cmd.Flags().BoolVar(&natTraversal, "natt", true, "enable NAT traversal for IPsec")
-	cmd.Flags().BoolVar(&disableNat, "disable-nat", false, "Disable NAT for IPsec")
+	cmd.Flags().BoolVar(&disableNat, "disable-nat", false, "disable NAT for IPsec")
 	err := cmd.Flags().MarkDeprecated("disable-nat", "please use --natt=false instead")
 	// Errors here are fatal programming errors
 	exitOnError("deprecation error", err)
-	cmd.Flags().BoolVar(&ipsecDebug, "ipsec-debug", false, "Enable IPsec debugging (verbose logging)")
-	cmd.Flags().BoolVar(&submarinerDebug, "subm-debug", false, "Enable Submariner debugging (verbose logging)")
+	cmd.Flags().BoolVar(&ipsecDebug, "ipsec-debug", false, "enable IPsec debugging (verbose logging)")
+	cmd.Flags().BoolVar(&submarinerDebug, "subm-debug", false, "enable Submariner debugging (verbose logging)")
 	err = cmd.Flags().MarkDeprecated("subm-debug", "please use --pod-debug instead")
 	// Errors here are fatal programming errors
 	exitOnError("deprecation error", err)
 	cmd.Flags().BoolVar(&submarinerDebug, "pod-debug", false,
 		"enable Submariner pod debugging (verbose logging in the deployed pods)")
 	cmd.Flags().BoolVar(&submarinerDebug, "enable-pod-debugging", false,
-		"Enable Submariner pod debugging (verbose logging in the deployed pods)")
+		"enable Submariner pod debugging (verbose logging in the deployed pods)")
 	err = cmd.Flags().MarkDeprecated("enable-pod-debugging", "please use --pod-debug instead")
 	// Errors here are fatal programming errors
 	exitOnError("deprecation error", err)
@@ -111,21 +111,21 @@ func addJoinFlags(cmd *cobra.Command) {
 	err = cmd.Flags().MarkDeprecated("no-label", "please use --label-gateway=false instead")
 	// Errors here are fatal programming errors
 	exitOnError("deprecation error", err)
-	cmd.Flags().StringVar(&cableDriver, "cable-driver", "", "Cable driver implementation")
+	cmd.Flags().StringVar(&cableDriver, "cable-driver", "", "cable driver implementation")
 	cmd.Flags().UintVar(&globalnetClusterSize, "globalnet-cluster-size", 0,
-		"Cluster size for GlobalCIDR allocated to this cluster (amount of global IPs)")
+		"cluster size for GlobalCIDR allocated to this cluster (amount of global IPs)")
 	cmd.Flags().StringVar(&globalnetCIDR, "globalnet-cidr", "",
 		"GlobalCIDR to be allocated to the cluster")
 	cmd.Flags().StringSliceVar(&customDomains, "custom-domains", nil,
-		"List of domains to use for multicluster service discovery")
+		"list of domains to use for multicluster service discovery")
 	cmd.Flags().StringSliceVar(&imageOverrideArr, "image-override", nil,
-		"Override component image")
+		"override component image")
 	cmd.Flags().BoolVar(&healthCheckEnable, "health-check", true,
-		"Enable Gateway health check")
+		"enable Gateway health check")
 	cmd.Flags().Uint64Var(&healthCheckInterval, "health-check-interval", 1,
-		"The interval in seconds in which health check packets will be send")
+		"interval in seconds between health check packets")
 	cmd.Flags().Uint64Var(&healthCheckMaxPacketLossCount, "health-check-max-packet-loss-count", 5,
-		"The maximum number of packets lost at which the health checker will mark the connection as down.")
+		"maximum number of packets lost before the connection is marked as down")
 }
 
 const (
@@ -136,7 +136,7 @@ const (
 
 var joinCmd = &cobra.Command{
 	Use:   "join",
-	Short: "connect a cluster to an existing broker",
+	Short: "Connect a cluster to an existing broker",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		err := checkArgumentPassed(args)

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -58,9 +58,11 @@ var (
 	nattPort                      int
 	ikePort                       int
 	colorCodes                    string
+	natTraversal                  bool
 	disableNat                    bool
 	ipsecDebug                    bool
 	submarinerDebug               bool
+	labelGateway                  bool
 	noLabel                       bool
 	cableDriver                   string
 	clienttoken                   *v1.Secret
@@ -87,15 +89,28 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&colorCodes, "colorcodes", submariner.DefaultColorCode, "color codes")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
+	cmd.Flags().BoolVar(&natTraversal, "natt", true, "enable NAT traversal for IPsec")
 	cmd.Flags().BoolVar(&disableNat, "disable-nat", false, "Disable NAT for IPsec")
-	cmd.Flags().BoolVar(&ipsecDebug, "ipsec-debug", false, "Enable IPsec debugging (verbose logging)")
-	cmd.Flags().BoolVar(&submarinerDebug, "subm-debug", false, "Enable Submariner debugging (verbose logging)")
-	err := cmd.Flags().MarkDeprecated("subm-debug", "please use --enable-pod-debugging instead")
+	err := cmd.Flags().MarkDeprecated("disable-nat", "please use --natt=false instead")
 	// Errors here are fatal programming errors
 	exitOnError("deprecation error", err)
+	cmd.Flags().BoolVar(&ipsecDebug, "ipsec-debug", false, "Enable IPsec debugging (verbose logging)")
+	cmd.Flags().BoolVar(&submarinerDebug, "subm-debug", false, "Enable Submariner debugging (verbose logging)")
+	err = cmd.Flags().MarkDeprecated("subm-debug", "please use --pod-debug instead")
+	// Errors here are fatal programming errors
+	exitOnError("deprecation error", err)
+	cmd.Flags().BoolVar(&submarinerDebug, "pod-debug", false,
+		"enable Submariner pod debugging (verbose logging in the deployed pods)")
 	cmd.Flags().BoolVar(&submarinerDebug, "enable-pod-debugging", false,
 		"Enable Submariner pod debugging (verbose logging in the deployed pods)")
+	err = cmd.Flags().MarkDeprecated("enable-pod-debugging", "please use --pod-debug instead")
+	// Errors here are fatal programming errors
+	exitOnError("deprecation error", err)
+	cmd.Flags().BoolVar(&labelGateway, "label-gateway", true, "label gateways if necessary")
 	cmd.Flags().BoolVar(&noLabel, "no-label", false, "skip gateway labeling")
+	err = cmd.Flags().MarkDeprecated("no-label", "please use --label-gateway=false instead")
+	// Errors here are fatal programming errors
+	exitOnError("deprecation error", err)
 	cmd.Flags().StringVar(&cableDriver, "cable-driver", "", "Cable driver implementation")
 	cmd.Flags().UintVar(&globalnetClusterSize, "globalnet-cluster-size", 0,
 		"Cluster size for GlobalCIDR allocated to this cluster (amount of global IPs)")
@@ -214,7 +229,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 	}
 	exitOnError("Unable to check requirements", err)
 
-	if !noLabel {
+	if labelGateway && !noLabel {
 		err := handleNodeLabels(clientConfig)
 		exitOnError("Unable to set the gateway node up", err)
 	}
@@ -445,7 +460,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		BrokerK8sApiServerToken:  string(clienttoken.Data["token"]),
 		BrokerK8sApiServer:       brokerURL,
 		Broker:                   "k8s",
-		NatEnabled:               !disableNat,
+		NatEnabled:               natTraversal && !disableNat,
 		Debug:                    submarinerDebug,
 		ColorCodes:               colorCodes,
 		ClusterID:                clusterID,

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -66,12 +66,12 @@ func init() {
 }
 
 func addVerifyFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&verboseConnectivityVerification, "verbose", false, "Produce verbose logs during connectivity verification")
-	cmd.Flags().UintVar(&operationTimeout, "operation-timeout", 240, "Operation timeout for K8s API calls")
-	cmd.Flags().UintVar(&connectionTimeout, "connection-timeout", 60, "The timeout in seconds per connection attempt ")
-	cmd.Flags().UintVar(&connectionAttempts, "connection-attempts", 2, "The maximum number of connection attempts")
+	cmd.Flags().BoolVar(&verboseConnectivityVerification, "verbose", false, "produce verbose logs during connectivity verification")
+	cmd.Flags().UintVar(&operationTimeout, "operation-timeout", 240, "operation timeout for K8s API calls")
+	cmd.Flags().UintVar(&connectionTimeout, "connection-timeout", 60, "timeout in seconds per connection attempt")
+	cmd.Flags().UintVar(&connectionAttempts, "connection-attempts", 2, "maximum number of connection attempts")
 	cmd.Flags().StringVar(&reportDirectory, "report-dir", ".", "XML report directory")
-	cmd.Flags().StringVar(&submarinerNamespace, "submariner-namespace", "submariner-operator", "Namespace in which submariner is deployed")
+	cmd.Flags().StringVar(&submarinerNamespace, "submariner-namespace", "submariner-operator", "namespace in which submariner is deployed")
 }
 
 var verifyCmd = &cobra.Command{


### PR DESCRIPTION
The help library we use produces default help texts where help for
commands starts with an uppercase letter, but help for options starts
with a lowercase letter:

    $ subctl help
    [...]
      help                Help about any command
    [...]
      -h, --help   help for subctl
    [...]

This patch fixes all our help texts to follow the same convention. 

While we're at it, reword a few options for succinctness, and drop
leading "the".

Signed-off-by: Stephen Kitt <skitt@redhat.com>