### PR TITLE
Log the curl output when testing metrics

### DIFF
--- a/.github/workflows/prometheus.yml
+++ b/.github/workflows/prometheus.yml
@@ -36,5 +36,6 @@ jobs:
 
       - name: Make sure the submariner_gateways metric is exported
         run: >-
+          curl -s --data-urlencode query=submariner_gateways http://localhost:9090/api/v1/query | jq .;
           test "$(curl -s --data-urlencode query=submariner_gateways http://localhost:9090/api/v1/query |
           jq -r '.data.result[0].metric.__name__')" = "submariner_gateways"


### PR DESCRIPTION
If the metric test fails, the output isn't traced which makes it
difficult to determine what happened. This runs the same curl-based
query twice, once piping to jq to pretty-print it and log it, the
second time to actually perform the check.

Signed-off-by: Stephen Kitt <skitt@redhat.com>