### PR TITLE
Add dependabot ignore for submariner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,4 @@ updates:
       - dependency-name: sigs.k8s.io/controller-runtime
         versions:
           - "> 0.6.2"
+      - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
Updates to submariner dependencies is done via our release process.
