### PR TITLE
Make config changes to PR dependency workflow

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -5,17 +5,19 @@ on:
   issues:
     types:
       - opened
+      - edited
+      - closed
       - reopened
+      - synchronize
   pull_request_target:
     types:
       - opened
+      - edited
+      - closed
       - reopened
-  pull_request:
-    types:
-      - opened
-      - reopened
+      - synchronize
   schedule:
-    - cron: '0 0 * * *' # check daily
+    - cron: '0 0/6 * * *' # every 6 hours
 
 jobs:
   check:


### PR DESCRIPTION
 This PR makes below changes to the action config:

1. Run workflow only on `pull_request_target` as it
   has read/write repository token and can access secrets
2. Run the job whenever a PR is
   - opened
   - edited
   - closed
   - reopened
   - synchronize
3. Run the job every 6 hours as well

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>