### PR TITLE
Add upgrade tests to flake finder

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -37,3 +37,29 @@ jobs:
           df -h
           free -h
           make post-mortem
+  upgrade-e2e:
+    name: Latest Release to Latest Version
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Reclaim free space!
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          df -h
+          free -h
+
+      - name: Install an old cluster, upgrade it and check it
+        run: |
+          make upgrade-e2e
+
+      - name: Post Mortem
+        if: failure()
+        run: |
+          df -h
+          free -h
+          make post-mortem

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Reclaim free space!
+      - name: Reclaim free space
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -57,7 +57,7 @@ jobs:
         run: |
           make upgrade-e2e
 
-      - name: Post Mortem
+      - name: Post mortem
         if: failure()
         run: |
           df -h

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Reclaim free space!
+      - name: Reclaim free space
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -25,7 +25,7 @@ jobs:
         run: |
           make upgrade-e2e
 
-      - name: Post Mortem
+      - name: Post mortem
         if: failure()
         run: |
           df -h


### PR DESCRIPTION
Per discussions on the Automation Sync yesterday, run upgrade tests
periodically against the main branch to find and highlight any
instability. Run in the Flake Finder GHA workflow to better track
results, make spotting unexpected failures easier.