### PR TITLE
Log status update errors without failing

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -216,7 +216,10 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		err := r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			reqLogger.Error(err, "failed to update the Submariner status")
-			return reconcile.Result{}, err
+			// Log the error, but indicate success, to avoid reconciliation storms
+			// TODO skitt determine what we should really be doing for concurrent updates to the Submariner CR
+			// Updates fail here because the instance is updated between the .Update() at the start of the function
+			// and the status update here
 		}
 	}
 


### PR DESCRIPTION
On OpenShift, we’re seeing reconciliation loops with continuous errors
when updating the status. To avoid this (temporarily), only log the
error, and indicate success; the status should end up being updated at
some point...

Signed-off-by: Stephen Kitt <skitt@redhat.com>