### PR TITLE
[release-0.8] Backports for 0.8.1

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
+          base-branch: ${{ github.base_ref }}
 
   markdownlint:
     name: Markdown

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,17 @@ on:
   pull_request:
 
 jobs:
+  crds:
+    name: CRDs up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Run make manifests to update CRDs
+        run: make manifests
+      - name: Validate that nothing has changed
+        run: git add -A && git diff --staged --exit-code
+
   dco:
     name: DCO in Commit Message(s)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release-*
 
 jobs:
   e2e:
@@ -51,5 +52,5 @@ jobs:
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          RELEASE_ARGS: submariner-operator
-        run: make release
+        # Pass RELEASE_ARGS on the call, since GITHUB_REF set in the `env` directive doesn't get properly expanded
+        run: make release RELEASE_ARGS="submariner-operator --tag '${GITHUB_REF##*/}'"

--- a/apis/submariner/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/submariner/v1alpha1/zz_generated.deepcopy.go
@@ -2,7 +2,7 @@
 
 /*
 
-© 2020 Red Hat, Inc. and others.
+© 2021 Red Hat, Inc. and others.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -57,26 +57,26 @@ spec:
       name: submariners.submariner.io
       version: v1alpha1
   description: |
-    [Submariner](https://submariner-io) enables direct networking between Pods and Services in different Kubernetes
+    [Submariner](https://submariner.io) enables direct networking between Pods and Services in different Kubernetes
     clusters. With Submariner, your applications and services can span multiple cloud providers, data centers, and regions.
 
     Submariner is designed to be cloud provider and network plugin (CNI) agnostic.
 
     Submariner consists of several main components that work in conjunction to securely connect workloads across
     multiple Kubernetes clusters, both on-premise and on public clouds:
-    * [Gateway Engine](https://submariner.io/architecture/gateway-engine/): manages the secure tunnels to other clusters.
-    * [Route Agent](https://submariner.io/architecture/route-agent/): routes cross-cluster traffic from nodes
+    * [Gateway Engine](https://submariner.io/getting-started/architecture/gateway-engine/): manages the secure tunnels to other clusters.
+    * [Route Agent](https://submariner.io/getting-started/architecture/route-agent/): routes cross-cluster traffic from nodes
     to the active Gateway Engine.
-    * [Broker](https://submariner.io/architecture/broker/): facilitates the exchange of metadata between Gateway
+    * [Broker](https://submariner.io/getting-started/architecture/broker/): facilitates the exchange of metadata between Gateway
     Engines enabling them to discover one another.
 
     Submariner has optional components that provide additional functionality:
-    * [Globalnet Controller](https://submariner.io/architecture/globalnet/): handles overlapping CIDRs across clusters.
-    * [Service Discovery](https://submariner.io/architecture/service-discovery/): provides DNS discovery of services
+    * [Globalnet Controller](https://submariner.io/getting-started/architecture/globalnet/): handles overlapping CIDRs across clusters.
+    * [Service Discovery](https://submariner.io/getting-started/architecture/service-discovery/): provides DNS discovery of services
     across clusters.
 
     ### Prerequisites
-    Submariner has a few requirements to get started, all are documented [here](https://submariner.io/quickstart/#prerequisites).
+    Submariner has a few requirements to get started, all are documented [here](https://submariner.io/getting-started/quickstart/kind/#prerequisites).
 
     ### Deployment
     Submariner provides an [Operator](https://github.com/submariner-io/submariner-operator) for easy API-based
@@ -84,8 +84,8 @@ spec:
     A command line utility, [subctl](https://github.com/submariner-io/submariner-operator/releases), wraps the
     Operator to aid users with manual deployments and easy experimentation.
     subctl greatly simplifies the deployment of Submariner, and is therefore the recommended deployment method.
-    For complete information about subctl, please refer to [this page](https://submariner.io/deployment/subctl).
-    In addition to Operator and subctl, Submariner also provides [Helm Charts](https://submariner.io/deployment/helm).
+    For complete information about subctl, please refer to [this page](https://submariner.io/operations/deployment/subctl).
+    In addition to Operator and subctl, Submariner also provides [Helm Charts](https://submariner.io/operations/deployment/helm).
 
     #### Deploying with subctl
     Install the tool:
@@ -102,7 +102,7 @@ spec:
 
     `subctl join --kubeconfig <PATH-TO-JOINING-CLUSTER> broker-info.subm --clusterid <ID>`
 
-    More information can be found [here](https://submariner.io/deployment/subctl).
+    More information can be found [here](https://submariner.io/operations/deployment/subctl).
 
     Submariner is deployed using the Submariner CR. The following values can be specified:
     * **namespace**: the namespace to install in;

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -295,26 +295,6 @@ spec:
                             - public_ip
                             - subnets
                             type: object
-                          latency:
-                            description: LatencySpec describes the round trip time information in nanoseconds for a packet between the gateway pods of two clusters.
-                            properties:
-                              averageRTT:
-                                format: int64
-                                type: integer
-                              lastRTT:
-                                description: TODO This shall be deleted once the operator is using the latest. Using Optional to avoid validation errors when this field is not used.
-                                format: int64
-                                type: integer
-                              maxRTT:
-                                format: int64
-                                type: integer
-                              minRTT:
-                                format: int64
-                                type: integer
-                              stddevRTT:
-                                format: int64
-                                type: integer
-                            type: object
                           latencyRTT:
                             description: LatencySpec describes the round trip time information for a packet between the gateway pods of two clusters.
                             properties:

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -334,30 +334,6 @@ spec:
                             - public_ip
                             - subnets
                             type: object
-                          latency:
-                            description: LatencySpec describes the round trip time
-                              information in nanoseconds for a packet between the
-                              gateway pods of two clusters.
-                            properties:
-                              averageRTT:
-                                format: int64
-                                type: integer
-                              lastRTT:
-                                description: TODO This shall be deleted once the operator
-                                  is using the latest. Using Optional to avoid validation
-                                  errors when this field is not used.
-                                format: int64
-                                type: integer
-                              maxRTT:
-                                format: int64
-                                type: integer
-                              minRTT:
-                                format: int64
-                                type: integer
-                              stddevRTT:
-                                format: int64
-                                type: integer
-                            type: object
                           latencyRTT:
                             description: LatencySpec describes the round trip time
                               information for a packet between the gateway pods of

--- a/config/manifests/bases/submariner.clusterserviceversion.yaml
+++ b/config/manifests/bases/submariner.clusterserviceversion.yaml
@@ -18,26 +18,26 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}
   description: |
-    [Submariner](https://submariner-io) enables direct networking between Pods and Services in different Kubernetes
+    [Submariner](https://submariner.io) enables direct networking between Pods and Services in different Kubernetes
     clusters. With Submariner, your applications and services can span multiple cloud providers, data centers, and regions.
 
     Submariner is designed to be cloud provider and network plugin (CNI) agnostic.
 
     Submariner consists of several main components that work in conjunction to securely connect workloads across
     multiple Kubernetes clusters, both on-premise and on public clouds:
-    * [Gateway Engine](https://submariner.io/architecture/gateway-engine/): manages the secure tunnels to other clusters.
-    * [Route Agent](https://submariner.io/architecture/route-agent/): routes cross-cluster traffic from nodes
+    * [Gateway Engine](https://submariner.io/getting-started/architecture/gateway-engine/): manages the secure tunnels to other clusters.
+    * [Route Agent](https://submariner.io/getting-started/architecture/route-agent/): routes cross-cluster traffic from nodes
     to the active Gateway Engine.
-    * [Broker](https://submariner.io/architecture/broker/): facilitates the exchange of metadata between Gateway
+    * [Broker](https://submariner.io/getting-started/architecture/broker/): facilitates the exchange of metadata between Gateway
     Engines enabling them to discover one another.
 
     Submariner has optional components that provide additional functionality:
-    * [Globalnet Controller](https://submariner.io/architecture/globalnet/): handles overlapping CIDRs across clusters.
-    * [Service Discovery](https://submariner.io/architecture/service-discovery/): provides DNS discovery of services
+    * [Globalnet Controller](https://submariner.io/getting-started/architecture/globalnet/): handles overlapping CIDRs across clusters.
+    * [Service Discovery](https://submariner.io/getting-started/architecture/service-discovery/): provides DNS discovery of services
     across clusters.
 
     ### Prerequisites
-    Submariner has a few requirements to get started, all are documented [here](https://submariner.io/quickstart/#prerequisites).
+    Submariner has a few requirements to get started, all are documented [here](https://submariner.io/getting-started/quickstart/kind/#prerequisites).
 
     ### Deployment
     Submariner provides an [Operator](https://github.com/submariner-io/submariner-operator) for easy API-based
@@ -45,8 +45,8 @@ spec:
     A command line utility, [subctl](https://github.com/submariner-io/submariner-operator/releases), wraps the
     Operator to aid users with manual deployments and easy experimentation.
     subctl greatly simplifies the deployment of Submariner, and is therefore the recommended deployment method.
-    For complete information about subctl, please refer to [this page](https://submariner.io/deployment/subctl).
-    In addition to Operator and subctl, Submariner also provides [Helm Charts](https://submariner.io/deployment/helm).
+    For complete information about subctl, please refer to [this page](https://submariner.io/operations/deployment/subctl).
+    In addition to Operator and subctl, Submariner also provides [Helm Charts](https://submariner.io/operations/deployment/helm).
 
     #### Deploying with subctl
     Install the tool:
@@ -63,7 +63,7 @@ spec:
 
     `subctl join --kubeconfig <PATH-TO-JOINING-CLUSTER> broker-info.subm --clusterid <ID>`
 
-    More information can be found [here](https://submariner.io/deployment/subctl).
+    More information can be found [here](https://submariner.io/operations/deployment/subctl).
 
     Submariner is deployed using the Submariner CR. The following values can be specified:
     * **namespace**: the namespace to install in;

--- a/controllers/helpers/helpers.go
+++ b/controllers/helpers/helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	errorutil "github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/pkg/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,4 +204,12 @@ func ReconcileService(owner metav1.Object, service *corev1.Service, reqLogger lo
 	}
 
 	return service, errorutil.WithMessagef(err, "error creating or updating Service %s/%s", service.Namespace, service.Name)
+}
+
+func GetPullPolicy(version, override string) corev1.PullPolicy {
+	if len(override) > 0 {
+		tag := strings.Split(override, ":")[1]
+		return images.GetPullPolicy(tag)
+	}
+	return images.GetPullPolicy(version)
 }

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -279,6 +279,9 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 							Name:            lighthouseCoreDNSName,
 							Image:           getImagePath(cr, names.LighthouseCoreDNSImage),
 							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSImage]),
+							Env: []corev1.EnvVar{
+								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
+							},
 							Args: []string{
 								"-conf",
 								"/etc/coredns/Corefile",

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -192,7 +192,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery) *appsv1.Deploym
 						{
 							Name:            "submariner-lighthouse-agent",
 							Image:           getImagePath(cr, names.ServiceDiscoveryImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.ServiceDiscoveryImage]),
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
@@ -278,7 +278,7 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 						{
 							Name:            lighthouseCoreDNSName,
 							Image:           getImagePath(cr, names.LighthouseCoreDNSImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSImage]),
 							Args: []string{
 								"-conf",
 								"/etc/coredns/Corefile",

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -47,6 +47,7 @@ const (
 	lighthouseForwardPluginName   = "lighthouse"
 	coreDNSNamespace              = "kube-system"
 	coreDNSName                   = "coredns"
+	customCoreDNSName             = "coredns-custom"
 )
 
 // NewReconciler returns a new ServiceDiscoveryReconciler
@@ -140,7 +141,14 @@ func (r *ServiceDiscoveryReconciler) Reconcile(request reconcile.Request) (recon
 			return reconcile.Result{}, err
 		}
 	}
-	err = updateDNSConfigMap(r.client, r.k8sClientSet, instance, reqLogger)
+	err = updateDNSCustomConfigMap(r.client, r.k8sClientSet, instance, reqLogger)
+	if errors.IsNotFound(err) {
+		err = updateDNSConfigMap(r.client, r.k8sClientSet, instance, reqLogger)
+	} else if err != nil {
+		reqLogger.Error(err, "Error updating the 'custom-coredns' ConfigMap")
+		return reconcile.Result{}, err
+	}
+
 	if errors.IsNotFound(err) {
 		// Try to update Openshift-DNS
 		return reconcile.Result{}, updateOpenshiftClusterDNSOperator(instance, r.client, r.operatorClientSet, reqLogger)
@@ -331,6 +339,39 @@ func newLighthouseCoreDNSService(cr *submarinerv1alpha1.ServiceDiscovery) *corev
 			},
 		},
 	}
+}
+
+func updateDNSCustomConfigMap(client controllerClient.Client, k8sclientSet clientset.Interface, cr *submarinerv1alpha1.ServiceDiscovery,
+	reqLogger logr.Logger) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		configMap, err := k8sclientSet.CoreV1().ConfigMaps(coreDNSNamespace).Get(customCoreDNSName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		lighthouseDnsService := &corev1.Service{}
+		err = client.Get(context.TODO(), types.NamespacedName{Name: lighthouseCoreDNSName, Namespace: cr.Namespace}, lighthouseDnsService)
+		lighthouseClusterIp := lighthouseDnsService.Spec.ClusterIP
+		if err != nil || lighthouseClusterIp == "" {
+			return goerrors.New("lighthouseDnsService ClusterIp should be available")
+		}
+
+		if _, ok := configMap.Data["lighthouse.server"]; ok {
+			reqLogger.Info("Overwriting existing lighthouse.server data in coredns-custom")
+		}
+
+		coreFile := ""
+		for _, domain := range append([]string{"clusterset.local"}, cr.Spec.CustomDomains...) {
+			coreFile = fmt.Sprintf("%s%s:53 {\n    forward . %s\n}\n",
+				coreFile, domain, lighthouseClusterIp)
+		}
+		log.Info("Updated coredns-custom ConfigMap for lighthouse.server" + coreFile)
+		configMap.Data["lighthouse.server"] = coreFile
+		// Potentially retried
+		_, err = k8sclientSet.CoreV1().ConfigMaps(coreDNSNamespace).Update(configMap)
+		return err
+	})
+	return retryErr
 }
 
 func updateDNSConfigMap(client controllerClient.Client, k8sclientSet clientset.Interface, cr *submarinerv1alpha1.ServiceDiscovery,

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -356,8 +356,13 @@ func updateDNSCustomConfigMap(client controllerClient.Client, k8sclientSet clien
 			return goerrors.New("lighthouseDnsService ClusterIp should be available")
 		}
 
+		if configMap.Data == nil {
+			reqLogger.Info("Initializing configMap.Data in " + customCoreDNSName)
+			configMap.Data = make(map[string]string)
+		}
+
 		if _, ok := configMap.Data["lighthouse.server"]; ok {
-			reqLogger.Info("Overwriting existing lighthouse.server data in coredns-custom")
+			reqLogger.Info("Overwriting existing lighthouse.server data in " + customCoreDNSName)
 		}
 
 		coreFile := ""
@@ -365,7 +370,7 @@ func updateDNSCustomConfigMap(client controllerClient.Client, k8sclientSet clien
 			coreFile = fmt.Sprintf("%s%s:53 {\n    forward . %s\n}\n",
 				coreFile, domain, lighthouseClusterIp)
 		}
-		log.Info("Updated coredns-custom ConfigMap for lighthouse.server" + coreFile)
+		log.Info("Updating coredns-custom ConfigMap for lighthouse.server: " + coreFile)
 		configMap.Data["lighthouse.server"] = coreFile
 		// Potentially retried
 		_, err = k8sclientSet.CoreV1().ConfigMaps(coreDNSNamespace).Update(configMap)

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -547,6 +547,11 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 						{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
 						{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(healthCheckInterval, 10)},
 						{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(healthCheckMaxPacketLossCount, 10)},
+						{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "spec.nodeName",
+							},
+						}},
 					},
 				},
 			},

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -521,7 +521,7 @@ func newEnginePodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 				{
 					Name:            "submariner",
 					Image:           getImagePath(cr, names.EngineImage),
-					ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+					ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.EngineImage]),
 					Command:         []string{"submariner.sh"},
 					SecurityContext: &security_context_all_caps_privileged,
 					VolumeMounts: []corev1.VolumeMount{
@@ -630,7 +630,7 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 						{
 							Name:            "submariner-routeagent",
 							Image:           getImagePath(cr, names.RouteAgentImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.RouteAgentImage]),
 							// FIXME: Should be entrypoint script, find/use correct file for routeagent
 							Command:         []string{"submariner-route-agent.sh"},
 							SecurityContext: &security_context_all_cap_allow_escal,
@@ -710,7 +710,7 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 						{
 							Name:            "submariner-globalnet",
 							Image:           getImagePath(cr, names.GlobalnetImage),
-							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GlobalnetImage]),
 							SecurityContext: &security_context_all_cap_allow_escal,
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "host-slash", MountPath: "/host", ReadOnly: true},

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -153,6 +153,10 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	if err := r.serviceDiscoveryReconciler(instance, reqLogger, instance.Spec.ServiceDiscoveryEnabled); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Retrieve the gateway information
 	gateways, err := r.retrieveGateways(instance, request.Namespace)
 	if err != nil {
@@ -209,9 +213,6 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 
-	if err := r.serviceDiscoveryReconciler(instance, reqLogger, instance.Spec.ServiceDiscoveryEnabled); err != nil {
-		return reconcile.Result{}, err
-	}
 	return reconcile.Result{}, nil
 }
 

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -722,6 +722,11 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
 								{Name: "SUBMARINER_EXCLUDENS", Value: "submariner-operator,kube-system,operators,openshift-monitoring,openshift-dns"},
+								{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "spec.nodeName",
+									},
+								}},
 							},
 						},
 					},

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -209,7 +209,10 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		err := r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			reqLogger.Error(err, "failed to update the Submariner status")
-			return reconcile.Result{}, err
+			// Log the error, but indicate success, to avoid reconciliation storms
+			// TODO skitt determine what we should really be doing for concurrent updates to the Submariner CR
+			// Updates fail here because the instance is updated between the .Update() at the start of the function
+			// and the status update here
 		}
 	}
 

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -127,7 +127,8 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 
 	// discovery is performed after Update to avoid storing the discovery in the
 	// struct beyond status
-	if err := r.discoverNetwork(instance); err != nil {
+	clusterNetwork, err := r.discoverNetwork(instance)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -148,7 +149,7 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 
-	if _, err := r.reconcileNetworkPluginSyncerDeployment(instance, reqLogger); err != nil {
+	if _, err := r.reconcileNetworkPluginSyncerDeployment(instance, clusterNetwork, reqLogger); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -306,10 +307,11 @@ func (r *SubmarinerReconciler) reconcileEngineDaemonSet(instance *submopv1a1.Sub
 }
 
 func (r *SubmarinerReconciler) reconcileNetworkPluginSyncerDeployment(instance *submopv1a1.Submariner,
-	reqLogger logr.Logger) (*appsv1.Deployment, error) {
+	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger) (*appsv1.Deployment, error) {
 	// Only OVNKubernetes needs networkplugin-syncer so far
-	if instance.Status.NetworkPlugin == "OVNKubernetes" {
-		return helpers.ReconcileDeployment(instance, newNetworkPluginSyncerDeployment(instance), reqLogger, r.client, r.scheme)
+	if instance.Status.NetworkPlugin == network.OvnKubernetes {
+		return helpers.ReconcileDeployment(instance, newNetworkPluginSyncerDeployment(instance,
+			clusterNetwork), reqLogger, r.client, r.scheme)
 	}
 	return nil, nil
 }

--- a/controllers/submariner/submariner_networkdiscovery.go
+++ b/controllers/submariner/submariner_networkdiscovery.go
@@ -29,7 +29,7 @@ func (r *SubmarinerReconciler) getClusterNetwork(submariner *submopv1a1.Submarin
 	return r.clusterNetwork, err
 }
 
-func (r *SubmarinerReconciler) discoverNetwork(submariner *submopv1a1.Submariner) error {
+func (r *SubmarinerReconciler) discoverNetwork(submariner *submopv1a1.Submariner) (*network.ClusterNetwork, error) {
 	clusterNetwork, err := r.getClusterNetwork(submariner)
 	submariner.Status.ClusterCIDR = getCIDR(
 		"Cluster",
@@ -46,7 +46,7 @@ func (r *SubmarinerReconciler) discoverNetwork(submariner *submopv1a1.Submariner
 	//TODO: globalCIDR allocation if no global CIDR is assigned and enabled.
 	//      currently the clusterNetwork discovers any existing operator setting,
 	//      but that's not really helpful here
-	return err
+	return clusterNetwork, err
 }
 
 func getCIDR(cidrType, currentCIDR string, detectedCIDRs []string) string {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/admiral v0.8.0
-	github.com/submariner-io/lighthouse v0.8.0
+	github.com/submariner-io/lighthouse v0.8.1-0.20201222110455-4924193f35b4
 	github.com/submariner-io/shipyard v0.8.0
 	github.com/submariner-io/submariner v0.8.0
 	k8s.io/api v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -1014,8 +1014,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.8.0 h1:M1SN2+HCBVsjv+/vOyuaE+UijuNu7vaTkw4WhTlyKk4=
 github.com/submariner-io/admiral v0.8.0/go.mod h1:z3cqLnFjYlmtJDZwnbw0wwaV2Xwlf1i4pdlQ4+D3L3A=
-github.com/submariner-io/lighthouse v0.8.0 h1:YeONJeed16Fd/5s2rAGj0DTvU+IEM4slw+DXMXhSEFc=
-github.com/submariner-io/lighthouse v0.8.0/go.mod h1:gP2UpKb+0VuA1hsPML8wwYQxChdVotvD2deEjLS7EBA=
+github.com/submariner-io/lighthouse v0.8.1-0.20201222110455-4924193f35b4 h1:pWzl3tRVFAIg4I43q0bVKt5NJPi6lBPS/Zbv4p72AIg=
+github.com/submariner-io/lighthouse v0.8.1-0.20201222110455-4924193f35b4/go.mod h1:gP2UpKb+0VuA1hsPML8wwYQxChdVotvD2deEjLS7EBA=
 github.com/submariner-io/shipyard v0.8.0 h1:HKvVDJ4VbEz2CFK5h7fhBCz0z421hoykp7Al7j3kE3Y=
 github.com/submariner-io/shipyard v0.8.0/go.mod h1:kPqFCYY2F9vMEzEr6YwYQ1dhwL+uXgezG0aLey5rXD0=
 github.com/submariner-io/submariner v0.8.0 h1:ehTG08c1JN375eSVar3rlRgnsCnI2rfC5/yhw753Zn8=

--- a/packagemanifests/0.8.0/submariner.io_submariners.yaml
+++ b/packagemanifests/0.8.0/submariner.io_submariners.yaml
@@ -295,26 +295,6 @@ spec:
                             - public_ip
                             - subnets
                             type: object
-                          latency:
-                            description: LatencySpec describes the round trip time information in nanoseconds for a packet between the gateway pods of two clusters.
-                            properties:
-                              averageRTT:
-                                format: int64
-                                type: integer
-                              lastRTT:
-                                description: TODO This shall be deleted once the operator is using the latest. Using Optional to avoid validation errors when this field is not used.
-                                format: int64
-                                type: integer
-                              maxRTT:
-                                format: int64
-                                type: integer
-                              minRTT:
-                                format: int64
-                                type: integer
-                              stddevRTT:
-                                format: int64
-                                type: integer
-                            type: object
                           latencyRTT:
                             description: LatencySpec describes the round trip time information for a packet between the gateway pods of two clusters.
                             properties:

--- a/packagemanifests/0.8.0/submariner.v0.8.0.clusterserviceversion.yaml
+++ b/packagemanifests/0.8.0/submariner.v0.8.0.clusterserviceversion.yaml
@@ -57,26 +57,26 @@ spec:
       name: submariners.submariner.io
       version: v1alpha1
   description: |
-    [Submariner](https://submariner-io) enables direct networking between Pods and Services in different Kubernetes
+    [Submariner](https://submariner.io) enables direct networking between Pods and Services in different Kubernetes
     clusters. With Submariner, your applications and services can span multiple cloud providers, data centers, and regions.
 
     Submariner is designed to be cloud provider and network plugin (CNI) agnostic.
 
     Submariner consists of several main components that work in conjunction to securely connect workloads across
     multiple Kubernetes clusters, both on-premise and on public clouds:
-    * [Gateway Engine](https://submariner.io/architecture/gateway-engine/): manages the secure tunnels to other clusters.
-    * [Route Agent](https://submariner.io/architecture/route-agent/): routes cross-cluster traffic from nodes
+    * [Gateway Engine](https://submariner.io/getting-started/architecture/gateway-engine/): manages the secure tunnels to other clusters.
+    * [Route Agent](https://submariner.io/getting-started/architecture/route-agent/): routes cross-cluster traffic from nodes
     to the active Gateway Engine.
-    * [Broker](https://submariner.io/architecture/broker/): facilitates the exchange of metadata between Gateway
+    * [Broker](https://submariner.io/getting-started/architecture/broker/): facilitates the exchange of metadata between Gateway
     Engines enabling them to discover one another.
 
     Submariner has optional components that provide additional functionality:
-    * [Globalnet Controller](https://submariner.io/architecture/globalnet/): handles overlapping CIDRs across clusters.
-    * [Service Discovery](https://submariner.io/architecture/service-discovery/): provides DNS discovery of services
+    * [Globalnet Controller](https://submariner.io/getting-started/architecture/globalnet/): handles overlapping CIDRs across clusters.
+    * [Service Discovery](https://submariner.io/getting-started/architecture/service-discovery/): provides DNS discovery of services
     across clusters.
 
     ### Prerequisites
-    Submariner has a few requirements to get started, all are documented [here](https://submariner.io/quickstart/#prerequisites).
+    Submariner has a few requirements to get started, all are documented [here](https://submariner.io/getting-started/quickstart/kind/#prerequisites).
 
     ### Deployment
     Submariner provides an [Operator](https://github.com/submariner-io/submariner-operator) for easy API-based
@@ -84,8 +84,8 @@ spec:
     A command line utility, [subctl](https://github.com/submariner-io/submariner-operator/releases), wraps the
     Operator to aid users with manual deployments and easy experimentation.
     subctl greatly simplifies the deployment of Submariner, and is therefore the recommended deployment method.
-    For complete information about subctl, please refer to [this page](https://submariner.io/deployment/subctl).
-    In addition to Operator and subctl, Submariner also provides [Helm Charts](https://submariner.io/deployment/helm).
+    For complete information about subctl, please refer to [this page](https://submariner.io/operations/deployment/subctl).
+    In addition to Operator and subctl, Submariner also provides [Helm Charts](https://submariner.io/operations/deployment/helm).
 
     #### Deploying with subctl
     Install the tool:
@@ -102,7 +102,7 @@ spec:
 
     `subctl join --kubeconfig <PATH-TO-JOINING-CLUSTER> broker-info.subm --clusterid <ID>`
 
-    More information can be found [here](https://submariner.io/deployment/subctl).
+    More information can be found [here](https://submariner.io/operations/deployment/subctl).
 
     Submariner is deployed using the Submariner CR. The following values can be specified:
     * **namespace**: the namespace to install in;
@@ -372,7 +372,7 @@ spec:
   maturity: alpha
   provider:
     name: submariner.io
-  replaces: submariner.v0.0.0
+  replaces: submariner.v0.7.0
   selector:
     matchLabels:
       control-plane: submariner-operator

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	v1 "k8s.io/api/core/v1"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -165,26 +164,4 @@ func testDiscoverGenericWith(objects ...runtime.Object) *ClusterNetwork {
 	clusterNet, err := discoverGenericNetwork(clientSet)
 	Expect(err).NotTo(HaveOccurred())
 	return clusterNet
-}
-
-func fakePod(component string, command []string, env []v1.EnvVar) *v1.Pod {
-	return fakePodWithName(component, component, command, env)
-}
-
-func fakePodWithName(name, component string, command []string, env []v1.EnvVar) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: v1meta.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"component": component, "name": component},
-		},
-
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Command: command,
-					Env:     env,
-				},
-			},
-		},
-	}
 }

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -29,10 +29,11 @@ import (
 )
 
 type ClusterNetwork struct {
-	PodCIDRs      []string
-	ServiceCIDRs  []string
-	NetworkPlugin string
-	GlobalCIDR    string
+	PodCIDRs       []string
+	ServiceCIDRs   []string
+	NetworkPlugin  string
+	GlobalCIDR     string
+	PluginSettings map[string]string
 }
 
 func (cn *ClusterNetwork) Show() {
@@ -114,6 +115,11 @@ func networkPluginsDiscovery(dynClient dynamic.Interface, clientSet kubernetes.I
 	canalClusterNet, err := discoverCanalFlannelNetwork(clientSet)
 	if err != nil || canalClusterNet != nil {
 		return canalClusterNet, err
+	}
+
+	ovnClusterNet, err := discoverOvnKubernetesNetwork(clientSet)
+	if err != nil || ovnClusterNet != nil {
+		return ovnClusterNet, err
 	}
 
 	return nil, nil

--- a/pkg/discovery/network/network_suite_test.go
+++ b/pkg/discovery/network/network_suite_test.go
@@ -21,9 +21,49 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestOpenShift4NetworkDiscovery(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Network discovery")
+}
+
+func fakePod(component string, command []string, env []v1.EnvVar) *v1.Pod {
+	return fakePodWithName(component, component, command, env)
+}
+
+func fakePodWithName(name, component string, command []string, env []v1.EnvVar) *v1.Pod {
+	return fakePodWithNamespace("default", name, component, command, env)
+}
+
+func fakePodWithNamespace(namespace, name, component string, command []string, env []v1.EnvVar) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: v1meta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"component": component, "name": component},
+		},
+
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Command: command,
+					Env:     env,
+				},
+			},
+		},
+	}
+}
+
+func fakeService(namespace, name, component string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: v1meta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"component": component, "name": component},
+		},
+		Spec: v1.ServiceSpec{},
+	}
 }

--- a/pkg/discovery/network/ovnkubernetes.go
+++ b/pkg/discovery/network/ovnkubernetes.go
@@ -1,0 +1,79 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ovnKubeService     = "ovnkube-db"
+	OvnNBDB            = "OVN_NBDB"
+	OvnSBDB            = "OVN_SBDB"
+	OvnNBDBDefaultPort = 6641
+	OvnSBDBDefaultPort = 6642
+	OvnKubernetes      = "OVNKubernetes"
+)
+
+func discoverOvnKubernetesNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, error) {
+	ovnDbPod, err := findPod(clientSet, "name=ovnkube-db")
+
+	if err != nil || ovnDbPod == nil {
+		return nil, err
+	}
+
+	if _, err := clientSet.CoreV1().Services(ovnDbPod.Namespace).Get(ovnKubeService, v1.GetOptions{}); err != nil {
+		return nil, fmt.Errorf("error finding %q service in %q namespace", ovnKubeService, ovnDbPod.Namespace)
+	}
+
+	dbConnectionProtocol := "tcp"
+
+	for _, container := range ovnDbPod.Spec.Containers {
+		for _, envVar := range container.Env {
+			if envVar.Name == "OVN_SSL_ENABLE" {
+				if strings.ToUpper(envVar.Value) != "NO" {
+					dbConnectionProtocol = "ssl"
+				}
+			}
+		}
+	}
+
+	clusterNetwork := &ClusterNetwork{
+		NetworkPlugin: OvnKubernetes,
+		PluginSettings: map[string]string{
+			OvnNBDB: fmt.Sprintf("%s:%s.%s:%d", dbConnectionProtocol, ovnKubeService, ovnDbPod.Namespace, OvnNBDBDefaultPort),
+			OvnSBDB: fmt.Sprintf("%s:%s.%s:%d", dbConnectionProtocol, ovnKubeService, ovnDbPod.Namespace, OvnSBDBDefaultPort),
+		},
+	}
+
+	// If the cluster/service CIDRs weren't found we leave it to the generic functions to figure out later
+	if ovnConfig, err := clientSet.CoreV1().ConfigMaps(ovnDbPod.Namespace).Get("ovn-config", v1.GetOptions{}); err == nil {
+		if netCidr, ok := ovnConfig.Data["net_cidr"]; ok {
+			clusterNetwork.PodCIDRs = []string{netCidr}
+		}
+
+		if svcCidr, ok := ovnConfig.Data["svc_cidr"]; ok {
+			clusterNetwork.ServiceCIDRs = []string{svcCidr}
+		}
+	}
+
+	return clusterNetwork, nil
+}

--- a/pkg/discovery/network/ovnkubernetes_test.go
+++ b/pkg/discovery/network/ovnkubernetes_test.go
@@ -1,0 +1,105 @@
+/*
+© 2020 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const ovnKubeNamespace = "ovn-kubernetes"
+
+var _ = Describe("discoverOvnKubernetesNetwork", func() {
+	When("ovn-kubernetes can't be found", func() {
+		It("Should return nil cluster network", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterNet).To(BeNil())
+		})
+	})
+
+	const ovnKubeSvcTest = "ovnkube-db"
+	When("ovn-kubernetes database is found, but no database service", func() {
+		It("Should return error", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(clusterNet).To(BeNil())
+		})
+	})
+
+	When("ovn-kubernetes database and service found, no configmap", func() {
+		It("Should return cluster network with empty CIDRs", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
+				fakeService(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest),
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal("OVNKubernetes"))
+			connectionStr := fmt.Sprintf("tcp:%s.%s", ovnKubeSvcTest, ovnKubeNamespace)
+			Expect(clusterNet.PluginSettings["OVN_NBDB"]).To(Equal(connectionStr + ":6641"))
+			Expect(clusterNet.PluginSettings["OVN_SBDB"]).To(Equal(connectionStr + ":6642"))
+			Expect(clusterNet.PodCIDRs).To(HaveLen(0))
+			Expect(clusterNet.ServiceCIDRs).To(HaveLen(0))
+		})
+	})
+
+	When("ovn-kubernetes database, configmap and service found", func() {
+		It("Should return cluster network with empty CIDRs", func() {
+			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
+				fakeService(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest),
+				ovnFakeConfigMap(ovnKubeNamespace, "ovn-config"),
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.PodCIDRs).To(Equal([]string{testPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
+		})
+	})
+})
+
+func testOvnKubernetesDiscoveryWith(objects ...runtime.Object) (*ClusterNetwork, error) {
+	clientSet := fake.NewSimpleClientset(objects...)
+	return discoverOvnKubernetesNetwork(clientSet)
+}
+
+func ovnFakeConfigMap(namespace, name string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: v1meta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{
+			"net_cidr": testPodCIDR,
+			"svc_cidr": testServiceCIDR,
+		},
+	}
+}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/submariner-io/submariner-operator/pkg/names"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/deployment"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -48,7 +47,7 @@ func ParseOperatorImage(operatorImage string) (string, string) {
 		version = operatorImage[i+1:]
 	}
 
-	suffix := "/" + deployment.OperatorName
+	suffix := "/" + names.OperatorImage
 	j := strings.LastIndex(repository, suffix)
 	if j != -1 {
 		repository = repository[:j]

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -8,6 +8,7 @@ const (
 	ServiceDiscoveryImage    = "lighthouse-agent"
 	LighthouseCoreDNSImage   = "lighthouse-coredns"
 	ServiceDiscoveryCrName   = "service-discovery"
+	OperatorImage            = "submariner-operator"
 )
 
 var (

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -434,7 +434,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 	}
 
 	submarinerSpec := submariner.SubmarinerSpec{
-		Repository:               repository,
+		Repository:               getImageRepo(),
 		Version:                  getImageVersion(),
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
@@ -483,6 +483,21 @@ func getImageVersion() string {
 	}
 
 	return version
+}
+
+func getImageRepo() string {
+	imageOverrides := getImageOverrides()
+	repo := repository
+
+	if repository == "" {
+		repo = versions.DefaultRepo
+	}
+
+	if override, ok := imageOverrides[names.OperatorImage]; ok {
+		_, repo = images.ParseOperatorImage(override)
+	}
+
+	return repo
 }
 
 func operatorImage() string {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -35,14 +35,13 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/images"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/deployment"
-
 	"k8s.io/client-go/rest"
 
 	submariner "github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
@@ -486,7 +485,7 @@ func operatorImage() string {
 		version = versions.DefaultSubmarinerOperatorVersion
 	}
 
-	return images.GetImagePath(repository, version, deployment.OperatorName, getImageOverrides())
+	return images.GetImagePath(repository, version, names.OperatorImage, getImageOverrides())
 }
 
 func getImageOverrides() map[string]string {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -435,7 +435,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,
-		Version:                  imageVersion,
+		Version:                  getImageVersion(),
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             ipsecDebug,
@@ -468,6 +468,21 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		submarinerSpec.CustomDomains = customDomains
 	}
 	return submarinerSpec
+}
+
+func getImageVersion() string {
+	imageOverrides := getImageOverrides()
+	version := imageVersion
+
+	if imageVersion == "" {
+		version = versions.DefaultSubmarinerOperatorVersion
+	}
+
+	if override, ok := imageOverrides[names.OperatorImage]; ok {
+		version, _ = images.ParseOperatorImage(override)
+	}
+
+	return version
 }
 
 func operatorImage() string {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -82,7 +82,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&clusterID, "clusterid", "", "cluster ID used to identify the tunnels")
 	cmd.Flags().StringVar(&serviceCIDR, "servicecidr", "", "service CIDR")
 	cmd.Flags().StringVar(&clusterCIDR, "clustercidr", "", "cluster CIDR")
-	cmd.Flags().StringVar(&repository, "repository", versions.DefaultRepo, "image repository")
+	cmd.Flags().StringVar(&repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&imageVersion, "version", "", "image version")
 	cmd.Flags().StringVar(&colorCodes, "colorcodes", submariner.DefaultColorCode, "color codes")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
@@ -417,14 +417,6 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		brokerURL = brokerURL[(idx + 3):]
 	}
 
-	crImageVersion := imageVersion
-
-	if imageVersion == "" {
-		// Default engine version
-		// This is handled in the operator after 0.0.1 (of the operator)
-		crImageVersion = versions.DefaultSubmarinerVersion
-	}
-
 	// if our network discovery code was capable of discovering those CIDRs
 	// we don't need to explicitly set it in the operator
 	crServiceCIDR := ""
@@ -443,7 +435,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 
 	submarinerSpec := submariner.SubmarinerSpec{
 		Repository:               repository,
-		Version:                  crImageVersion,
+		Version:                  imageVersion,
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             ipsecDebug,
@@ -480,12 +472,17 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 
 func operatorImage() string {
 	version := imageVersion
+	repo := repository
 
 	if imageVersion == "" {
 		version = versions.DefaultSubmarinerOperatorVersion
 	}
 
-	return images.GetImagePath(repository, version, names.OperatorImage, getImageOverrides())
+	if repository == "" {
+		repo = versions.DefaultRepo
+	}
+
+	return images.GetImagePath(repo, version, names.OperatorImage, getImageOverrides())
 }
 
 func getImageOverrides() map[string]string {

--- a/pkg/subctl/cmd/show_versions.go
+++ b/pkg/subctl/cmd/show_versions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/deployment"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -52,14 +51,14 @@ func getSubmarinerVersion(submarinerClient submarinerclientset.Interface, versio
 }
 
 func getOperatorVersion(clientSet kubernetes.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
-	operatorConfig, err := clientSet.AppsV1().Deployments(OperatorNamespace).Get(deployment.OperatorName, v1.GetOptions{})
+	operatorConfig, err := clientSet.AppsV1().Deployments(OperatorNamespace).Get(names.OperatorImage, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	operatorFullImageStr := operatorConfig.Spec.Template.Spec.Containers[0].Image
 	version, repository := images.ParseOperatorImage(operatorFullImageStr)
-	versions = append(versions, newVersionInfoFrom(repository, deployment.OperatorName, version))
+	versions = append(versions, newVersionInfoFrom(repository, names.OperatorImage, version))
 	return versions, nil
 }
 

--- a/pkg/subctl/operator/submarinerop/deployment/ensure.go
+++ b/pkg/subctl/operator/submarinerop/deployment/ensure.go
@@ -17,16 +17,12 @@ limitations under the License.
 package deployment
 
 import (
-	"k8s.io/client-go/rest"
-
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/operatorpod"
-)
-
-const (
-	OperatorName = "submariner-operator"
+	"k8s.io/client-go/rest"
 )
 
 // Ensure the operator is deployed, and running
 func Ensure(restConfig *rest.Config, namespace, image string) (bool, error) {
-	return operatorpod.Ensure(restConfig, namespace, OperatorName, image)
+	return operatorpod.Ensure(restConfig, namespace, names.OperatorImage, image)
 }


### PR DESCRIPTION
Backports the following PRs to release-0.8:
 - Update references to Lighthouse repo (#1009)
 - Ensure that CRDs are up-to-date (#1008)
 - Detect OVNKubernetes without Cluster Network Operator (#1001)
 - Use the PR base branch as reference when linting (#1026)
 - AKS: Use coredns-custom configmap for lighthouse (#1054)
 - Fix missing data section in coredns-custom (#1056)
 - Reconcile ServiceDiscovery before status updates (#1058)
 - Update GatewayEngine Pod env with the host nodeName (#1019)
 - chore: update bundle broken links (#1014)
 - fix: update image pull policy when using image override (#939)
 - Add ClusterId to lighthouse-coredns env (#1053)
 - Generate the submariners crd again to update the changes for bundle 0.8.0 (#1007)
 - Tag released image with branch name (#1025)
 - fix(subctl): avoid pinning the version and repo to submariners cr (#1004)
 - fix(subctl): image-override will override the version and repository properties (#1045)
- Update Globalnet Pod env with the host nodeName (#1015)