### PR TITLE
fix: parse operator image url enhancement

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -52,20 +52,24 @@ func GetPullPolicy(version string) v1.PullPolicy {
 }
 
 func ParseOperatorImage(operatorImage string) (string, string) {
-	i := strings.LastIndex(operatorImage, ":")
 	var repository string
 	var version string
-	if i == -1 {
-		repository = operatorImage
+
+	pathParts := strings.SplitN(operatorImage, "/", 3)
+	if len(pathParts) < 3 || (!strings.Contains(pathParts[0], ".") &&
+		!strings.Contains(pathParts[0], ":") && pathParts[0] != "localhost") {
+		repository = pathParts[0]
 	} else {
-		repository = operatorImage[:i]
-		version = operatorImage[i+1:]
+		repository = pathParts[0] + "/" + pathParts[1]
 	}
 
-	suffix := "/" + names.OperatorImage
-	j := strings.LastIndex(repository, suffix)
-	if j != -1 {
-		repository = repository[:j]
+	imageName := strings.Replace(operatorImage, repository, "", 1)
+	i := strings.LastIndex(imageName, ":")
+	if i == -1 {
+		version = "latest"
+	} else {
+		version = imageName[i+1:]
 	}
+
 	return version, repository
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -56,7 +56,9 @@ func ParseOperatorImage(operatorImage string) (string, string) {
 	var version string
 
 	pathParts := strings.SplitN(operatorImage, "/", 3)
-	if len(pathParts) < 3 || (!strings.Contains(pathParts[0], ".") &&
+	if len(pathParts) == 1 {
+		repository = ""
+	} else if len(pathParts) < 3 || (!strings.Contains(pathParts[0], ".") &&
 		!strings.Contains(pathParts[0], ":") && pathParts[0] != "localhost") {
 		repository = pathParts[0]
 	} else {


### PR DESCRIPTION
Do not rely on the name of the operator but instead split the first
2 strings according to "/" char.
This way we support any operator image name including those with a "/" as well.
tested on: 
```
registry.redhat.io/rhacm2-tech-preview/submariner-rhel8-operator:v0.8
quay.io/submariner/submariner-operator:v0.8
localhost/submariner-operator:v0.8
localhost:5000/submariner-operator:v0.8
localhost:5000/submariner-operator
registry.redhat.io/rhacm2-tech-preview/submariner-rhel8-operator
submariner-operator:v0.8
submariner-operator
```

Signed-off-by: Steve Mattar <smattar@redhat.com>
