### PR TITLE
Add additional parameters for IPSec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,9 @@ issues:
         - lll
         - stylecheck
       path: "pkg/subctl/operator/common/embeddedyamls/yamls.go"
-
+    - linters:
+        - maligned
+      path: "apis/submariner/v1alpha1/submariner_types.go"
     # BrokerK8sApiServer parameter is used by other projects, like ACM,
     # so not changing it to BrokerK8sAPIServer as suggested by stylecheck
     - linters:

--- a/apis/submariner/v1alpha1/submariner_types.go
+++ b/apis/submariner/v1alpha1/submariner_types.go
@@ -52,6 +52,8 @@ type SubmarinerSpec struct {
 	CeIPSecIKEPort           int                  `json:"ceIPSecIKEPort,omitempty"`
 	CeIPSecNATTPort          int                  `json:"ceIPSecNATTPort,omitempty"`
 	CeIPSecDebug             bool                 `json:"ceIPSecDebug"`
+	CeIPSecPreferredServer   bool                 `json:"ceIPSecPreferredServer,omitempty"`
+	CeIPSecForceUDPEncaps    bool                 `json:"ceIPSecForceUDPEncaps,omitempty"`
 	Debug                    bool                 `json:"debug"`
 	NatEnabled               bool                 `json:"natEnabled"`
 	ServiceDiscoveryEnabled  bool                 `json:"serviceDiscoveryEnabled,omitempty"`

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -50,12 +50,16 @@ spec:
                 type: string
               ceIPSecDebug:
                 type: boolean
+              ceIPSecForceUDPEncaps:
+                type: boolean
               ceIPSecIKEPort:
                 type: integer
               ceIPSecNATTPort:
                 type: integer
               ceIPSecPSK:
                 type: string
+              ceIPSecPreferredServer:
+                type: boolean
               clusterCIDR:
                 type: string
               clusterID:

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -539,6 +539,12 @@ func newGatewayPodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 			corev1.EnvVar{Name: "CE_IPSEC_NATTPORT", Value: strconv.Itoa(cr.Spec.CeIPSecNATTPort)})
 	}
 
+	podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "CE_IPSEC_PREFERREDSERVER", Value: strconv.FormatBool(cr.Spec.CeIPSecPreferredServer)})
+
+	podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "CE_IPSEC_FORCEENCAPS", Value: strconv.FormatBool(cr.Spec.CeIPSecForceUDPEncaps)})
+
 	return podTemplate
 }
 

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -58,6 +58,8 @@ var (
 	imageVersion                  string
 	nattPort                      int
 	ikePort                       int
+	preferredServer               bool
+	forceUDPEncaps                bool
 	colorCodes                    string
 	natTraversal                  bool
 	disableNat                    bool
@@ -95,6 +97,11 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&natTraversal, "natt", true, "enable NAT traversal for IPsec")
 	cmd.Flags().BoolVar(&disableNat, "disable-nat", false, "disable NAT for IPsec")
 	err := cmd.Flags().MarkDeprecated("disable-nat", "please use --natt=false instead")
+
+	cmd.Flags().BoolVar(&preferredServer, "preferred-server", false,
+		"enable this cluster as a preferred server for dataplane connections")
+	cmd.Flags().BoolVar(&forceUDPEncaps, "force-udp-encaps", false, "force UDP encapsulation for IPSec")
+
 	// Errors here are fatal programming errors
 	exitOnError("deprecation error", err)
 	cmd.Flags().BoolVar(&ipsecDebug, "ipsec-debug", false, "enable IPsec debugging (verbose logging)")
@@ -481,6 +488,8 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 		CeIPSecNATTPort:          nattPort,
 		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             ipsecDebug,
+		CeIPSecForceUDPEncaps:    forceUDPEncaps,
+		CeIPSecPreferredServer:   preferredServer,
 		CeIPSecPSK:               base64.StdEncoding.EncodeToString(subctlData.IPSecPSK.Data["psk"]),
 		BrokerK8sCA:              base64.StdEncoding.EncodeToString(subctlData.ClientToken.Data["ca.crt"]),
 		BrokerK8sRemoteNamespace: string(subctlData.ClientToken.Data["namespace"]),


### PR DESCRIPTION
to subctl join:
--preferred-server
--force-udp-encaps

which are passed down to the submariner-gateway as:

- CE_IPSEC_PREFERREDSERVER
- CE_IPSEC_FORCEENCAPS

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
