### PR TITLE
When replacing a Submariner CR, wait for deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
-	github.com/submariner-io/admiral v0.9.0-m1
+	github.com/submariner-io/admiral v0.9.0-m1.0.20210302163417-57a3ab841d27
 	github.com/submariner-io/lighthouse v0.9.0-m1
 	github.com/submariner-io/shipyard v0.9.0-m1
 	github.com/submariner-io/submariner v0.9.0-m1

--- a/go.sum
+++ b/go.sum
@@ -1078,6 +1078,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.9.0-m1 h1:7QSdxC2eiX6bbuHOr8+fAzoOA49h35Q3v2mSwr5sk4Y=
 github.com/submariner-io/admiral v0.9.0-m1/go.mod h1:NFsFrk2CDac2ekq+EDqgPiyh9Tu4f6crh01HJJv2+M4=
+github.com/submariner-io/admiral v0.9.0-m1.0.20210302163417-57a3ab841d27 h1:ahSmkrlyFceNkt/abdaWcAerTFXMVRDYpNoIve5xDxM=
+github.com/submariner-io/admiral v0.9.0-m1.0.20210302163417-57a3ab841d27/go.mod h1:NFsFrk2CDac2ekq+EDqgPiyh9Tu4f6crh01HJJv2+M4=
 github.com/submariner-io/lighthouse v0.9.0-m1 h1:5H7rtXUTUseHjY/BzSXHIRFZDMGZRdc58OHOCdy4d9w=
 github.com/submariner-io/lighthouse v0.9.0-m1/go.mod h1:rkOi2ySskuEoAysyqIV5NZpWLIzFpnVqhgPZW4cvUMo=
 github.com/submariner-io/shipyard v0.9.0-m1 h1:UILEZrgtugmDUxOFnWmeGmMk0NTxcavsEXgzptxAKNg=

--- a/pkg/subctl/operator/brokercr/ensure.go
+++ b/pkg/subctl/operator/brokercr/ensure.go
@@ -48,5 +48,5 @@ func Ensure(config *rest.Config, namespace string, brokerSpec submariner.BrokerS
 		Version:  submariner.SchemeGroupVersion.Version,
 		Resource: "brokers"}).Namespace(namespace)
 
-	return util.CreateAnew(client, brokerCR)
+	return util.CreateAnew(client, brokerCR, nil)
 }

--- a/pkg/subctl/operator/submarinercr/ensure.go
+++ b/pkg/subctl/operator/submarinercr/ensure.go
@@ -47,6 +47,9 @@ func Ensure(config *rest.Config, namespace string, submarinerSpec submariner.Sub
 		Group:    submariner.SchemeGroupVersion.Group,
 		Version:  submariner.SchemeGroupVersion.Version,
 		Resource: "submariners"}).Namespace(namespace)
+	propagationPolicy := metav1.DeletePropagationForeground
 
-	return util.CreateAnew(client, submarinerCR)
+	return util.CreateAnew(client, submarinerCR, &metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	})
 }


### PR DESCRIPTION
Before creating the new Submariner CR, wait for the old one to be
completely deleted, including all its owned resources. This should
make upgrades much more reliable.

(Ultimately we need to ensure we cope with fast re-creations...)

Signed-off-by: Stephen Kitt <skitt@redhat.com>