### PR TITLE
Drop the host mounts for GN and RA

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -591,9 +591,6 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 							// FIXME: Should be entrypoint script, find/use correct file for routeagent
 							Command:         []string{"submariner-route-agent.sh"},
 							SecurityContext: &securityContextAllCapAllowEscal,
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "host-slash", MountPath: "/host", ReadOnly: true},
-							},
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
@@ -612,9 +609,6 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					},
 					ServiceAccountName: "submariner-routeagent",
 					HostNetwork:        true,
-					Volumes: []corev1.Volume{
-						{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
-					},
 					// The route agent engine on all nodes, regardless of existing taints
 					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},
@@ -668,9 +662,6 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 							Image:           getImagePath(cr, names.GlobalnetImage),
 							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GlobalnetImage]),
 							SecurityContext: &securityContextAllCapAllowEscal,
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "host-slash", MountPath: "/host", ReadOnly: true},
-							},
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
@@ -687,9 +678,6 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					NodeSelector:                  map[string]string{"submariner.io/gateway": "true"},
 					HostNetwork:                   true,
-					Volumes: []corev1.Volume{
-						{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
-					},
 					// The Globalnet Pod must be able to run on any flagged node, regardless of existing taints
 					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -345,11 +345,9 @@ function verify_subm_routeagent_pod() {
     validate_pod_container_env 'SUBMARINER_DEBUG' $subm_debug
     validate_pod_container_env 'SUBMARINER_SERVICECIDR' ${service_CIDRs[$cluster]}
     validate_pod_container_env 'SUBMARINER_CLUSTERCIDR' ${cluster_CIDRs[$cluster]}
-    validate_pod_container_volume_mount '/host' 'host-slash' 'true'
 
     validate_equals '.spec.serviceAccount' 'submariner-routeagent'
 
-    [[ $(jq -r ".spec.volumes[] | select(.name==\"host-slash\").hostPath.path" $json_file) = '/' ]]
     validate_equals '.status.phase' 'Running'
     validate_equals '.metadata.namespace' $subm_ns
     validate_equals '.spec.terminationGracePeriodSeconds' '1'


### PR DESCRIPTION
The Globalnet and route agents no longer need host mounts, remove
them.

This needs https://github.com/submariner-io/submariner/pull/1186.

Signed-off-by: Stephen Kitt <skitt@redhat.com>