### PR TITLE
Use shared GHAs from Shipyard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,20 +18,12 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2
 
-      - name: Reclaim free space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
-          free -h
-
       - name: Run E2E deployment and tests
-        run: |
-          make e2e using="${{ matrix.globalnet }} ${{ matrix.lighthouse }}"
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          globalnet: ${{ matrix.globalnet }}
+          lighthouse: ${{ matrix.lighthouse }}
 
       - name: Post mortem
         if: failure()
-        run: |
-          df -h
-          free -h
-          make post-mortem
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -20,23 +20,17 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2
 
-      - name: Reclaim free space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
-          free -h
 
       - name: Run E2E deployment and tests
-        run: |
-          make e2e using="${{ matrix.cable_driver }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }}"
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          cabledriver: ${{ matrix.cable_driver }}
+          globalnet: ${{ matrix.globalnet }}
+          lighthouse: ${{ matrix.lighthouse }}
 
       - name: Post mortem
         if: failure()
-        run: |
-          df -h
-          free -h
-          make post-mortem
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel
   upgrade-e2e:
     name: Latest Release to Latest Version
     timeout-minutes: 30
@@ -46,20 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Reclaim free space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
-          free -h
-
       - name: Install an old cluster, upgrade it and check it
-        run: |
-          make upgrade-e2e
+        uses: submariner-io/shipyard/gh-actions/upgrade-e2e@devel
 
       - name: Post mortem
         if: failure()
-        run: |
-          df -h
-          free -h
-          make post-mortem
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -14,20 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Reclaim free space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
-          free -h
-
       - name: Install an old cluster, upgrade it and check it
-        run: |
-          make upgrade-e2e
+        uses: submariner-io/shipyard/gh-actions/upgrade-e2e@devel
 
       - name: Post mortem
         if: failure()
-        run: |
-          df -h
-          free -h
-          make post-mortem
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel


### PR DESCRIPTION
Run common Submariner CI logic like E2E tests, upgrade tests, and the
flake finder using Submariner's custom GitHub Actions from Shipyard.

This should fix the upgrade job.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>