### PR TITLE
subctl join to list master nodes when labelled as workers

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -163,19 +163,27 @@ func handleNodeLabels(config *rest.Config) error {
 }
 
 func askForGatewayNode(clientset kubernetes.Interface) (struct{ Node string }, error) {
-	// List all nodes and select one
-	allNodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/master"})
+	// List the worker nodes and select one
+	workerNodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
 	if err != nil {
 		return struct{ Node string }{}, err
 	}
-	if len(allNodes.Items) == 0 {
-		return struct{ Node string }{}, nil
+	if len(workerNodes.Items) == 0 {
+		// In some deployments (like KIND), worker nodes are not explicitly labelled. So list non-master nodes.
+		workerNodes, err = clientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/master"})
+		if err != nil {
+			return struct{ Node string }{}, err
+		}
+		if len(workerNodes.Items) == 0 {
+			return struct{ Node string }{}, nil
+		}
 	}
-	if len(allNodes.Items) == 1 {
-		return struct{ Node string }{allNodes.Items[0].GetName()}, nil
+
+	if len(workerNodes.Items) == 1 {
+		return struct{ Node string }{workerNodes.Items[0].GetName()}, nil
 	}
 	allNodeNames := []string{}
-	for _, node := range allNodes.Items {
+	for _, node := range workerNodes.Items {
 		allNodeNames = append(allNodeNames, node.GetName())
 	}
 	var qs = []*survey.Question{


### PR DESCRIPTION
In some deployments (like a master only deployment) where the master
node[s] are labelled as workers, subctl join should list such nodes
to the user for selection of Gateway node.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1210
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>