### PR TITLE
Subctl release 0.8 backports

### DIFF
--- a/.github/workflows/subctl_bleeding_edge.yml
+++ b/.github/workflows/subctl_bleeding_edge.yml
@@ -2,7 +2,7 @@
 on:
   push:
     branches: [master]
-name: Release Subctl Bleeding Edge
+name: Release Subctl Devel
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,13 +15,13 @@ jobs:
 
       - name: Generate the Artifacts
         run: |
-          make build-cross VERSION=devel
+          make build-cross VERSION=subctl-devel
           echo "BINARIES=$(find dist/ -type f -name '*.tar.xz' -printf '%p ')" >> $GITHUB_ENV
 
-      - name: Bump the devel tag
+      - name: Bump the subctl-devel tag
         uses: richardsimko/update-tag@v1.0.3
         with:
-          tag_name: devel
+          tag_name: subctl-devel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -30,5 +30,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release: Cutting Edge
-          tag: devel
+          tag: subctl-devel
           files: ${{ env.BINARIES }}

--- a/.github/workflows/subctl_bleeding_edge.yml
+++ b/.github/workflows/subctl_bleeding_edge.yml
@@ -1,7 +1,10 @@
 ---
 on:
   push:
-    branches: [master]
+    branches:
+      - devel
+      - release-*
+
 name: Release Subctl Devel
 jobs:
   release:
@@ -13,15 +16,18 @@ jobs:
 
       - run: git fetch origin +refs/tags/*:refs/tags/*
 
+      - name: generate version tag
+        run: echo "SUBCTL_TAG=subctl-${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Generate the Artifacts
         run: |
-          make build-cross VERSION=subctl-devel
+          make build-cross VERSION=${{ env.SUBCTL_TAG }}
           echo "BINARIES=$(find dist/ -type f -name '*.tar.xz' -printf '%p ')" >> $GITHUB_ENV
 
-      - name: Bump the subctl-devel tag
+      - name: Bump the subctl tag
         uses: richardsimko/update-tag@v1.0.3
         with:
-          tag_name: subctl-devel
+          tag_name: ${{ env.SUBCTL_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -29,6 +35,6 @@ jobs:
         uses: johnwbyrd/update-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release: Cutting Edge
-          tag: subctl-devel
+          release: ${{ env.SUBCTL_TAG }} Cutting Edge
+          tag: ${{ env.SUBCTL_TAG }}
           files: ${{ env.BINARIES }}

--- a/.github/workflows/subctl_cutting_edges.yml
+++ b/.github/workflows/subctl_cutting_edges.yml
@@ -17,24 +17,24 @@ jobs:
       - run: git fetch origin +refs/tags/*:refs/tags/*
 
       - name: generate version tag
-        run: echo "SUBCTL_TAG=subctl-${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "SUBCTL_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Generate the Artifacts
         run: |
           make build-cross VERSION=${{ env.SUBCTL_TAG }}
           echo "BINARIES=$(find dist/ -type f -name '*.tar.xz' -printf '%p ')" >> $GITHUB_ENV
 
-      - name: Bump the subctl tag
-        uses: richardsimko/update-tag@v1.0.3
-        with:
-          tag_name: ${{ env.SUBCTL_TAG }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Update the Release
         uses: johnwbyrd/update-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release: ${{ env.SUBCTL_TAG }} Cutting Edge
-          tag: ${{ env.SUBCTL_TAG }}
+          release: "Cutting Edge: ${{ env.SUBCTL_TAG }}"
+          tag: subctl-${{ env.SUBCTL_TAG }}
           files: ${{ env.BINARIES }}
+
+      - name: Bump the subctl tag
+        uses: richardsimko/update-tag@v1.0.3
+        with:
+          tag_name: subctl-${{ env.SUBCTL_TAG }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR backports the necessary commits to generate subctl-release-0.8 binaries:
* Change `devel` tag to `subctl-devel` #1031 (dc084ce8)
* Fix subctl cutting edge subctl #1070 (ea4716b1)
* Publish subctl for devel and release-xxx #1068 (fdf5f37c)