### PR TITLE
Detect OVNKubernetes without Cluster Network Operator

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -127,7 +127,8 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 
 	// discovery is performed after Update to avoid storing the discovery in the
 	// struct beyond status
-	if err := r.discoverNetwork(instance); err != nil {
+	clusterNetwork, err := r.discoverNetwork(instance)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -148,7 +149,7 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 
-	if _, err := r.reconcileNetworkPluginSyncerDeployment(instance, reqLogger); err != nil {
+	if _, err := r.reconcileNetworkPluginSyncerDeployment(instance, clusterNetwork, reqLogger); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -306,10 +307,11 @@ func (r *SubmarinerReconciler) reconcileEngineDaemonSet(instance *submopv1a1.Sub
 }
 
 func (r *SubmarinerReconciler) reconcileNetworkPluginSyncerDeployment(instance *submopv1a1.Submariner,
-	reqLogger logr.Logger) (*appsv1.Deployment, error) {
+	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger) (*appsv1.Deployment, error) {
 	// Only OVNKubernetes needs networkplugin-syncer so far
-	if instance.Status.NetworkPlugin == "OVNKubernetes" {
-		return helpers.ReconcileDeployment(instance, newNetworkPluginSyncerDeployment(instance), reqLogger, r.client, r.scheme)
+	if instance.Status.NetworkPlugin == network.OvnKubernetes {
+		return helpers.ReconcileDeployment(instance, newNetworkPluginSyncerDeployment(instance,
+			clusterNetwork), reqLogger, r.client, r.scheme)
 	}
 	return nil, nil
 }

--- a/controllers/submariner/submariner_networkdiscovery.go
+++ b/controllers/submariner/submariner_networkdiscovery.go
@@ -29,7 +29,7 @@ func (r *SubmarinerReconciler) getClusterNetwork(submariner *submopv1a1.Submarin
 	return r.clusterNetwork, err
 }
 
-func (r *SubmarinerReconciler) discoverNetwork(submariner *submopv1a1.Submariner) error {
+func (r *SubmarinerReconciler) discoverNetwork(submariner *submopv1a1.Submariner) (*network.ClusterNetwork, error) {
 	clusterNetwork, err := r.getClusterNetwork(submariner)
 	submariner.Status.ClusterCIDR = getCIDR(
 		"Cluster",
@@ -46,7 +46,7 @@ func (r *SubmarinerReconciler) discoverNetwork(submariner *submopv1a1.Submariner
 	//TODO: globalCIDR allocation if no global CIDR is assigned and enabled.
 	//      currently the clusterNetwork discovers any existing operator setting,
 	//      but that's not really helpful here
-	return err
+	return clusterNetwork, err
 }
 
 func getCIDR(cidrType, currentCIDR string, detectedCIDRs []string) string {

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	v1 "k8s.io/api/core/v1"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -165,26 +164,4 @@ func testDiscoverGenericWith(objects ...runtime.Object) *ClusterNetwork {
 	clusterNet, err := discoverGenericNetwork(clientSet)
 	Expect(err).NotTo(HaveOccurred())
 	return clusterNet
-}
-
-func fakePod(component string, command []string, env []v1.EnvVar) *v1.Pod {
-	return fakePodWithName(component, component, command, env)
-}
-
-func fakePodWithName(name, component string, command []string, env []v1.EnvVar) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: v1meta.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"component": component, "name": component},
-		},
-
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Command: command,
-					Env:     env,
-				},
-			},
-		},
-	}
 }

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -29,10 +29,11 @@ import (
 )
 
 type ClusterNetwork struct {
-	PodCIDRs      []string
-	ServiceCIDRs  []string
-	NetworkPlugin string
-	GlobalCIDR    string
+	PodCIDRs       []string
+	ServiceCIDRs   []string
+	NetworkPlugin  string
+	GlobalCIDR     string
+	PluginSettings map[string]string
 }
 
 func (cn *ClusterNetwork) Show() {
@@ -114,6 +115,11 @@ func networkPluginsDiscovery(dynClient dynamic.Interface, clientSet kubernetes.I
 	canalClusterNet, err := discoverCanalFlannelNetwork(clientSet)
 	if err != nil || canalClusterNet != nil {
 		return canalClusterNet, err
+	}
+
+	ovnClusterNet, err := discoverOvnKubernetesNetwork(clientSet)
+	if err != nil || ovnClusterNet != nil {
+		return ovnClusterNet, err
 	}
 
 	return nil, nil

--- a/pkg/discovery/network/network_suite_test.go
+++ b/pkg/discovery/network/network_suite_test.go
@@ -21,9 +21,49 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestOpenShift4NetworkDiscovery(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Network discovery")
+}
+
+func fakePod(component string, command []string, env []v1.EnvVar) *v1.Pod {
+	return fakePodWithName(component, component, command, env)
+}
+
+func fakePodWithName(name, component string, command []string, env []v1.EnvVar) *v1.Pod {
+	return fakePodWithNamespace("default", name, component, command, env)
+}
+
+func fakePodWithNamespace(namespace, name, component string, command []string, env []v1.EnvVar) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: v1meta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"component": component, "name": component},
+		},
+
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Command: command,
+					Env:     env,
+				},
+			},
+		},
+	}
+}
+
+func fakeService(namespace, name, component string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: v1meta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"component": component, "name": component},
+		},
+		Spec: v1.ServiceSpec{},
+	}
 }

