### PR TITLE
Reconcile ServiceDiscovery before status updates

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -158,6 +158,10 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	if err := r.serviceDiscoveryReconciler(instance, reqLogger, instance.Spec.ServiceDiscoveryEnabled); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Retrieve the gateway information
 	gateways, err := r.retrieveGateways(instance, request.Namespace)
 	if err != nil {
@@ -216,9 +220,6 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 
-	if err := r.serviceDiscoveryReconciler(instance, reqLogger, instance.Spec.ServiceDiscoveryEnabled); err != nil {
-		return reconcile.Result{}, err
-	}
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Currently ServiceDiscovery reconciler runs after Status reconcilers.
This can delay service discovery bring up and bugs in status reconciler
can even block service discovery bring up.

Reconcile service discovery alongwith other submariner components,
before statuses.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>