### PR TITLE
Ignore resources pending deletion

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -127,6 +127,12 @@ func (r *ServiceDiscoveryReconciler) Reconcile(request reconcile.Request) (recon
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+
+	if instance.ObjectMeta.DeletionTimestamp != nil {
+		// Graceful deletion has been requested, ignore the object
+		return reconcile.Result{}, nil
+	}
+
 	lightHouseAgent := newLighthouseAgent(instance)
 	if _, err = helpers.ReconcileDeployment(instance, lightHouseAgent, reqLogger,
 		r.client, r.scheme); err != nil {

--- a/controllers/submariner/broker_controller.go
+++ b/controllers/submariner/broker_controller.go
@@ -64,6 +64,11 @@ func (r *BrokerReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) 
 		return reconcile.Result{}, err
 	}
 
+	if instance.ObjectMeta.DeletionTimestamp != nil {
+		// Graceful deletion has been requested, ignore the object
+		return reconcile.Result{}, nil
+	}
+
 	// Broker CRDs
 	crdUpdater := crdutils.NewFromControllerClient(r.Client)
 	err = gateway.Ensure(crdUpdater)

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -121,6 +121,11 @@ func (r *SubmarinerReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	if instance.ObjectMeta.DeletionTimestamp != nil {
+		// Graceful deletion has been requested, ignore the object
+		return reconcile.Result{}, nil
+	}
+
 	initialStatus := instance.Status.DeepCopy()
 
 	clusterNetwork, err := r.discoverNetwork(instance)


### PR DESCRIPTION
If a resource is deleted with a grace period, we will continue
receiving reconciliation requests for it, but we should ignore them.

Signed-off-by: Stephen Kitt <skitt@redhat.com>