--- a/pkg/discovery/network/ovnkubernetes.go
+++ b/pkg/discovery/network/ovnkubernetes.go
@@ -1,0 +1,79 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ovnKubeService     = "ovnkube-db"
+	OvnNBDB            = "OVN_NBDB"
+	OvnSBDB            = "OVN_SBDB"
+	OvnNBDBDefaultPort = 6641
+	OvnSBDBDefaultPort = 6642
+	OvnKubernetes      = "OVNKubernetes"
+)
+
+func discoverOvnKubernetesNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, error) {
+	ovnDbPod, err := findPod(clientSet, "name=ovnkube-db")
+
+	if err != nil || ovnDbPod == nil {
+		return nil, err
+	}
+
+	if _, err := clientSet.CoreV1().Services(ovnDbPod.Namespace).Get(ovnKubeService, v1.GetOptions{}); err != nil {
+		return nil, fmt.Errorf("error finding %q service in %q namespace", ovnKubeService, ovnDbPod.Namespace)
+	}
+
+	dbConnectionProtocol := "tcp"
+
+	for _, container := range ovnDbPod.Spec.Containers {
+		for _, envVar := range container.Env {
+			if envVar.Name == "OVN_SSL_ENABLE" {
+				if strings.ToUpper(envVar.Value) != "NO" {
+					dbConnectionProtocol = "ssl"
+				}
+			}
+		}
+	}
+
+	clusterNetwork := &ClusterNetwork{
+		NetworkPlugin: OvnKubernetes,
+		PluginSettings: map[string]string{
+			OvnNBDB: fmt.Sprintf("%s:%s.%s:%d", dbConnectionProtocol, ovnKubeService, ovnDbPod.Namespace, OvnNBDBDefaultPort),
+			OvnSBDB: fmt.Sprintf("%s:%s.%s:%d", dbConnectionProtocol, ovnKubeService, ovnDbPod.Namespace, OvnSBDBDefaultPort),
+		},
+	}
+
+	// If the cluster/service CIDRs weren't found we leave it to the generic functions to figure out later
+	if ovnConfig, err := clientSet.CoreV1().ConfigMaps(ovnDbPod.Namespace).Get("ovn-config", v1.GetOptions{}); err == nil {
+		if netCidr, ok := ovnConfig.Data["net_cidr"]; ok {
+			clusterNetwork.PodCIDRs = []string{netCidr}
+		}
+
+		if svcCidr, ok := ovnConfig.Data["svc_cidr"]; ok {
+			clusterNetwork.ServiceCIDRs = []string{svcCidr}
+		}
+	}
+
+	return clusterNetwork, nil
+}

--- a/pkg/discovery/network/ovnkubernetes_test.go
+++ b/pkg/discovery/network/ovnkubernetes_test.go
@@ -1,0 +1,105 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const ovnKubeNamespace = "ovn-kubernetes"
+
+var _ = Describe("discoverOvnKubernetesNetwork", func() {
+	When("ovn-kubernetes can't be found", func() {
+		It("Should return nil cluster network", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterNet).To(BeNil())
+		})
+	})
+
+	const ovnKubeSvcTest = "ovnkube-db"
+	When("ovn-kubernetes database is found, but no database service", func() {
+		It("Should return error", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(clusterNet).To(BeNil())
+		})
+	})
+
+	When("ovn-kubernetes database and service found, no configmap", func() {
+		It("Should return cluster network with empty CIDRs", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
+				fakeService(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest),
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal("OVNKubernetes"))
+			connectionStr := fmt.Sprintf("tcp:%s.%s", ovnKubeSvcTest, ovnKubeNamespace)
+			Expect(clusterNet.PluginSettings["OVN_NBDB"]).To(Equal(connectionStr + ":6641"))
+			Expect(clusterNet.PluginSettings["OVN_SBDB"]).To(Equal(connectionStr + ":6642"))
+			Expect(clusterNet.PodCIDRs).To(HaveLen(0))
+			Expect(clusterNet.ServiceCIDRs).To(HaveLen(0))
+		})
+	})
+
+	When("ovn-kubernetes database, configmap and service found", func() {
+		It("Should return cluster network with empty CIDRs", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
+				fakeService(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest),
+				ovnFakeConfigMap(ovnKubeNamespace, "ovn-config"),
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.PodCIDRs).To(Equal([]string{testPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
+		})
+	})
+})
+
+func testOvnKubernetesDiscoveryWith(objects ...runtime.Object) (*ClusterNetwork, error) {
+	clientSet := fake.NewSimpleClientset(objects...)
+	return discoverOvnKubernetesNetwork(clientSet)
+}
+
+func ovnFakeConfigMap(namespace, name string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: v1meta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{
+			"net_cidr": testPodCIDR,
+			"svc_cidr": testServiceCIDR,
+		},
+	}
+}


### PR DESCRIPTION
When running in kind, and possibly other clusters OVNKubernetes
works standalone and we need to find the details in the system,
so we can pass them down to the other services.

Fixes-Issue: #999

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>