### PR TITLE
0.9.0-m1 release of subctl deploys devel images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ bin/subctl-%: generate-embeddedyamls $(shell find pkg/subctl/ -name "*.go") vend
 	export GOARCH GOOS; \
 	$(SCRIPTS_DIR)/compile.sh \
 		--ldflags "-X github.com/submariner-io/submariner-operator/pkg/version.Version=$(CALCULATED_VERSION) \
-			   -X=github.com/submariner-io/submariner-operator/pkg/versions.DefaultSubmarinerOperatorVersion=$(if eq($(patsubst subctl-devel-%,devel,$(CALCULATED_VERSION)),devel),devel,$(CALCULATED_VERSION))" \
+			   -X=github.com/submariner-io/submariner-operator/pkg/versions.DefaultSubmarinerOperatorVersion=$(if $(eq($(patsubst subctl-devel-%,devel,$(CALCULATED_VERSION)),devel)),devel,$(CALCULATED_VERSION))" \
 		--noupx $@ ./pkg/subctl/main.go
 
 ci: generate-embeddedyamls golangci-lint markdownlint unit build images


### PR DESCRIPTION
The `if` condition in the Makefile that calculates `versions.DefaultSubmarinerOperatorVersion` when building `subctl` needs to be made a var (surrounded by `$()`, ie `$(eq(...,devel))`) so it is properly expanded and evaluated so it doesn't always yield "devel".

