### PR TITLE
Allow service to be deployed without connectivity

### DIFF
--- a/apis/submariner/v1alpha1/servicediscovery_types.go
+++ b/apis/submariner/v1alpha1/servicediscovery_types.go
@@ -85,4 +85,9 @@ func (serviceDiscovery *ServiceDiscovery) SetDefaults() {
 	if serviceDiscovery.Spec.Version == "" {
 		serviceDiscovery.Spec.Version = versions.DefaultLighthouseVersion
 	}
+
+	if serviceDiscovery.Spec.Repository == "" {
+		// An empty field is converted to the default upstream submariner repository where all images live
+		serviceDiscovery.Spec.Repository = versions.DefaultRepo
+	}
 }

--- a/apis/submariner/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/submariner/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -43,6 +43,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/servicediscoverycr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
 	"github.com/submariner-io/submariner-operator/pkg/versions"
@@ -232,7 +233,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 	}
 	exitOnError("Unable to check requirements", err)
 
-	if labelGateway && !noLabel {
+	if subctlData.IsConnectivityEnabled() && labelGateway && !noLabel {
 		err := handleNodeLabels(clientConfig)
 		exitOnError("Unable to set the gateway node up", err)
 	}
@@ -277,16 +278,30 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 	status.End(cli.CheckForError(err))
 	exitOnError("Error creating SA for cluster", err)
 
-	status.Start("Deploying Submariner")
-	err = submarinercr.Ensure(clientConfig, OperatorNamespace, populateSubmarinerSpec(subctlData, netconfig))
-	if err == nil {
-		status.QueueSuccessMessage("Submariner is up and running")
-		status.End(cli.Success)
-	} else {
-		status.QueueFailureMessage("Submariner deployment failed")
-		status.End(cli.Failure)
+	if subctlData.IsConnectivityEnabled() {
+		status.Start("Deploying Submariner")
+		err = submarinercr.Ensure(clientConfig, OperatorNamespace, populateSubmarinerSpec(subctlData, netconfig))
+		if err == nil {
+			status.QueueSuccessMessage("Submariner is up and running")
+			status.End(cli.Success)
+		} else {
+			status.QueueFailureMessage("Submariner deployment failed")
+			status.End(cli.Failure)
+		}
+
+		exitOnError("Error deploying Submariner", err)
+	} else if subctlData.IsServiceDiscoveryEnabled() {
+		status.Start("Deploying service discovery only")
+		err = servicediscoverycr.Ensure(clientConfig, OperatorNamespace, populateServiceDiscoverySpec(subctlData))
+		if err == nil {
+			status.QueueSuccessMessage("Service discovery is up an running")
+			status.End(cli.Success)
+		} else {
+			status.QueueFailureMessage("Service discovery deployment failed")
+			status.End(cli.Failure)
+		}
+		exitOnError("Error deploying service discovery", err)
 	}
-	exitOnError("Error deploying Submariner", err)
 }
 
 func checkRequirements(config *rest.Config) ([]string, error) {
@@ -473,7 +488,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		ClusterCIDR:              crClusterCIDR,
 		Namespace:                SubmarinerNamespace,
 		CableDriver:              cableDriver,
-		ServiceDiscoveryEnabled:  subctlData.ServiceDiscovery,
+		ServiceDiscoveryEnabled:  subctlData.IsServiceDiscoveryEnabled(),
 		ImageOverrides:           getImageOverrides(),
 		ConnectionHealthCheck: &submariner.HealthCheckSpec{
 			Enabled:            healthCheckEnable,
@@ -488,6 +503,41 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		submarinerSpec.CustomDomains = customDomains
 	}
 	return submarinerSpec
+}
+
+func removeSchemaPrefix(brokerURL string) string {
+	if idx := strings.Index(brokerURL, "://"); idx >= 0 {
+		// Submariner doesn't work with a schema prefix
+		brokerURL = brokerURL[(idx + 3):]
+	}
+
+	return brokerURL
+}
+
+func populateServiceDiscoverySpec(subctlData *datafile.SubctlData) submariner.ServiceDiscoverySpec {
+	brokerURL := removeSchemaPrefix(subctlData.BrokerURL)
+
+	if customDomains == nil && subctlData.CustomDomains != nil {
+		customDomains = *subctlData.CustomDomains
+	}
+
+	serviceDiscoverySpec := submariner.ServiceDiscoverySpec{
+		Repository:               repository,
+		Version:                  imageVersion,
+		BrokerK8sCA:              base64.StdEncoding.EncodeToString(subctlData.ClientToken.Data["ca.crt"]),
+		BrokerK8sRemoteNamespace: string(subctlData.ClientToken.Data["namespace"]),
+		BrokerK8sApiServerToken:  string(clienttoken.Data["token"]),
+		BrokerK8sApiServer:       brokerURL,
+		Debug:                    submarinerDebug,
+		ClusterID:                clusterID,
+		Namespace:                SubmarinerNamespace,
+		ImageOverrides:           getImageOverrides(),
+	}
+
+	if len(customDomains) > 0 {
+		serviceDiscoverySpec.CustomDomains = customDomains
+	}
+	return serviceDiscoverySpec
 }
 
 func operatorImage() string {

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -34,6 +34,7 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
@@ -222,8 +223,8 @@ func checkVerifyArguments() error {
 }
 
 var verifyE2EPatterns = map[string]string{
-	"connectivity":      "\\[dataplane",
-	"service-discovery": "\\[discovery",
+	components.Connectivity:     "\\[dataplane",
+	components.ServiceDiscovery: "\\[discovery",
 }
 
 var verifyE2EDisruptivePatterns = map[string]string{

--- a/pkg/subctl/components/consts.go
+++ b/pkg/subctl/components/consts.go
@@ -1,0 +1,6 @@
+package components
+
+const (
+	Connectivity     = "connectivity"
+	ServiceDiscovery = "service-discovery"
+)

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -24,26 +24,47 @@ import (
 	"io/ioutil"
 	"net/url"
 
+	"github.com/submariner-io/admiral/pkg/stringset"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/broker"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
+
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 )
 
 type SubctlData struct {
-	BrokerURL        string     `json:"brokerURL"`
-	ClientToken      *v1.Secret `omitempty,json:"clientToken"`
-	IPSecPSK         *v1.Secret `omitempty,json:"ipsecPSK"`
-	ServiceDiscovery bool       `omitempty,json:"serviceDiscovery"`
-	CustomDomains    *[]string  `omitempty,json:"customDomains"`
+	BrokerURL   string     `json:"brokerURL"`
+	ClientToken *v1.Secret `omitempty,json:"clientToken"`
+	IPSecPSK    *v1.Secret `omitempty,json:"ipsecPSK"`
+	// TODO (remove): ServiceDiscovery flag is now deprecated, it's keep in the file for consistency and backwards compatibility
+	ServiceDiscovery bool      `omitempty,json:"serviceDiscovery"`
+	components       []string  `omitempty,json:"components"`
+	CustomDomains    *[]string `omitempty,json:"customDomains"`
 	// Todo (revisit): The following values are moved from the broker-info.subm file to configMap
 	// on the Broker. This needs to be revisited to support seamless upgrades.
 	// https://github.com/submariner-io/submariner-operator/issues/504
 	// GlobalnetCidrRange   string `omitempty,json:"globalnetCidrRange"`
 	// GlobalnetClusterSize uint   `omitempty,json:"globalnetClusterSize"`
+}
+
+func (data *SubctlData) SetComponents(componentSet stringset.Interface) {
+	data.components = componentSet.Elements()
+}
+
+func (data *SubctlData) Components() stringset.Interface {
+	return stringset.New(data.components...)
+}
+
+func (data *SubctlData) IsConnectivityEnabled() bool {
+	return data.Components().Contains(components.Connectivity)
+}
+
+func (data *SubctlData) IsServiceDiscoveryEnabled() bool {
+	return data.Components().Contains(components.ServiceDiscovery) || data.ServiceDiscovery
 }
 
 func (data *SubctlData) ToString() (string, error) {

--- a/pkg/subctl/operator/servicediscoverycr/ensure.go
+++ b/pkg/subctl/operator/servicediscoverycr/ensure.go
@@ -1,0 +1,78 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicediscoverycr
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+
+	submariner "github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+)
+
+const (
+	ServiceDiscoveryName = "service-discovery"
+)
+
+func Ensure(config *rest.Config, namespace string, serviceDiscoverySpec submariner.ServiceDiscoverySpec) error {
+	serviceDiscoveryCR := &submariner.ServiceDiscovery{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ServiceDiscoveryName,
+		},
+		Spec: serviceDiscoverySpec,
+	}
+
+	submarinerClient, err := submarinerclientset.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = createServiceDiscovery(submarinerClient, namespace, serviceDiscoveryCR)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createServiceDiscovery(clientSet submarinerclientset.Interface, namespace string, serviceDiscoveryCR *submariner.ServiceDiscovery) (
+	bool, error) {
+	_, err := clientSet.SubmarinerV1alpha1().ServiceDiscoveries(namespace).Create(serviceDiscoveryCR)
+	if err == nil {
+		return true, nil
+	} else if errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// We can’t always handle existing resources, and we want to overwrite them anyway, so delete them
+			err := clientSet.SubmarinerV1alpha1().ServiceDiscoveries(namespace).Delete(serviceDiscoveryCR.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to delete pre-existing cfg %s : %s", serviceDiscoveryCR.Name, err)
+			}
+			_, err = clientSet.SubmarinerV1alpha1().ServiceDiscoveries(namespace).Create(serviceDiscoveryCR)
+			if err != nil {
+				return fmt.Errorf("failed to create cfg  %s : %s", serviceDiscoveryCR.Name, err)
+			}
+			return nil
+		})
+		return false, retryErr
+	}
+	return false, err
+}


### PR DESCRIPTION
This cover the use case of routed networks where pods and
services can already talk to remote clusters by other means
and the submariner routing and gateways are not required,
but service discovery is necessary.


Continues in: https://github.com/submariner-io/submariner-operator/pull/1087  , sorry for the mess, I deleted the original branch by error.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
