### PR TITLE
Use contexts for subctl verify

### DIFF
--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -78,7 +78,11 @@ func checkBenchmarkArguments(args []string, intraCluster bool) error {
 }
 
 func testThroughput(cmd *cobra.Command, args []string) {
-	configureTestingFramework(args)
+	err := configureTestingFramework(args)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
 
 	if benchmark.Verbose {
 		fmt.Printf("Performing throughput tests\n")
@@ -87,7 +91,11 @@ func testThroughput(cmd *cobra.Command, args []string) {
 }
 
 func testLatency(cmd *cobra.Command, args []string) {
-	configureTestingFramework(args)
+	err := configureTestingFramework(args)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
 
 	if benchmark.Verbose {
 		fmt.Printf("Performing latency tests\n")

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -37,9 +37,9 @@ else
 fi
 
 # run dataplane E2E tests between the two clusters
-${DAPPER_SOURCE}/bin/subctl verify ${verify} --submariner-namespace=$subm_ns --verbose --connection-timeout 20 --connection-attempts 4 \
-    ${KUBECONFIGS_DIR}/kind-config-cluster1 \
-    ${KUBECONFIGS_DIR}/kind-config-cluster2
+${DAPPER_SOURCE}/bin/subctl verify ${verify} --submariner-namespace=$subm_ns \
+    --verbose --connection-timeout 20 --connection-attempts 4 \
+    --kubecontexts cluster1,cluster2
 
 . ${DAPPER_SOURCE}/scripts/kind-e2e/lib_subctl_gather_test.sh
 


### PR DESCRIPTION
Allow the user to specify contexts as arguments to subctl verify,
instead of kubeconfigs; this allows contexts to be loaded from the
KUBECONFIG environment variable, and with the help of the loading fix
in Shipyard, avoids errors when the default context is set in the
kubeconfigs.

To ease the transition, kubeconfigs are still supported.

Depends on: https://github.com/submariner-io/shipyard/pull/511
Fixes: #1130
Signed-off-by: Stephen Kitt <skitt@redhat.com>