### PR TITLE
Allow service to be deployed without connectivity

### DIFF
--- a/apis/submariner/v1alpha1/servicediscovery_types.go
+++ b/apis/submariner/v1alpha1/servicediscovery_types.go
@@ -85,4 +85,9 @@ func (serviceDiscovery *ServiceDiscovery) SetDefaults() {
 	if serviceDiscovery.Spec.Version == "" {
 		serviceDiscovery.Spec.Version = versions.DefaultLighthouseVersion
 	}
+
+	if serviceDiscovery.Spec.Repository == "" {
+		// An empty field is converted to the default upstream submariner repository where all images live
+		serviceDiscovery.Spec.Repository = versions.DefaultRepo
+	}
 }

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -59,6 +59,8 @@ func init() {
 	deployBroker.PersistentFlags().BoolVar(&serviceDiscoveryEnabled, "service-discovery", true,
 		"enable multi-cluster service discovery")
 
+	_ = deployBroker.PersistentFlags().MarkDeprecated("service-discovery", "please use --components instead")
+
 	deployBroker.PersistentFlags().StringSliceVar(&defaultCustomDomains, "custom-domains", nil,
 		"list of domains to use for multicluster service discovery")
 

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -18,11 +18,14 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/admiral/pkg/stringset"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
@@ -34,10 +37,13 @@ var (
 	globalnetEnable             bool
 	globalnetCidrRange          string
 	defaultGlobalnetClusterSize uint
-	serviceDiscovery            bool
+	serviceDiscoveryEnabled     bool
+	componentArr                []string
 	GlobalCIDRConfigMap         *v1.ConfigMap
 	defaultCustomDomains        []string
 )
+
+var validComponents = []string{components.ServiceDiscovery, components.Connectivity}
 
 func init() {
 	deployBroker.PersistentFlags().BoolVar(&globalnetEnable, "globalnet", false,
@@ -50,11 +56,15 @@ func init() {
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
 		"import IPsec PSK from existing submariner broker file, like broker-info.subm")
 
-	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", true,
+	deployBroker.PersistentFlags().BoolVar(&serviceDiscoveryEnabled, "service-discovery", true,
 		"enable multi-cluster service discovery")
 
 	deployBroker.PersistentFlags().StringSliceVar(&defaultCustomDomains, "custom-domains", nil,
 		"list of domains to use for multicluster service discovery")
+
+	deployBroker.PersistentFlags().StringSliceVar(&componentArr, "components", validComponents,
+		fmt.Sprintf("The components to be installed - any of %s. The default is all components",
+			strings.Join(validComponents, ",")))
 
 	addKubeconfigFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
@@ -67,10 +77,21 @@ var deployBroker = &cobra.Command{
 	Short: "Set the broker up",
 	Run: func(cmd *cobra.Command, args []string) {
 
+		componentSet := stringset.New(componentArr...)
+
+		// TODO: Remove this in the future, while service-discovery is marked as
+		//       deprecated we should still provide a consistent broker config file
+		if !serviceDiscoveryEnabled {
+			componentSet.Remove(components.ServiceDiscovery)
+		}
+
+		if err := isValidComponents(componentSet); err != nil {
+			exitOnError("Invalid components parameter", err)
+		}
+
 		if valid, err := isValidGlobalnetConfig(); !valid {
 			exitOnError("Invalid GlobalCidr configuration", err)
 		}
-
 		config, err := getRestConfig(kubeConfig, kubeContext)
 		exitOnError("The provided kubeconfig is invalid", err)
 
@@ -102,7 +123,8 @@ var deployBroker = &cobra.Command{
 			status.QueueSuccessMessage(fmt.Sprintf("Backed up previous %s to %s", brokerDetailsFilename, newFilename))
 		}
 
-		subctlData.ServiceDiscovery = serviceDiscovery
+		subctlData.ServiceDiscovery = serviceDiscoveryEnabled
+		subctlData.SetComponents(componentSet)
 
 		if len(defaultCustomDomains) > 0 {
 			subctlData.CustomDomains = &defaultCustomDomains
@@ -119,6 +141,22 @@ var deployBroker = &cobra.Command{
 		exitOnError("Error writing the broker information", err)
 
 	},
+}
+
+func isValidComponents(componentSet stringset.Interface) error {
+	validComponentSet := stringset.New(validComponents...)
+
+	if componentSet.Size() < 1 {
+		return fmt.Errorf("at least one component must be provided for deployment")
+	}
+
+	for _, component := range componentSet.Elements() {
+		if !validComponentSet.Contains(component) {
+			return fmt.Errorf("unknown component: %s", component)
+		}
+	}
+
+	return nil
 }
 
 func isValidGlobalnetConfig() (bool, error) {

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -34,6 +34,7 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
@@ -222,8 +223,8 @@ func checkVerifyArguments() error {
 }
 
 var verifyE2EPatterns = map[string]string{
-	"connectivity":      "\\[dataplane",
-	"service-discovery": "\\[discovery",
+	components.Connectivity:     "\\[dataplane",
+	components.ServiceDiscovery: "\\[discovery",
 }
 
 var verifyE2EDisruptivePatterns = map[string]string{

--- a/pkg/subctl/components/consts.go
+++ b/pkg/subctl/components/consts.go
@@ -1,0 +1,22 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+const (
+	Connectivity     = "connectivity"
+	ServiceDiscovery = "service-discovery"
+)

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -24,12 +24,15 @@ import (
 	"io/ioutil"
 	"net/url"
 
+	"github.com/submariner-io/admiral/pkg/stringset"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/submariner-io/submariner-operator/pkg/broker"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
+
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 )
 
@@ -38,12 +41,29 @@ type SubctlData struct {
 	ClientToken      *v1.Secret `omitempty,json:"clientToken"`
 	IPSecPSK         *v1.Secret `omitempty,json:"ipsecPSK"`
 	ServiceDiscovery bool       `omitempty,json:"serviceDiscovery"`
+	Components       []string   `json:",omitempty"`
 	CustomDomains    *[]string  `omitempty,json:"customDomains"`
 	// Todo (revisit): The following values are moved from the broker-info.subm file to configMap
 	// on the Broker. This needs to be revisited to support seamless upgrades.
 	// https://github.com/submariner-io/submariner-operator/issues/504
 	// GlobalnetCidrRange   string `omitempty,json:"globalnetCidrRange"`
 	// GlobalnetClusterSize uint   `omitempty,json:"globalnetClusterSize"`
+}
+
+func (data *SubctlData) SetComponents(componentSet stringset.Interface) {
+	data.Components = componentSet.Elements()
+}
+
+func (data *SubctlData) GetComponents() stringset.Interface {
+	return stringset.New(data.Components...)
+}
+
+func (data *SubctlData) IsConnectivityEnabled() bool {
+	return data.GetComponents().Contains(components.Connectivity)
+}
+
+func (data *SubctlData) IsServiceDiscoveryEnabled() bool {
+	return data.GetComponents().Contains(components.ServiceDiscovery) || data.ServiceDiscovery
 }
 
 func (data *SubctlData) ToString() (string, error) {

--- a/pkg/subctl/operator/servicediscoverycr/ensure.go
+++ b/pkg/subctl/operator/servicediscoverycr/ensure.go
@@ -1,0 +1,71 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicediscoverycr
+
+import (
+	"github.com/submariner-io/admiral/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	submariner "github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+)
+
+func init() {
+	err := submariner.AddToScheme(scheme.Scheme)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Ensure(config *rest.Config, namespace string, serviceDiscoverySpec *submariner.ServiceDiscoverySpec) error {
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	client := dynClient.Resource(schema.GroupVersionResource{
+		Group: "submariner.io", Version: "v1alpha1", Resource: "servicediscoveries"}).Namespace(namespace)
+
+	sd := &submariner.ServiceDiscovery{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      names.ServiceDiscoveryCrName,
+		},
+		Spec: *serviceDiscoverySpec,
+	}
+
+	return createServiceDiscovery(client, sd)
+}
+
+func createServiceDiscovery(client dynamic.ResourceInterface, sd *submariner.ServiceDiscovery) error {
+	serviceDiscovery, err := util.ToUnstructured(sd)
+	if err != nil {
+		return err
+	}
+
+	_, err = util.CreateOrUpdate(client, serviceDiscovery, func(existing *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		err = unstructured.SetNestedField(existing.Object, util.GetNestedField(serviceDiscovery, "spec"), "spec")
+		return existing, err
+	})
+
+	return err
+}


### PR DESCRIPTION
This covers the use case of routed networks where pods and
services can already talk to remote clusters by other means
and the submariner routing and gateways are not required,
but service discovery is necessary.

Signed-off-by: Miguel Angel Ajo majopela@redhat.com