### PR TITLE
Pull devel images for development subctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ bin/subctl-%: generate-embeddedyamls $(shell find pkg/subctl/ -name "*.go") vend
 	export GOARCH GOOS; \
 	$(SCRIPTS_DIR)/compile.sh \
 		--ldflags "-X github.com/submariner-io/submariner-operator/pkg/version.Version=$(CALCULATED_VERSION) \
-        		   -X=github.com/submariner-io/submariner-operator/pkg/versions.DefaultSubmarinerOperatorVersion=$(CALCULATED_VERSION)" \
+        		   -X=github.com/submariner-io/submariner-operator/pkg/versions.DefaultSubmarinerOperatorVersion=$(if eq($(patsubst subctl-devel-%,devel,$(CALCULATED_VERSION)),devel),devel,$(CALCULATED_VERSION))" \
 		--noupx $@ ./pkg/subctl/main.go
 
 ci: generate-embeddedyamls golangci-lint markdownlint unit build images


### PR DESCRIPTION
Instead of trying to pull subctl-devel-SHA, pull devel (hardcoded for
now).

This will need to be reworked, but local operator deployments are
broken currently and this unblocks them.

Signed-off-by: Stephen Kitt <skitt@redhat.com>