### PR TITLE
Write each resource to separate file

### DIFF
--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -80,7 +80,7 @@ func processLogStream(logrequest *rest.Request) (string, error) {
 }
 
 func writeLogToFile(data, podName string, info *Info) error {
-	fileName := filepath.Join(info.DirName, info.ClusterName+"-"+podName+".log")
+	fileName := filepath.Join(info.DirName, info.ClusterName+"_"+podName+".log")
 	f, err := os.Create(fileName)
 	if err != nil {
 		return errors.WithMessagef(err, "error opening file %s", fileName)


### PR DESCRIPTION
If there are say 2 configmaps, each cm will be written
to seaparate file (2 files in total) at location
`submariner-<timestamp>/cluster1-configmaps-cm1name.yaml`
and
`submariner-<timestamp>/cluster1-configmaps-cm2name.yaml`

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>