### PR TITLE
subctl gather: Add support for multiple clusters

### DIFF
--- a/pkg/subctl/cmd/resource.go
+++ b/pkg/subctl/cmd/resource.go
@@ -32,7 +32,7 @@ import (
 	subClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 )
 
-func getMultipleRestConfigs(kubeConfigPath, kubeContext string) ([]restConfig, error) {
+func getMultipleRestConfigs(kubeConfigPath string, kubeContexts []string) ([]restConfig, error) {
 	var restConfigs []restConfig
 
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -41,8 +41,8 @@ func getMultipleRestConfigs(kubeConfigPath, kubeContext string) ([]restConfig, e
 	rules.ExplicitPath = kubeConfigPath
 
 	contexts := []string{}
-	if kubeContext != "" {
-		contexts = append(contexts, kubeContext)
+	if len(kubeContexts) > 0 {
+		contexts = append(contexts, kubeContexts...)
 	} else {
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
 		rawConfig, err := kubeConfig.RawConfig()

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -43,9 +43,10 @@ import (
 )
 
 var (
-	kubeConfig  string
-	kubeContext string
-	rootCmd     = &cobra.Command{
+	kubeConfig   string
+	kubeContext  string
+	kubeContexts []string
+	rootCmd      = &cobra.Command{
 		Use:   "subctl",
 		Short: "An installer for Submariner",
 	}
@@ -60,7 +61,15 @@ func init() {
 
 func addKubeconfigFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path(s) to the kubeconfig file(s)")
-	cmd.PersistentFlags().StringVar(&kubeContext, "kubecontext", "", "kubeconfig context to use")
+	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontext", nil, "kubeconfig context to use")
+	if len(kubeContexts) > 0 {
+		kubeContext = kubeContexts[0]
+	}
+}
+
+func addKubecontextsFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontexts", nil,
+		"comma separated list of kubeconfig contexts to use. If none specified, all contexts referenced by kubeconfig are used")
 }
 
 const (

--- a/pkg/subctl/cmd/show_all.go
+++ b/pkg/subctl/cmd/show_all.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func showAll(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/show_connections.go
+++ b/pkg/subctl/cmd/show_connections.go
@@ -73,7 +73,7 @@ func getConnectionsStatus(submariner *v1alpha1.Submariner) []connectionStatus {
 }
 
 func showConnections(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()

--- a/pkg/subctl/cmd/show_endpoints.go
+++ b/pkg/subctl/cmd/show_endpoints.go
@@ -83,7 +83,7 @@ func getEndpointsStatus(submariner *v1alpha1.Submariner) []endpointStatus {
 }
 
 func showEndpoints(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()

--- a/pkg/subctl/cmd/show_gateways.go
+++ b/pkg/subctl/cmd/show_gateways.go
@@ -82,7 +82,7 @@ func getGatewaysStatus(submariner *v1alpha1.Submariner) []gatewayStatus {
 }
 
 func showGateways(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/show_networks.go
+++ b/pkg/subctl/cmd/show_networks.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func showNetwork(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/show_versions.go
+++ b/pkg/subctl/cmd/show_versions.go
@@ -117,7 +117,7 @@ func showVersionsFor(config *rest.Config, submariner *v1alpha1.Submariner) {
 }
 
 func showVersions(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()

--- a/pkg/subctl/cmd/validate_cni.go
+++ b/pkg/subctl/cmd/validate_cni.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func validateCniConfig(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/validate_connections.go
+++ b/pkg/subctl/cmd/validate_connections.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func validateConnections(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/validate_deployment.go
+++ b/pkg/subctl/cmd/validate_deployment.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func validateSubmarinerDeployment(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/validate_fw_metrics.go
+++ b/pkg/subctl/cmd/validate_fw_metrics.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func validateFirewallMetricsConfig(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/validate_fw_vxlan.go
+++ b/pkg/subctl/cmd/validate_fw_vxlan.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 func validateFirewallVxLANConfig(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/validate_k8sversion.go
+++ b/pkg/subctl/cmd/validate_k8sversion.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func validateK8sVersion(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/pkg/subctl/cmd/validate_kubeproxy.go
+++ b/pkg/subctl/cmd/validate_kubeproxy.go
@@ -50,7 +50,7 @@ func init() {
 }
 
 func validateKubeProxyMode(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -43,7 +43,7 @@ ${DAPPER_SOURCE}/bin/subctl verify ${verify} --submariner-namespace=$subm_ns --v
 
 . ${DAPPER_SOURCE}/scripts/kind-e2e/lib_subctl_gather_test.sh
 
-with_context "${clusters[1]}" test_subctl_gather
+test_subctl_gather
 
 print_clusters_message
 

--- a/scripts/kind-e2e/lib_subctl_gather_test.sh
+++ b/scripts/kind-e2e/lib_subctl_gather_test.sh
@@ -11,7 +11,17 @@ function test_subctl_gather() {
   rm -rf $out_dir
   mkdir $out_dir
 
-  ${DAPPER_SOURCE}/bin/subctl gather --kubeconfig ${KUBECONFIGS_DIR}/kind-config-${cluster} --dir $out_dir
+  ${DAPPER_SOURCE}/bin/subctl gather --dir $out_dir
+
+  for cluster in "${clusters[@]}"; do
+      with_context "${cluster}" validate_gathered_files
+  done
+
+  # Broker
+  with_context "$broker" validate_broker_resources
+}
+
+function validate_gathered_files () {
 
   # connectivity
   validate_resource_files $subm_ns 'endpoints.submariner.io' 'Endpoint'
@@ -45,9 +55,6 @@ function test_subctl_gather() {
 
   validate_pod_log_files $subm_ns '-l component=submariner-lighthouse'
   validate_pod_log_files kube-system '-l k8s-app=kube-dns'
-
-  # Broker
-  with_context "$broker" validate_broker_resources
 }
 
 function validate_pod_log_files() {


### PR DESCRIPTION
* Modify `kubecontext` param to be a comma separated list
* If none specified, get all contexts present in config
* Use single context for commands that operate on single cluter

Fixes #1218

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>