### PR TITLE
Pin GHAs to versions to avoid breakages

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install an old cluster, upgrade it and check it
         uses: submariner-io/shipyard/gh-actions/upgrade-e2e@devel

--- a/.github/workflows/subctl_bin.yml
+++ b/.github/workflows/subctl_bin.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - run: git fetch origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/subctl_bin.yml
+++ b/.github/workflows/subctl_bin.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate the artifacts
         run: make build-cross
       - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
+        uses: skx/github-action-publish-binaries@release-0.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/subctl_cutting_edges.yml
+++ b/.github/workflows/subctl_cutting_edges.yml
@@ -25,7 +25,7 @@ jobs:
           echo "BINARIES=$(find dist/ -type f -name '*.tar.xz' -printf '%p ')" >> $GITHUB_ENV
 
       - name: Update the Release
-        uses: johnwbyrd/update-release@master
+        uses: johnwbyrd/update-release@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release: "Cutting Edge: ${{ env.SUBCTL_TAG }}"

--- a/.github/workflows/subctl_cutting_edges.yml
+++ b/.github/workflows/subctl_cutting_edges.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install an old cluster, upgrade it and check it
         uses: submariner-io/shipyard/gh-actions/upgrade-e2e@devel


### PR DESCRIPTION
To avoid breakages from changes to dependencies' master branches, we
should pin to (at least major) versions.

This also follows guidance from GitHub:

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses