### PR TITLE
fix(subctl): avoid pinning the version and repo to submariners cr

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/submariner-io/submariner-operator/pkg/names"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/deployment"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -48,7 +47,7 @@ func ParseOperatorImage(operatorImage string) (string, string) {
 		version = operatorImage[i+1:]
 	}
 
-	suffix := "/" + deployment.OperatorName
+	suffix := "/" + names.OperatorImage
 	j := strings.LastIndex(repository, suffix)
 	if j != -1 {
 		repository = repository[:j]

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -8,6 +8,7 @@ const (
 	ServiceDiscoveryImage    = "lighthouse-agent"
 	LighthouseCoreDNSImage   = "lighthouse-coredns"
 	ServiceDiscoveryCrName   = "service-discovery"
+	OperatorImage            = "submariner-operator"
 )
 
 var (

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -35,14 +35,13 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/images"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/deployment"
-
 	"k8s.io/client-go/rest"
 
 	submariner "github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
@@ -486,7 +485,7 @@ func operatorImage() string {
 		version = versions.DefaultSubmarinerOperatorVersion
 	}
 
-	return images.GetImagePath(repository, version, deployment.OperatorName, getImageOverrides())
+	return images.GetImagePath(repository, version, names.OperatorImage, getImageOverrides())
 }
 
 func getImageOverrides() map[string]string {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -82,7 +82,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&clusterID, "clusterid", "", "cluster ID used to identify the tunnels")
 	cmd.Flags().StringVar(&serviceCIDR, "servicecidr", "", "service CIDR")
 	cmd.Flags().StringVar(&clusterCIDR, "clustercidr", "", "cluster CIDR")
-	cmd.Flags().StringVar(&repository, "repository", versions.DefaultRepo, "image repository")
+	cmd.Flags().StringVar(&repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&imageVersion, "version", "", "image version")
 	cmd.Flags().StringVar(&colorCodes, "colorcodes", submariner.DefaultColorCode, "color codes")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
@@ -417,14 +417,6 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		brokerURL = brokerURL[(idx + 3):]
 	}
 
-	crImageVersion := imageVersion
-
-	if imageVersion == "" {
-		// Default engine version
-		// This is handled in the operator after 0.0.1 (of the operator)
-		crImageVersion = versions.DefaultSubmarinerVersion
-	}
-
 	// if our network discovery code was capable of discovering those CIDRs
 	// we don't need to explicitly set it in the operator
 	crServiceCIDR := ""
@@ -443,7 +435,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,
-		Version:                  crImageVersion,
+		Version:                  imageVersion,
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             ipsecDebug,
@@ -480,12 +472,17 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 
 func operatorImage() string {
 	version := imageVersion
+	repo := repository
 
 	if imageVersion == "" {
 		version = versions.DefaultSubmarinerOperatorVersion
 	}
 
-	return images.GetImagePath(repository, version, names.OperatorImage, getImageOverrides())
+	if repository == "" {
+		repo = versions.DefaultRepo
+	}
+
+	return images.GetImagePath(repo, version, names.OperatorImage, getImageOverrides())
 }
 
 func getImageOverrides() map[string]string {

--- a/pkg/subctl/cmd/show_versions.go
+++ b/pkg/subctl/cmd/show_versions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/deployment"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -52,14 +51,14 @@ func getSubmarinerVersion(submarinerClient submarinerclientset.Interface, versio
 }
 
 func getOperatorVersion(clientSet kubernetes.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
-	operatorConfig, err := clientSet.AppsV1().Deployments(OperatorNamespace).Get(deployment.OperatorName, v1.GetOptions{})
+	operatorConfig, err := clientSet.AppsV1().Deployments(OperatorNamespace).Get(names.OperatorImage, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	operatorFullImageStr := operatorConfig.Spec.Template.Spec.Containers[0].Image
 	version, repository := images.ParseOperatorImage(operatorFullImageStr)
-	versions = append(versions, newVersionInfoFrom(repository, deployment.OperatorName, version))
+	versions = append(versions, newVersionInfoFrom(repository, names.OperatorImage, version))
 	return versions, nil
 }
 

--- a/pkg/subctl/operator/submarinerop/deployment/ensure.go
+++ b/pkg/subctl/operator/submarinerop/deployment/ensure.go
@@ -17,16 +17,12 @@ limitations under the License.
 package deployment
 
 import (
-	"k8s.io/client-go/rest"
-
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/operatorpod"
-)
-
-const (
-	OperatorName = "submariner-operator"
+	"k8s.io/client-go/rest"
 )
 
 // Ensure the operator is deployed, and running
 func Ensure(restConfig *rest.Config, namespace, image string) (bool, error) {
-	return operatorpod.Ensure(restConfig, namespace, OperatorName, image)
+	return operatorpod.Ensure(restConfig, namespace, names.OperatorImage, image)
 }


### PR DESCRIPTION
`subctl join` will not add the repository and version properties to submariners
CR but instead these default values will be set by the operator.
For instance when using a custom operator image
or when running `subctl show versions`.

Signed-off-by: Steve Mattar <smattar@redhat.com>