### PR TITLE
Validate if the clusters have overlapping CIDRs

### DIFF
--- a/pkg/internal/cli/status.go
+++ b/pkg/internal/cli/status.go
@@ -152,6 +152,10 @@ func (s *Status) QueueWarningMessage(message string) {
 	s.warningQueue = append(s.warningQueue, message)
 }
 
+func (s *Status) HasFailureMessages() bool {
+	return len(s.failureQueue) > 0
+}
+
 func CheckForError(err error) Result {
 	if err == nil {
 		return Success

--- a/pkg/subctl/cmd/validate_deployment.go
+++ b/pkg/subctl/cmd/validate_deployment.go
@@ -17,46 +17,129 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	smClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+
+	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 )
 
 var validatePodsCmd = &cobra.Command{
-	Use:   "pods",
-	Short: "Validate the submariner pods",
-	Long:  "This command checks that all the submariner pods are running",
-	Run:   validatePods,
+	Use:   "deployment",
+	Short: "Validate the submariner deployment",
+	Long: "This command checks that the submariner components are properly deployed and running" +
+		" with no overlapping CIDRs.",
+	Run: validateSubmarinerDeployment,
 }
 
 func init() {
 	validateCmd.AddCommand(validatePodsCmd)
 }
 
-func validatePods(cmd *cobra.Command, args []string) {
+func validateSubmarinerDeployment(cmd *cobra.Command, args []string) {
 	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
 	exitOnError("error getting REST config for cluster", err)
 
 	for _, item := range configs {
-		message := fmt.Sprintf("Validating submariner pods in %q", item.clusterName)
-		status.Start(message)
-		fmt.Println()
-		checkPods(item.config, OperatorNamespace)
+		submariner := getSubmarinerResource(item.config)
+		if submariner == nil {
+			status.QueueWarningMessage(submMissingMessage)
+			status.End(cli.Success)
+			return
+		}
+
+		checkPods(item, submariner, OperatorNamespace)
+		checkOverlappingCIDRs(item, submariner)
 	}
 }
 
-func checkPods(config *rest.Config, operatorNamespace string) {
-	submariner := getSubmarinerResource(config)
-	if submariner == nil {
-		status.QueueWarningMessage(submMissingMessage)
-		status.End(cli.Success)
-		return
+func checkOverlappingCIDRs(item restConfig, submariner *v1alpha1.Submariner) {
+	var message string
+	submarinerClient, err := smClientset.NewForConfig(item.config)
+	exitOnError("Unable to get the Submariner client", err)
+
+	localClusterName := submariner.Status.ClusterID
+	endpointList, err := submarinerClient.SubmarinerV1().Endpoints(submariner.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		exitOnError("Error while listing the endpoints", err)
 	}
 
-	kubeClientSet, err := kubernetes.NewForConfig(config)
+	status.Start("Verifying if cluster CIDRs overlap")
+
+	var localEndpoint submarinerv1.Endpoint
+	overlappingClusters := make(map[string]submarinerv1.Endpoint)
+	for i, source := range endpointList.Items {
+		if localClusterName == source.Spec.ClusterID {
+			localEndpoint = source
+		}
+
+		for _, dest := range endpointList.Items[i+1:] {
+			// Currently we dont support multiple endpoints in a cluster, hence return an error.
+			// When the corresponding support is added, this check needs to be updated.
+			if source.Spec.ClusterID == dest.Spec.ClusterID {
+				message = fmt.Sprintf("Looks like some stale endpoints are present for cluster %q",
+					source.Spec.ClusterID)
+				status.QueueFailureMessage(message)
+				status.End(cli.Failure)
+				break
+			}
+
+			for _, subnet := range dest.Spec.Subnets {
+				overlap, err := util.IsOverlappingCIDR(source.Spec.Subnets, subnet)
+				if err != nil {
+					// Ideally this case will never hit, as the subnets are valid CIDRs
+					message = fmt.Sprintf("Error parsing the CIDR %s in cluster %q", err, dest.Spec.ClusterID)
+					status.QueueFailureMessage(message)
+					status.End(cli.Failure)
+					break
+				}
+
+				if overlap {
+					overlappingClusters[source.Spec.ClusterID] = source
+					overlappingClusters[dest.Spec.ClusterID] = dest
+				}
+			}
+		}
+	}
+
+	if len(overlappingClusters) > 0 {
+		if _, exists := overlappingClusters[localClusterName]; exists {
+			delete(overlappingClusters, localClusterName)
+			message = fmt.Sprintf("localCluster %q with CIDRs %q overlaps with clusters %#v",
+				localClusterName, localEndpoint.Spec.Subnets, overlappingClusters)
+		} else {
+			message = fmt.Sprintf("localCluster %q does not have overlapping CIDRs with other member clusters. "+
+				"However, the following submariner member clusters have overlapping CIDRs %#v", localClusterName,
+				getClusterDetails(overlappingClusters))
+		}
+		status.QueueFailureMessage(message)
+		status.End(cli.Failure)
+	}
+
+	status.QueueSuccessMessage("Clusters do not have overlapping CIDRs")
+	status.End(cli.Success)
+}
+
+func getClusterDetails(overlappingClusters map[string]submarinerv1.Endpoint) string {
+	output := []string{}
+	for _, cluster := range overlappingClusters {
+		output = append(output, fmt.Sprintf("clusterID: %s, subnets: %s", cluster.Spec.ClusterID, cluster.Spec.Subnets))
+	}
+	return strings.Join(output, " ; ")
+}
+
+func checkPods(item restConfig, submariner *v1alpha1.Submariner, operatorNamespace string) {
+	message := fmt.Sprintf("Validating submariner pods in %q", item.clusterName)
+	status.Start(message)
+	fmt.Println()
+
+	kubeClientSet, err := kubernetes.NewForConfig(item.config)
 
 	if err != nil {
 		exitOnError("error creating Kubernetes client", err)
@@ -89,7 +172,7 @@ func checkPods(config *rest.Config, operatorNamespace string) {
 		}
 	}
 
-	message := "All Submariner pods are up and running"
+	message = "All Submariner pods are up and running"
 	status.QueueSuccessMessage(message)
 	status.End(cli.Success)
 }


### PR DESCRIPTION
This PR validates the endpoint objects in the cluster and verifies if
they have overlapping CIDRs. The implementation works for both vanilla
Submariner as well as Globalnet deployments as we check the endpoint objects.
Along with overlapping check, it also verifies if there are any stale
endpoint objects in the cluster.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1144
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>