### PR TITLE
subctl only discovery backport

### DIFF
--- a/apis/submariner/v1alpha1/servicediscovery_types.go
+++ b/apis/submariner/v1alpha1/servicediscovery_types.go
@@ -85,4 +85,9 @@ func (serviceDiscovery *ServiceDiscovery) SetDefaults() {
 	if serviceDiscovery.Spec.Version == "" {
 		serviceDiscovery.Spec.Version = versions.DefaultLighthouseVersion
 	}
+
+	if serviceDiscovery.Spec.Repository == "" {
+		// An empty field is converted to the default upstream submariner repository where all images live
+		serviceDiscovery.Spec.Repository = versions.DefaultRepo
+	}
 }

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -18,11 +18,14 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/admiral/pkg/stringset"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
@@ -34,10 +37,13 @@ var (
 	globalnetEnable             bool
 	globalnetCidrRange          string
 	defaultGlobalnetClusterSize uint
-	serviceDiscovery            bool
+	serviceDiscoveryEnabled     bool
+	componentArr                []string
 	GlobalCIDRConfigMap         *v1.ConfigMap
 	defaultCustomDomains        []string
 )
+
+var validComponents = []string{components.ServiceDiscovery, components.Connectivity}
 
 func init() {
 	deployBroker.PersistentFlags().BoolVar(&globalnetEnable, "globalnet", false,
@@ -50,11 +56,15 @@ func init() {
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
 		"Import IPsec PSK from existing submariner broker file, like broker-info.subm")
 
-	deployBroker.PersistentFlags().BoolVar(&serviceDiscovery, "service-discovery", true,
-		"Enable Multi-Cluster Service Discovery")
+	deployBroker.PersistentFlags().BoolVar(&serviceDiscoveryEnabled, "service-discovery", true,
+		"enable multi-cluster service discovery")
 
 	deployBroker.PersistentFlags().StringSliceVar(&defaultCustomDomains, "custom-domains", nil,
 		"List of domains to use for multicluster service discovery")
+
+	deployBroker.PersistentFlags().StringSliceVar(&componentArr, "components", validComponents,
+		fmt.Sprintf("The components to be installed - any of %s. The default is all components",
+			strings.Join(validComponents, ",")))
 
 	addKubeconfigFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
@@ -67,10 +77,24 @@ var deployBroker = &cobra.Command{
 	Short: "set the broker up",
 	Run: func(cmd *cobra.Command, args []string) {
 
+		componentSet := stringset.New()
+		for _, component := range componentArr {
+			componentSet.Add(component)
+		}
+
+		// TODO: Remove this in the future, while service-discovery is marked as
+		//       deprecated we should still provide a consistent broker config file
+		if !serviceDiscoveryEnabled {
+			componentSet.Remove(components.ServiceDiscovery)
+		}
+
+		if err := isValidComponents(componentSet); err != nil {
+			exitOnError("Invalid components parameter", err)
+		}
+
 		if valid, err := isValidGlobalnetConfig(); !valid {
 			exitOnError("Invalid GlobalCidr configuration", err)
 		}
-
 		config, err := getRestConfig(kubeConfig, kubeContext)
 		exitOnError("The provided kubeconfig is invalid", err)
 
@@ -102,7 +126,8 @@ var deployBroker = &cobra.Command{
 			status.QueueSuccessMessage(fmt.Sprintf("Backed up previous %s to %s", brokerDetailsFilename, newFilename))
 		}
 
-		subctlData.ServiceDiscovery = serviceDiscovery
+		subctlData.ServiceDiscovery = serviceDiscoveryEnabled
+		subctlData.SetComponents(componentSet)
 
 		if len(defaultCustomDomains) > 0 {
 			subctlData.CustomDomains = &defaultCustomDomains
@@ -119,6 +144,25 @@ var deployBroker = &cobra.Command{
 		exitOnError("Error writing the broker information", err)
 
 	},
+}
+
+func isValidComponents(componentSet stringset.Interface) error {
+	validComponentSet := stringset.New()
+	for _, component := range validComponents {
+		validComponentSet.Add(component)
+	}
+
+	if componentSet.Size() < 1 {
+		return fmt.Errorf("at least one component must be provided for deployment")
+	}
+
+	for _, component := range componentSet.Elements() {
+		if !validComponentSet.Contains(component) {
+			return fmt.Errorf("unknown component: %s", component)
+		}
+	}
+
+	return nil
 }
 
 func isValidGlobalnetConfig() (bool, error) {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -43,6 +43,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/servicediscoverycr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
 	"github.com/submariner-io/submariner-operator/pkg/versions"
@@ -214,7 +215,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 	}
 	exitOnError("Unable to check requirements", err)
 
-	if !noLabel {
+	if subctlData.IsConnectivityEnabled() && !noLabel {
 		err := handleNodeLabels(clientConfig)
 		exitOnError("Unable to set the gateway node up", err)
 	}
@@ -257,16 +258,30 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 	status.End(cli.CheckForError(err))
 	exitOnError("Error creating SA for cluster", err)
 
-	status.Start("Deploying Submariner")
-	err = submarinercr.Ensure(clientConfig, OperatorNamespace, populateSubmarinerSpec(subctlData, netconfig))
-	if err == nil {
-		status.QueueSuccessMessage("Submariner is up and running")
-		status.End(cli.Success)
-	} else {
-		status.QueueFailureMessage("Submariner deployment failed")
-		status.End(cli.Failure)
+	if subctlData.IsConnectivityEnabled() {
+		status.Start("Deploying Submariner")
+		err = submarinercr.Ensure(clientConfig, OperatorNamespace, populateSubmarinerSpec(subctlData, netconfig))
+		if err == nil {
+			status.QueueSuccessMessage("Submariner is up and running")
+			status.End(cli.Success)
+		} else {
+			status.QueueFailureMessage("Submariner deployment failed")
+			status.End(cli.Failure)
+		}
+
+		exitOnError("Error deploying Submariner", err)
+	} else if subctlData.IsServiceDiscoveryEnabled() {
+		status.Start("Deploying service discovery only")
+		err = servicediscoverycr.Ensure(clientConfig, OperatorNamespace, populateServiceDiscoverySpec(subctlData))
+		if err == nil {
+			status.QueueSuccessMessage("Service discovery is up an running")
+			status.End(cli.Success)
+		} else {
+			status.QueueFailureMessage("Service discovery deployment failed")
+			status.End(cli.Failure)
+		}
+		exitOnError("Error deploying service discovery", err)
 	}
-	exitOnError("Error deploying Submariner", err)
 }
 
 func checkRequirements(config *rest.Config) ([]string, error) {
@@ -453,7 +468,7 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		ClusterCIDR:              crClusterCIDR,
 		Namespace:                SubmarinerNamespace,
 		CableDriver:              cableDriver,
-		ServiceDiscoveryEnabled:  subctlData.ServiceDiscovery,
+		ServiceDiscoveryEnabled:  subctlData.IsServiceDiscoveryEnabled(),
 		ImageOverrides:           getImageOverrides(),
 		ConnectionHealthCheck: &submariner.HealthCheckSpec{
 			Enabled:            healthCheckEnable,
@@ -498,6 +513,41 @@ func getImageRepo() string {
 	}
 
 	return repo
+}
+
+func removeSchemaPrefix(brokerURL string) string {
+	if idx := strings.Index(brokerURL, "://"); idx >= 0 {
+		// Submariner doesn't work with a schema prefix
+		brokerURL = brokerURL[(idx + 3):]
+	}
+
+	return brokerURL
+}
+
+func populateServiceDiscoverySpec(subctlData *datafile.SubctlData) *submariner.ServiceDiscoverySpec {
+	brokerURL := removeSchemaPrefix(subctlData.BrokerURL)
+
+	if customDomains == nil && subctlData.CustomDomains != nil {
+		customDomains = *subctlData.CustomDomains
+	}
+
+	serviceDiscoverySpec := submariner.ServiceDiscoverySpec{
+		Repository:               repository,
+		Version:                  imageVersion,
+		BrokerK8sCA:              base64.StdEncoding.EncodeToString(subctlData.ClientToken.Data["ca.crt"]),
+		BrokerK8sRemoteNamespace: string(subctlData.ClientToken.Data["namespace"]),
+		BrokerK8sApiServerToken:  string(clienttoken.Data["token"]),
+		BrokerK8sApiServer:       brokerURL,
+		Debug:                    submarinerDebug,
+		ClusterID:                clusterID,
+		Namespace:                SubmarinerNamespace,
+		ImageOverrides:           getImageOverrides(),
+	}
+
+	if len(customDomains) > 0 {
+		serviceDiscoverySpec.CustomDomains = customDomains
+	}
+	return &serviceDiscoverySpec
 }
 
 func operatorImage() string {

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -34,6 +34,7 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
@@ -218,8 +219,8 @@ func checkVerifyArguments() error {
 }
 
 var verifyE2EPatterns = map[string]string{
-	"connectivity":      "\\[dataplane",
-	"service-discovery": "\\[discovery",
+	components.Connectivity:     "\\[dataplane",
+	components.ServiceDiscovery: "\\[discovery",
 }
 
 var verifyE2EDisruptivePatterns = map[string]string{

--- a/pkg/subctl/components/consts.go
+++ b/pkg/subctl/components/consts.go
@@ -1,0 +1,22 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+const (
+	Connectivity     = "connectivity"
+	ServiceDiscovery = "service-discovery"
+)

--- a/pkg/subctl/operator/servicediscoverycr/ensure.go
+++ b/pkg/subctl/operator/servicediscoverycr/ensure.go
@@ -1,0 +1,71 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicediscoverycr
+
+import (
+	"github.com/submariner-io/admiral/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	submariner "github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+)
+
+func init() {
+	err := submariner.AddToScheme(scheme.Scheme)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Ensure(config *rest.Config, namespace string, serviceDiscoverySpec *submariner.ServiceDiscoverySpec) error {
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	client := dynClient.Resource(schema.GroupVersionResource{
+		Group: "submariner.io", Version: "v1alpha1", Resource: "servicediscoveries"}).Namespace(namespace)
+
+	sd := &submariner.ServiceDiscovery{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      names.ServiceDiscoveryCrName,
+		},
+		Spec: *serviceDiscoverySpec,
+	}
+
+	return createServiceDiscovery(client, sd)
+}
+
+func createServiceDiscovery(client dynamic.ResourceInterface, sd *submariner.ServiceDiscovery) error {
+	serviceDiscovery, err := util.ToUnstructured(sd)
+	if err != nil {
+		return err
+	}
+
+	_, err = util.CreateOrUpdate(client, serviceDiscovery, func(existing *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		err = unstructured.SetNestedField(existing.Object, util.GetNestedField(serviceDiscovery, "spec"), "spec")
+		return existing, err
+	})
+
+	return err
+}


### PR DESCRIPTION
Allow service to be deployed without connectivity

This cover the use case of routed networks where pods and
services can already talk to remote clusters by other means
and the submariner routing and gateways are not required,
but service discovery is necessary.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>

(cherry picked from commit 0bd8c77)

[subctl-v0.8.1-2-g26e0c01-dev-linux-amd64.gz](https://github.com/submariner-io/submariner-operator/files/6029616/subctl-v0.8.1-2-g26e0c01-dev-linux-amd64.gz)
