### PR TITLE
Add `deploy` as PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,8 @@ Makefile.dapper:
 
 include Makefile.dapper
 
+.PHONY: deploy
+
 endif
 
 # Disable rebuilding Makefile


### PR DESCRIPTION
Since deploy directory exists, the included `deploy` target is never
considered. Hence it's necessary to explicitly mark it as PHONY outside
the dapper environment

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>