### PR TITLE
Move failure logging to gatherPodLogs

### DIFF
--- a/pkg/subctl/cmd/gather.go
+++ b/pkg/subctl/cmd/gather.go
@@ -143,25 +143,10 @@ func gatherData() {
 func gatherConnectivity(dataType string, info gather.Info) bool {
 	switch dataType {
 	case Logs:
-		err := gather.GatewayPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather Gateway pod logs: %s", err))
-		}
-
-		err = gather.RouteAgentPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather Route Agent pod logs: %s", err))
-		}
-
-		err = gather.GlobalnetPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather Globalnet pod logs: %s", err))
-		}
-
-		err = gather.NetworkPluginSyncerPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather NetworkPluginSyncer pod logs: %s", err))
-		}
+		gather.GatewayPodLogs(info)
+		gather.RouteAgentPodLogs(info)
+		gather.GlobalnetPodLogs(info)
+		gather.NetworkPluginSyncerPodLogs(info)
 	case Resources:
 		gather.Endpoints(info, SubmarinerNamespace)
 		gather.Clusters(info, SubmarinerNamespace)
@@ -176,15 +161,8 @@ func gatherConnectivity(dataType string, info gather.Info) bool {
 func gatherDiscovery(dataType string, info gather.Info) bool {
 	switch dataType {
 	case Logs:
-		err := gather.ServiceDiscoveryPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather all ServiceDiscovery pod logs: %s", err))
-		}
-
-		err = gather.CoreDNSPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather CoreDNS pod logs: %s", err))
-		}
+		gather.ServiceDiscoveryPodLogs(info)
+		gather.CoreDNSPodLogs(info)
 	case Resources:
 		gather.ServiceExports(info, corev1.NamespaceAll)
 		gather.ServiceImports(info, corev1.NamespaceAll)
@@ -231,10 +209,7 @@ func gatherBroker(dataType string, info gather.Info) bool {
 func gatherOperator(dataType string, info gather.Info) bool {
 	switch dataType {
 	case Logs:
-		err := gather.SubmarinerOperatorPodLogs(info)
-		if err != nil {
-			info.Status.QueueFailureMessage(fmt.Sprintf("Failed to gather Submariner operator pod logs: %s", err))
-		}
+		gather.SubmarinerOperatorPodLogs(info)
 	case Resources:
 		gather.Submariners(info, SubmarinerNamespace)
 		gather.ServiceDiscoveries(info, SubmarinerNamespace)

--- a/pkg/subctl/cmd/gather/connectivity.go
+++ b/pkg/subctl/cmd/gather/connectivity.go
@@ -29,20 +29,20 @@ const (
 	networkpluginSyncerPodLabel = "app=submariner-networkplugin-syncer"
 )
 
-func GatewayPodLogs(info Info) error {
-	return gatherPodLogs(gatewayPodLabel, info)
+func GatewayPodLogs(info Info) {
+	gatherPodLogs(gatewayPodLabel, info)
 }
 
-func RouteAgentPodLogs(info Info) error {
-	return gatherPodLogs(routeagentPodLabel, info)
+func RouteAgentPodLogs(info Info) {
+	gatherPodLogs(routeagentPodLabel, info)
 }
 
-func GlobalnetPodLogs(info Info) error {
-	return gatherPodLogs(globalnetPodLabel, info)
+func GlobalnetPodLogs(info Info) {
+	gatherPodLogs(globalnetPodLabel, info)
 }
 
-func NetworkPluginSyncerPodLogs(info Info) error {
-	return gatherPodLogs(networkpluginSyncerPodLabel, info)
+func NetworkPluginSyncerPodLogs(info Info) {
+	gatherPodLogs(networkpluginSyncerPodLabel, info)
 }
 
 func Endpoints(info Info, namespace string) {

--- a/pkg/subctl/cmd/gather/operator.go
+++ b/pkg/subctl/cmd/gather/operator.go
@@ -68,6 +68,6 @@ func LighthouseCoreDNSDeployment(info Info, namespace string) {
 	gatherDeployment(info, namespace, metav1.ListOptions{LabelSelector: "app=submariner-lighthouse-coredns"})
 }
 
-func SubmarinerOperatorPodLogs(info Info) error {
-	return gatherPodLogs("name=submariner-operator", info)
+func SubmarinerOperatorPodLogs(info Info) {
+	gatherPodLogs("name=submariner-operator", info)
 }

--- a/pkg/subctl/cmd/gather/servicediscovery.go
+++ b/pkg/subctl/cmd/gather/servicediscovery.go
@@ -31,12 +31,12 @@ const (
 	coreDNSPodLabel           = "k8s-app=kube-dns"
 )
 
-func ServiceDiscoveryPodLogs(info Info) error {
-	return gatherPodLogs(lighthouseComponentsLabel, info)
+func ServiceDiscoveryPodLogs(info Info) {
+	gatherPodLogs(lighthouseComponentsLabel, info)
 }
 
-func CoreDNSPodLogs(info Info) error {
-	return gatherPodLogs(coreDNSPodLabel, info)
+func CoreDNSPodLogs(info Info) {
+	gatherPodLogs(coreDNSPodLabel, info)
 }
 
 func ServiceExports(info Info, namespace string) {


### PR DESCRIPTION
Simplifies callers plus `gatherPodLogs` already logs a success message. Similarly, `ResourcesToYAMLFile` logs a failure message.

