### PR TITLE
Add simple e2e tests for subctl gather command

### DIFF
--- a/pkg/subctl/cmd/gather.go
+++ b/pkg/subctl/cmd/gather.go
@@ -34,6 +34,7 @@ import (
 var (
 	gatherType   string
 	gatherModule string
+	directory    string
 )
 
 const (
@@ -71,6 +72,9 @@ func addGatherFlags(gatherCmd *cobra.Command) {
 		"comma-separated list of data types to gather")
 	gatherCmd.Flags().StringVar(&gatherModule, "module", strings.Join(getAllModuleKeys(), ","),
 		"comma-separated list of components for which to gather data")
+	gatherCmd.Flags().StringVar(&directory, "dir", "",
+		"the directory in which to store files. If not specified, a directory of the form \"submariner-<timestamp>\" "+
+			"is created in the current directory")
 }
 
 var gatherCmd = &cobra.Command{
@@ -105,11 +109,14 @@ func gatherData() {
 		return
 	}
 
-	dirName := "submariner-" + time.Now().UTC().Format("20060102150405") // submariner-YYYYMMDDHHMMSS
-	if _, err := os.Stat(dirName); os.IsNotExist(err) {
-		err := os.MkdirAll(dirName, 0700)
+	if directory == "" {
+		directory = "submariner-" + time.Now().UTC().Format("20060102150405") // submariner-YYYYMMDDHHMMSS
+	}
+
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		err := os.MkdirAll(directory, 0700)
 		if err != nil {
-			exitOnError(fmt.Sprintf("Error creating directory %s", dirName), err)
+			exitOnError(fmt.Sprintf("Error creating directory %q", directory), err)
 		}
 	}
 
@@ -119,7 +126,7 @@ func gatherData() {
 		RestConfig:  restConfig,
 		Submariner:  submariner,
 		ClusterName: clusterName,
-		DirName:     dirName,
+		DirName:     directory,
 	}
 
 	info.ClientSet, err = kubernetes.NewForConfig(restConfig)

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -36,15 +36,14 @@ else
     verify="--only connectivity"
 fi
 
-subm_ns=""
-if [[ -n "$SUBM_NS" ]]; then
-    subm_ns="--submariner-namespace=$SUBM_NS"
-fi
-
 # run dataplane E2E tests between the two clusters
-${DAPPER_SOURCE}/bin/subctl verify ${verify} ${subm_ns} --verbose --connection-timeout 20 --connection-attempts 4 \
+${DAPPER_SOURCE}/bin/subctl verify ${verify} --submariner-namespace=$subm_ns --verbose --connection-timeout 20 --connection-attempts 4 \
     ${KUBECONFIGS_DIR}/kind-config-cluster1 \
     ${KUBECONFIGS_DIR}/kind-config-cluster2
+
+. ${DAPPER_SOURCE}/scripts/kind-e2e/lib_subctl_gather_test.sh
+
+with_context "${clusters[1]}" test_subctl_gather
 
 print_clusters_message
 

--- a/scripts/kind-e2e/lib_subctl_gather_test.sh
+++ b/scripts/kind-e2e/lib_subctl_gather_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This should only be sourced
+if [ "${0##*/}" = "lib_subctl_gather_test.sh" ]; then
+    echo "Don't run me, source me" >&2
+    exit 1
+fi
+
+function test_subctl_gather() {
+  out_dir=/tmp/subctl-gather-output
+  rm -rf $out_dir
+  mkdir $out_dir
+
+  ${DAPPER_SOURCE}/bin/subctl gather --kubeconfig ${KUBECONFIGS_DIR}/kind-config-${cluster} --dir $out_dir
+
+  validate_resources_file $subm_ns 'endpoints.submariner.io' 'Endpoint' "$out_dir/${cluster}-endpoints.yaml"
+  validate_resources_file $subm_ns 'clusters.submariner.io' 'Cluster' "$out_dir/${cluster}-clusters.yaml"
+  validate_resources_file $subm_ns 'gateways.submariner.io' 'Gateway' "$out_dir/${cluster}-gateways.yaml"
+
+  validate_pod_log_files $subm_ns $gateway_deployment_name
+  validate_pod_log_files $subm_ns $routeagent_deployment_name
+}
+
+function validate_pod_log_files() {
+  local ns=$1
+  local label=$2
+
+  pod_names=$(kubectl get pods --namespace=$ns -l app=$label -o=jsonpath='{.items..metadata.name}')
+  read -ra pod_names_array <<< "$pod_names"
+
+  for pod_name in "${pod_names_array[@]}"; do
+    file=$out_dir/${cluster}-$pod_name.log
+    cat $file
+  done
+}
+
+function validate_resources_file() {
+  local ns=$1
+  local resource=$2
+  local kind=$3
+  local file=$4
+
+  exp_num=$(kubectl get $resource --namespace=$ns -o=yaml | grep "kind: $kind$" | wc -l)
+
+  cat $file
+  actual_num=$(grep "kind: $kind$" $file | wc -l)
+  if [[ $exp_num != $actual_num ]]; then
+     echo "Expected $exp_num $resource but got $actual_num"
+     return 1
+  fi
+}
+


### PR DESCRIPTION
For resources, it verifies the number of resource entries in the file matches the number returned from kubectl. 

For pods, it verifies the existence of log files based on the pod names returned from kubectl. 