### PR TITLE
The operator needs to be able to create configmaps

### DIFF
--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -12,6 +12,7 @@ rules:
     resources:
       - configmaps
     verbs:
+      - create
       - get
       - list
       - watch


### PR DESCRIPTION
... now that it takes care of the Globalnet configmap.

Fixes: #1124
Signed-off-by: Stephen Kitt <skitt@redhat.com>