### PR TITLE
Validate firewall configuration for prometheus metrics

### DIFF
--- a/pkg/subctl/cmd/validate_firewall.go
+++ b/pkg/subctl/cmd/validate_firewall.go
@@ -17,6 +17,10 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/resource"
 )
 
 var validateFirewallConfigCmd = &cobra.Command{
@@ -25,6 +29,49 @@ var validateFirewallConfigCmd = &cobra.Command{
 	Long:  "This command checks whether the firewall is configured as per Submariner pre-requisites.",
 }
 
+var validationTimeout uint
+
+func addValidateFWConfigFlags(cmd *cobra.Command) {
+	cmd.Flags().UintVar(&validationTimeout, "validation-timeout", 90,
+		"timeout in seconds while validating the connection attempt")
+	cmd.Flags().StringVar(&namespace, "namespace", "default",
+		"namespace in which validation pods should be deployed")
+}
+
 func init() {
 	validateCmd.AddCommand(validateFirewallConfigCmd)
+}
+
+func spawnSnifferPodOnGatewayNode(clientSet *kubernetes.Clientset,
+	namespace, podCommand string) (*resource.NetworkPod, error) {
+	sPod, err := resource.SchedulePod(&resource.PodConfig{
+		Name:       "validate-fwconfig-sniffer",
+		ClientSet:  clientSet,
+		Scheduling: framework.GatewayNode,
+		Networking: framework.HostNetworking,
+		Namespace:  namespace,
+		Command:    podCommand,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return sPod, nil
+}
+
+func spawnClientPodOnNonGatewayNode(clientSet *kubernetes.Clientset,
+	namespace, podCommand string) (*resource.NetworkPod, error) {
+	cPod, err := resource.SchedulePod(&resource.PodConfig{
+		Name:       "validate-fwconfig-client",
+		ClientSet:  clientSet,
+		Scheduling: framework.NonGatewayNode,
+		Networking: framework.PodNetworking,
+		Namespace:  namespace,
+		Command:    podCommand,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return cPod, nil
 }

--- a/pkg/subctl/cmd/validate_fw_metrics.go
+++ b/pkg/subctl/cmd/validate_fw_metrics.go
@@ -29,7 +29,7 @@ const (
 
 var validateFirewallMetricsCmd = &cobra.Command{
 	Use:   "metrics",
-	Short: "Validate if firewall allows metrics on the Gateway nodes.",
+	Short: "Validate firewall access to metrics.",
 	Long:  "This command checks whether firewall configuration allows metrics to be read from the Gateway nodes.",
 	Run:   validateFirewallMetricsConfig,
 }
@@ -99,5 +99,5 @@ func validateFirewallMetricsConfigWithinCluster(item restConfig) {
 		return
 	}
 
-	status.QueueSuccessMessage("The firewall configuration for prometheus metrics is working fine.")
+	status.QueueSuccessMessage("Prometheus metrics can be retrieved from gateway nodes.")
 }

--- a/pkg/subctl/cmd/validate_fw_metrics.go
+++ b/pkg/subctl/cmd/validate_fw_metrics.go
@@ -1,0 +1,103 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	TCPSniffMetricsCommand = "tcpdump -ln -c 5 -i any tcp and src port 9898 and dst port 8080 and 'tcp[tcpflags] == tcp-syn'"
+)
+
+var validateFirewallMetricsCmd = &cobra.Command{
+	Use:   "metrics",
+	Short: "Validate if firewall allows metrics on the Gateway nodes.",
+	Long:  "This command checks whether firewall configuration allows metrics to be read from the Gateway nodes.",
+	Run:   validateFirewallMetricsConfig,
+}
+
+func init() {
+	addValidateFWConfigFlags(validateFirewallMetricsCmd)
+	validateFirewallConfigCmd.AddCommand(validateFirewallMetricsCmd)
+}
+
+func validateFirewallMetricsConfig(cmd *cobra.Command, args []string) {
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	exitOnError("Error getting REST config for cluster", err)
+
+	for _, item := range configs {
+		status.Start(fmt.Sprintf("Validating the firewall configuration to check if metrics port (8080)"+
+			" is allowed in cluster %q", item.clusterName))
+		validateFirewallMetricsConfigWithinCluster(item)
+		status.End(status.ResultFromMessages())
+	}
+}
+
+func validateFirewallMetricsConfigWithinCluster(item restConfig) {
+	clientSet, err := kubernetes.NewForConfig(item.config)
+	if err != nil {
+		message := fmt.Sprintf("Error creating API server client: %s", err)
+		status.QueueFailureMessage(message)
+		return
+	}
+
+	podCommand := fmt.Sprintf("timeout %d %s", validationTimeout, TCPSniffMetricsCommand)
+	sPod, err := spawnSnifferPodOnGatewayNode(clientSet, namespace, podCommand)
+	if err != nil {
+		message := fmt.Sprintf("Error while spawning the sniffer pod on the GatewayNode: %v", err)
+		status.QueueFailureMessage(message)
+		return
+	}
+
+	defer sPod.DeletePod()
+	gatewayPodIP := sPod.Pod.Status.HostIP
+	podCommand = fmt.Sprintf("for i in $(seq 10); do timeout 2 nc -p 9898 %s 8080; done", gatewayPodIP)
+	cPod, err := spawnClientPodOnNonGatewayNode(clientSet, namespace, podCommand)
+	if err != nil {
+		message := fmt.Sprintf("Error while spawning the client pod on non-Gateway node: %v", err)
+		status.QueueFailureMessage(message)
+		return
+	}
+
+	defer cPod.DeletePod()
+	if err = cPod.AwaitPodCompletion(); err != nil {
+		message := fmt.Sprintf("Error while waiting for client pod to be finish its execution: %v", err)
+		status.QueueFailureMessage(message)
+		return
+	}
+
+	if err = sPod.AwaitPodCompletion(); err != nil {
+		message := fmt.Sprintf("Error while waiting for sniffer pod to be finish its execution: %v", err)
+		status.QueueFailureMessage(message)
+		return
+	}
+
+	// Verify that tcpdump output (i.e, from snifferPod) contains the HostIP of clientPod
+	if !strings.Contains(sPod.PodOutput, cPod.Pod.Status.HostIP) {
+		message := fmt.Sprintf("The tcpdump output from the sniffer pod does not contain the"+
+			" client pod HostIP. Please check that your firewall configuration allows TCP/8080 traffic"+
+			" on the %q node.", sPod.Pod.Spec.NodeName)
+		status.QueueFailureMessage(message)
+		return
+	}
+
+	status.QueueSuccessMessage("The firewall configuration for prometheus metrics is working fine.")
+}


### PR DESCRIPTION
This PR validates if the firewall configuration in the cluster allows
TCP/8080 traffic on the Gateway nodes. Validation is done by spawning
a tcpdump sniffer pod on the Gateway node and a client pod on one of
the non-Gateway nodes. The clientPod tries to send some tcp traffic
to the Gateway node while tcpdump is executed in the sniffer pod.
Finally, when both the Pods finish their execution, the Pod output is
compared with expected values and appropriate message is displayed to
the user.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1148
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>