### PR TITLE
Rename connections metric to requested_connections

### DIFF
--- a/controllers/submariner/submariner_metrics.go
+++ b/controllers/submariner/submariner_metrics.go
@@ -51,7 +51,7 @@ var (
 	)
 	connectionsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "submariner_connections",
+			Name: "submariner_requested_connections",
 			Help: "Number of connections (by endpoint and status)",
 		},
 		[]string{


### PR DESCRIPTION
This avoids a conflict with the submariner_connections metric in the
gateway engine, and more accurately reflects its meaning.

Signed-off-by: Stephen Kitt <skitt@redhat.com>