### PR TITLE
No failure message when no pods found

### DIFF
--- a/pkg/subctl/cmd/gather.go
+++ b/pkg/subctl/cmd/gather.go
@@ -157,15 +157,11 @@ func gatherConnectivity(dataType string, info *gather.Info) bool {
 		err := gather.GatewayPodLogs(info)
 		if err != nil {
 			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather Gateway pod logs: %s", err))
-		} else {
-			info.Status.QueueSuccessMessage("Successfully gathered Gateway pod logs")
 		}
 
 		err = gather.RouteAgentPodLogs(info)
 		if err != nil {
 			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather Route Agent pod logs: %s", err))
-		} else {
-			info.Status.QueueSuccessMessage("Successfully gathered Route Agent pod logs")
 		}
 	case Resources:
 		gather.Endpoints(info, SubmarinerNamespace)

--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -36,6 +36,8 @@ func gatherPodLogs(podLabelSelector string, info *Info) error {
 		return err
 	}
 
+	info.Status.QueueSuccessMessage(fmt.Sprintf("Found %d pods matching label selector %q", len(pods.Items), podLabelSelector))
+
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		err := podLogsToFile(pod, info)
@@ -100,10 +102,6 @@ func findPods(clientSet kubernetes.Interface, byLabelSelector string) (*corev1.P
 
 	if err != nil {
 		return nil, errors.WithMessage(err, "error listing pods")
-	}
-
-	if len(pods.Items) == 0 {
-		return nil, fmt.Errorf("no pods found matching label selector %q", byLabelSelector)
 	}
 
 	return pods, nil


### PR DESCRIPTION
`subctl gather` prints a failure message when no pods are found. The purpose of the command is to gather data, not validate - we have other commands for that. Instead print the number of pods found as a success message.

