### PR TITLE
Fix README link to latest subctl release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This release has the latest stable binaries: [latest release](https://github.com
 ### Latest Merged Release
 
 This release is constantly updated with the latest code, and might be unstable: [devel
-release](https://github.com/submariner-io/submariner-operator/releases/tag/devel).
+release](https://github.com/submariner-io/submariner-operator/releases/tag/subctl-devel).
 
 ## Building and Testing
 


### PR DESCRIPTION
Fixes the markdownlink-check linter, currently failing the periodic job.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>