### PR TITLE
Re-enable maligned on submariner_types.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,9 +61,6 @@ issues:
         - lll
         - stylecheck
       path: "pkg/subctl/operator/common/embeddedyamls/yamls.go"
-    - linters:
-        - maligned
-      path: "apis/submariner/v1alpha1/submariner_types.go"
     # BrokerK8sApiServer parameter is used by other projects, like ACM,
     # so not changing it to BrokerK8sAPIServer as suggested by stylecheck
     - linters:


### PR DESCRIPTION
Since the committed structure from commit e5a12e29a485 ("Add
additional parameters for IPSec") adds bools rather than pointers,
maligned doesn't complain, so we can re-enable it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>