### PR TITLE
fix: parse operator image url enhancement

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -37,20 +37,26 @@ func GetPullPolicy(version string) v1.PullPolicy {
 }
 
 func ParseOperatorImage(operatorImage string) (string, string) {
-	i := strings.LastIndex(operatorImage, ":")
 	var repository string
 	var version string
-	if i == -1 {
-		repository = operatorImage
+
+	pathParts := strings.SplitN(operatorImage, "/", 3)
+	if len(pathParts) == 1 {
+		repository = ""
+	} else if len(pathParts) < 3 || (!strings.Contains(pathParts[0], ".") &&
+		!strings.Contains(pathParts[0], ":") && pathParts[0] != "localhost") {
+		repository = pathParts[0]
 	} else {
-		repository = operatorImage[:i]
-		version = operatorImage[i+1:]
+		repository = pathParts[0] + "/" + pathParts[1]
 	}
 
-	suffix := "/" + names.OperatorImage
-	j := strings.LastIndex(repository, suffix)
-	if j != -1 {
-		repository = repository[:j]
+	imageName := strings.Replace(operatorImage, repository, "", 1)
+	i := strings.LastIndex(imageName, ":")
+	if i == -1 {
+		version = "latest"
+	} else {
+		version = imageName[i+1:]
 	}
+
 	return version, repository
 }


### PR DESCRIPTION
do not rely on the name of the operator but instead split the first
2 strings according to "/" char
This way we support any operator image name including those with a "/" as well.
eg: "registry.redhat.io/rhacm2-tech-preview/submariner-rhel8-operator:v0.8"

Signed-off-by: Steve Mattar <smattar@redhat.com>
(cherry picked from commit cfd28ba39266f7301a9c50518db8a31f008ebc80)
(cherry picked from commit 3c963bafa1960a80f54fa3d9a7d0cdebe941d56c)