### PR TITLE
Remove the blanket version check on verify

### DIFF
--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -95,7 +95,6 @@ The following verifications are deemed disruptive:
 		}
 		return checkVerifyArguments()
 	},
-	PreRunE: checkVersionMismatch,
 	Run: func(cmd *cobra.Command, args []string) {
 		testType := ""
 		configureTestingFramework(args)


### PR DESCRIPTION
subctl verify uses specific kubeconfigs provided on the command-line,
so checking the default context for a Submariner version is confusing
and ultimately fruitless. For now, this removes the check; verify's
config and context handling will be reworked more globally for #1130.

Fixes: #1209
Signed-off-by: Stephen Kitt <skitt@redhat.com>