### PR TITLE
subctl validate connections: show error message when there are no connections at all

### DIFF
--- a/pkg/subctl/cmd/validate_connections.go
+++ b/pkg/subctl/cmd/validate_connections.go
@@ -64,6 +64,13 @@ func validateConnections(cmd *cobra.Command, args []string) {
 			if gateway.Status.HAStatus != submv1.HAStatusActive {
 				continue
 			}
+
+			if len(gateway.Status.Connections) == 0 {
+				status.QueueFailureMessage("There are no active connections")
+				status.End(cli.Failure)
+				return
+			}
+
 			for _, connection := range gateway.Status.Connections {
 				if connection.Status == submv1.Connecting {
 					message = fmt.Sprintf("Connection to cluster %q is in progress", connection.Endpoint.ClusterID)


### PR DESCRIPTION
Show error message when there are no connections at all

Signed-off-by: Maayan Friedman <maafried@redhat.com>