### PR TITLE
fix(subctl): image-override will override the version and repository properties

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -454,7 +454,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 	}
 
 	submarinerSpec := submariner.SubmarinerSpec{
-		Repository:               repository,
+		Repository:               getImageRepo(),
 		Version:                  getImageVersion(),
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
@@ -503,6 +503,21 @@ func getImageVersion() string {
 	}
 
 	return version
+}
+
+func getImageRepo() string {
+	imageOverrides := getImageOverrides()
+	repo := repository
+
+	if repository == "" {
+		repo = versions.DefaultRepo
+	}
+
+	if override, ok := imageOverrides[names.OperatorImage]; ok {
+		_, repo = images.ParseOperatorImage(override)
+	}
+
+	return repo
 }
 
 func operatorImage() string {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -455,7 +455,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,
-		Version:                  imageVersion,
+		Version:                  getImageVersion(),
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             ipsecDebug,
@@ -488,6 +488,21 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		submarinerSpec.CustomDomains = customDomains
 	}
 	return submarinerSpec
+}
+
+func getImageVersion() string {
+	imageOverrides := getImageOverrides()
+	version := imageVersion
+
+	if imageVersion == "" {
+		version = versions.DefaultSubmarinerOperatorVersion
+	}
+
+	if override, ok := imageOverrides[names.OperatorImage]; ok {
+		version, _ = images.ParseOperatorImage(override)
+	}
+
+	return version
 }
 
 func operatorImage() string {


### PR DESCRIPTION
Update the version and repository properties in the submariner spec when using image-override.

Closes #1021

Signed-off-by: Steve Mattar <smattar@redhat.com>