### PR TITLE
Added commands to prepare/cleanup AWS cloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.7
+	github.com/aws/aws-sdk-go v1.38.14
 	github.com/go-logr/logr v0.3.0
 	github.com/go-openapi/spec v0.20.0
 	github.com/hashicorp/go-version v1.2.0
@@ -18,6 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.10.0
 	github.com/spf13/cobra v1.1.1
 	github.com/submariner-io/admiral v0.9.0-rc0
+	github.com/submariner-io/cloud-prepare v0.0.0-20210422124637-01644d90a37b
 	github.com/submariner-io/lighthouse v0.9.0-rc0
 	github.com/submariner-io/shipyard v0.9.0-rc0
 	github.com/submariner-io/submariner v0.9.0-rc0

--- a/go.sum
+++ b/go.sum
@@ -163,7 +163,10 @@ github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.14 h1:MpFh9HN9zJwdyRPSZQpZQDP/I1pqHlKhNLxRJsX5nlw=
+github.com/aws/aws-sdk-go v1.38.14/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -690,7 +693,9 @@ github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mo
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
@@ -908,6 +913,8 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.2/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
+github.com/onsi/ginkgo v1.16.0/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
 github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1148,10 +1155,14 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/submariner-io/admiral v0.9.0-m2/go.mod h1:NeABccXoo4w9YlguXd9u1Ztw1hkZqsL5EZymW4ddbbs=
 github.com/submariner-io/admiral v0.9.0-rc0 h1:qQRVX9YRszWxX6SoC5JoGOxM6sNHcUeXH3Ij3rXUIrU=
 github.com/submariner-io/admiral v0.9.0-rc0/go.mod h1:VgRQeLJPBadKEzsPG3kjizzHyc6qbvIbNidXzz8ikug=
+github.com/submariner-io/cloud-prepare v0.0.0-20210422124637-01644d90a37b h1:HvvkGv7dQV/PRslZ9i6hCEU/wtMLNRgo1QjvVDWbioU=
+github.com/submariner-io/cloud-prepare v0.0.0-20210422124637-01644d90a37b/go.mod h1:c26cwaqVLFDud+Lzblo/C2QEzeKDtZa42LplIGFP7Sw=
 github.com/submariner-io/lighthouse v0.9.0-rc0 h1:1X2hJakAoODL32mAqSbcJ94jgmb3bbBzLa57PtHLCJU=
 github.com/submariner-io/lighthouse v0.9.0-rc0/go.mod h1:XB/jsjoflwPNIxnVHDbijNLDIhEjWHtGib1ehs1r0z4=
+github.com/submariner-io/shipyard v0.9.0-m2/go.mod h1:y5q1jef9Hph3VGqD7d9W3fXtdLNZ4GR7b7Rf/lrA/go=
 github.com/submariner-io/shipyard v0.9.0-rc0 h1:6HO5tgJ9SRzsy9WvMfsAQlOnKdqvTLIqbCiJTgarG8w=
 github.com/submariner-io/shipyard v0.9.0-rc0/go.mod h1:vDGWreRLu2VfBoR8J4UgPKJjatx8pLkj89qAgB+N0ZE=
 github.com/submariner-io/submariner v0.9.0-rc0 h1:u1xdWEM9Q5eUcOYOa3fEAzROn7WzIYil6TZGFCduBlk=

--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -31,17 +31,16 @@ var (
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
 func newAWSCleanupCommand() *cobra.Command {
-	awsCloudPrepareCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "aws",
 		Short: "Clean up an AWS cloud",
 		Long:  "This command cleans up an AWS based cloud after Submariner uninstallation.",
 		Run:   cleanupAws,
 	}
 
-	awsCloudPrepareCmd.Flags().StringVar(&infraID, "infra-id", "", "AWS infra ID")
-	awsCloudPrepareCmd.Flags().StringVar(&region, "region", "", "AWS region")
+	cloudutils.AddAWSFlags(cmd, &infraID, &region)
 
-	return awsCloudPrepareCmd
+	return cmd
 }
 
 func cleanupAws(cmd *cobra.Command, args []string) {

--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -1,0 +1,54 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+)
+
+var (
+	infraID string
+	region  string
+)
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+func newAWSCleanupCommand() *cobra.Command {
+	awsCloudPrepareCmd := &cobra.Command{
+		Use:   "aws",
+		Short: "Clean up an AWS cloud",
+		Long:  "This command cleans up an AWS based cloud after Submariner uninstallation.",
+		Run:   cleanupAws,
+	}
+
+	awsCloudPrepareCmd.Flags().StringVar(&infraID, "infra-id", "", "AWS infra ID")
+	awsCloudPrepareCmd.Flags().StringVar(&region, "region", "", "AWS region")
+
+	return awsCloudPrepareCmd
+}
+
+func cleanupAws(cmd *cobra.Command, args []string) {
+	err := cloudutils.RunOnAWS(infraID, region, "", *kubeConfig, *kubeContext,
+		func(cloud api.Cloud, reporter api.Reporter) error {
+			return cloud.CleanupAfterSubmariner(reporter)
+		})
+
+	utils.ExitOnError("Failed to cleanup AWS cloud", err)
+}

--- a/pkg/subctl/cmd/cloud/cleanup/cleanup.go
+++ b/pkg/subctl/cmd/cloud/cleanup/cleanup.go
@@ -1,0 +1,41 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	kubeConfig  *string
+	kubeContext *string
+)
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
+	kubeConfig = origKubeConfig
+	kubeContext = origKubeContext
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Clean up the cloud",
+		Long:  `This command cleans up the cloud after Submariner uninstallation.`,
+	}
+
+	cmd.AddCommand(newAWSCleanupCommand())
+
+	return cmd
+}

--- a/pkg/subctl/cmd/cloud/cloud.go
+++ b/pkg/subctl/cmd/cloud/cloud.go
@@ -1,0 +1,37 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/cleanup"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/prepare"
+)
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Cloud operations",
+		Long:  `This command contains cloud operations relating to Submariner installation.`,
+	}
+
+	cmd.AddCommand(prepare.NewCommand(origKubeConfig, origKubeContext))
+	cmd.AddCommand(cleanup.NewCommand(origKubeConfig, origKubeContext))
+
+	return cmd
+}

--- a/pkg/subctl/cmd/cloud/cloud.go
+++ b/pkg/subctl/cmd/cloud/cloud.go
@@ -27,7 +27,7 @@ func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Cloud operations",
-		Long:  `This command contains cloud operations relating to Submariner installation.`,
+		Long:  `This command contains cloud operations related to Submariner installation.`,
 	}
 
 	cmd.AddCommand(prepare.NewCommand(origKubeConfig, origKubeContext))

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -32,19 +32,18 @@ var (
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
 func newAWSPrepareCommand() *cobra.Command {
-	awsCloudPrepareCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "aws",
 		Short: "Prepare an AWS cloud",
 		Long:  "This command prepares an AWS based cloud for Submariner installation.",
 		Run:   prepareAws,
 	}
 
-	awsCloudPrepareCmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "m5n.large", "Type of gateways instance machine")
-	awsCloudPrepareCmd.Flags().StringVar(&infraID, "infra-id", "", "AWS infra ID")
-	awsCloudPrepareCmd.Flags().StringVar(&region, "region", "", "AWS region")
-	awsCloudPrepareCmd.Flags().IntVar(&gateways, "gateways", 1, "Amount of gateways to prepare (0 = gateway per public subnet)")
+	cloudutils.AddAWSFlags(cmd, &infraID, &region)
+	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "m5n.large", "Type of gateways instance machine")
+	cmd.Flags().IntVar(&gateways, "gateways", 1, "Amount of gateways to prepare (0 = gateway per public subnet)")
 
-	return awsCloudPrepareCmd
+	return cmd
 }
 
 func prepareAws(cmd *cobra.Command, args []string) {

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -1,0 +1,68 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prepare
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+)
+
+var (
+	gwInstanceType string
+	infraID        string
+	region         string
+	gateways       int
+)
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+func newAWSPrepareCommand() *cobra.Command {
+	awsCloudPrepareCmd := &cobra.Command{
+		Use:   "aws",
+		Short: "Prepare an AWS cloud",
+		Long:  "This command prepares an AWS based cloud for Submariner installation.",
+		Run:   prepareAws,
+	}
+
+	awsCloudPrepareCmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "m5n.large", "Type of gateways instance machine")
+	awsCloudPrepareCmd.Flags().StringVar(&infraID, "infra-id", "", "AWS infra ID")
+	awsCloudPrepareCmd.Flags().StringVar(&region, "region", "", "AWS region")
+	awsCloudPrepareCmd.Flags().IntVar(&gateways, "gateways", 1, "Amount of gateways to prepare (0 = gateway per public subnet)")
+
+	return awsCloudPrepareCmd
+}
+
+func prepareAws(cmd *cobra.Command, args []string) {
+	input := api.PrepareForSubmarinerInput{
+		InternalPorts: []api.PortSpec{
+			{Port: vxlanPort, Protocol: "udp"},
+			{Port: metricsPort, Protocol: "tcp"},
+		},
+		PublicPorts: []api.PortSpec{
+			{Port: nattPort, Protocol: "udp"},
+			{Port: natDiscoveryPort, Protocol: "udp"},
+		},
+		Gateways: gateways,
+	}
+	err := cloudutils.RunOnAWS(infraID, region, gwInstanceType, *kubeConfig, *kubeContext,
+		func(cloud api.Cloud, reporter api.Reporter) error {
+			return cloud.PrepareForSubmariner(input, reporter)
+		})
+
+	utils.ExitOnError("Failed to prepare AWS cloud", err)
+}

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -1,0 +1,50 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prepare
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	nattPort         uint16
+	natDiscoveryPort uint16
+	vxlanPort        uint16
+	metricsPort      uint16
+	kubeConfig       *string
+	kubeContext      *string
+)
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
+	kubeConfig = origKubeConfig
+	kubeContext = origKubeContext
+	cmd := &cobra.Command{
+		Use:   "prepare",
+		Short: "Prepare the cloud",
+		Long:  `This command prepares the cloud for Submariner installation.`,
+	}
+
+	cmd.PersistentFlags().Uint16Var(&nattPort, "natt-port", 4500, "IPSec NAT traversal port")
+	cmd.PersistentFlags().Uint16Var(&natDiscoveryPort, "nat-discovery-port", 4490, "NAT discovery port")
+	cmd.PersistentFlags().Uint16Var(&vxlanPort, "vxlan-port", 4800, "Internal VXLAN port")
+	cmd.PersistentFlags().Uint16Var(&metricsPort, "metrics-port", 8080, "Metrics port")
+
+	cmd.AddCommand(newAWSPrepareCommand())
+
+	return cmd
+}

--- a/pkg/subctl/cmd/cloud/utils/aws.go
+++ b/pkg/subctl/cmd/cloud/utils/aws.go
@@ -1,0 +1,100 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	cloudprepareaws "github.com/submariner-io/cloud-prepare/pkg/aws"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// RunOnAWS runs the given function on AWS, supplying it with a cloud instance connected to AWS and a reporter that writes to CLI.
+// The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to AWS.
+func RunOnAWS(infraID, region, gwInstanceType, kubeConfig, kubeContext string,
+	function func(cloud api.Cloud, reporter api.Reporter) error) error {
+	if infraID == "" {
+		utils.ExitWithErrorMsg("You must specify the infraid")
+	}
+
+	if region == "" {
+		utils.ExitWithErrorMsg("You must specify the region")
+	}
+
+	k8sConfig, err := utils.GetRestConfig(kubeConfig, kubeContext)
+	utils.ExitOnError("Filed to initialize a Kubernetes config", err)
+
+	reporter := NewCLIReporter()
+	reporter.Started("Retrieving AWS credentials from your OpenShift installation")
+	creds, err := getAWSCredentials(k8sConfig)
+	if err != nil {
+		reporter.Failed(err)
+		return err
+	}
+	reporter.Succeeded("")
+
+	reporter.Started("Establishing connection to AWS")
+	awsConfig := aws.Config{
+		Credentials: creds,
+		Region:      aws.String(region),
+	}
+
+	awsSession, err := session.NewSession(&awsConfig)
+	if err != nil {
+		reporter.Failed(err)
+		return err
+	}
+	reporter.Succeeded("")
+
+	gwDeployer := cloudprepareaws.NewK8sMachinesetDeployer(k8sConfig)
+	awsCloud := cloudprepareaws.NewCloud(gwDeployer, ec2.New(awsSession), infraID, region, gwInstanceType)
+	return function(awsCloud, reporter)
+}
+
+// Retrieve AWS credentials from an OpenShift secret.
+func getAWSCredentials(k8sConfig *rest.Config) (*credentials.Credentials, error) {
+	kubeClient, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	credentialsSecret, err := kubeClient.CoreV1().Secrets("openshift-machine-api").Get("aws-cloud-credentials", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	accessKeyID, ok := credentialsSecret.Data["aws_access_key_id"]
+	if !ok {
+		return nil, errors.New("coulnd't get aws_access_key_id from the AWS credentials secret")
+	}
+
+	secretAccessKey, ok := credentialsSecret.Data["aws_secret_access_key"]
+	if !ok {
+		return nil, errors.New("coulnd't get aws_secret_access_key from the AWS credentials secret")
+	}
+
+	return credentials.NewStaticCredentials(string(accessKeyID), string(secretAccessKey), ""), nil
+}

--- a/pkg/subctl/cmd/cloud/utils/reporter.go
+++ b/pkg/subctl/cmd/cloud/utils/reporter.go
@@ -1,0 +1,50 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+)
+
+type cliReporter struct {
+	status *cli.Status
+}
+
+func NewCLIReporter() api.Reporter {
+	return &cliReporter{status: cli.NewStatus()}
+}
+
+func (r *cliReporter) Started(message string, args ...interface{}) {
+	r.status.Start(fmt.Sprintf(message, args...))
+}
+
+func (r *cliReporter) Succeeded(message string, args ...interface{}) {
+	if message != "" {
+		r.status.QueueSuccessMessage(fmt.Sprintf(message, args...))
+	}
+	r.status.End(cli.Success)
+}
+
+func (r *cliReporter) Failed(err ...error) {
+	if len(err) > 0 {
+		r.status.QueueFailureMessage(err[0].Error())
+	}
+	r.status.End(cli.Failure)
+}

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 	cmdversion "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/version"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -59,6 +60,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.AddCommand(cmdversion.Cmd)
+	rootCmd.AddCommand(cloud.NewCommand(&kubeConfig, &kubeContext))
 }
 
 func addKubeconfigFlag(cmd *cobra.Command) {

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -17,13 +17,14 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
 	"strings"
 	"time"
 
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	cmdversion "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/version"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -57,6 +58,7 @@ func Execute() error {
 }
 
 func init() {
+	rootCmd.AddCommand(cmdversion.Cmd)
 }
 
 func addKubeconfigFlag(cmd *cobra.Command) {
@@ -77,27 +79,16 @@ const (
 )
 
 func panicOnError(err error) {
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "")
-		PrintSubctlVersion(os.Stderr)
-		fmt.Fprintln(os.Stderr, "")
-		panic(err.Error())
-	}
+	utils.PanicOnError(err)
 }
 
 // exitOnError will print your error nicely and exit in case of error
 func exitOnError(message string, err error) {
-	if err != nil {
-		exitWithErrorMsg(fmt.Sprintf("%s: %s", message, err))
-	}
+	utils.ExitOnError(message, err)
 }
 
 func exitWithErrorMsg(message string) {
-	fmt.Fprintln(os.Stderr, message)
-	fmt.Fprintln(os.Stderr, "")
-	PrintSubctlVersion(os.Stderr)
-	fmt.Fprintln(os.Stderr, "")
-	os.Exit(1)
+	utils.ExitWithErrorMsg(message)
 }
 
 func getClients(config *rest.Config) (dynamic.Interface, kubernetes.Interface, error) {
@@ -125,19 +116,11 @@ func getClusterNameFromContext(rawConfig clientcmdapi.Config, overridesContext s
 }
 
 func getRestConfig(kubeConfigPath, kubeContext string) (*rest.Config, error) {
-	return getClientConfig(kubeConfigPath, kubeContext).ClientConfig()
+	return utils.GetRestConfig(kubeConfigPath, kubeContext)
 }
 
 func getClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	rules.ExplicitPath = kubeConfigPath
-
-	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
-	if kubeContext != "" {
-		overrides.CurrentContext = kubeContext
-	}
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+	return utils.GetClientConfig(kubeConfigPath, kubeContext)
 }
 
 func handleNodeLabels(config *rest.Config) error {

--- a/pkg/subctl/cmd/utils/utils.go
+++ b/pkg/subctl/cmd/utils/utils.go
@@ -1,0 +1,71 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/version"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// PanicOnError will print the subctl version and then panic in case of an actual error
+func PanicOnError(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "")
+		version.PrintSubctlVersion(os.Stderr)
+		fmt.Fprintln(os.Stderr, "")
+		panic(err.Error())
+	}
+}
+
+// ExitOnError will print your error nicely and exit in case of error
+func ExitOnError(message string, err error) {
+	if err != nil {
+		ExitWithErrorMsg(fmt.Sprintf("%s: %s", message, err))
+	}
+}
+
+// ExitWithErrorMsg will print the message and quit the program with an error code
+func ExitWithErrorMsg(message string) {
+	fmt.Fprintln(os.Stderr, message)
+	fmt.Fprintln(os.Stderr, "")
+	version.PrintSubctlVersion(os.Stderr)
+	fmt.Fprintln(os.Stderr, "")
+	os.Exit(1)
+}
+
+// GetRestConfig returns a rest.Config to use when communicating with K8s
+func GetRestConfig(kubeConfigPath, kubeContext string) (*rest.Config, error) {
+	return GetClientConfig(kubeConfigPath, kubeContext).ClientConfig()
+}
+
+// GetClientConfig returns a clientcmd.ClientConfig to use when communicating with K8s
+func GetClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = kubeConfigPath
+
+	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+	if kubeContext != "" {
+		overrides.CurrentContext = kubeContext
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+}

--- a/pkg/subctl/cmd/utils/utils.go
+++ b/pkg/subctl/cmd/utils/utils.go
@@ -69,3 +69,10 @@ func GetClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig 
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
 }
+
+// ExpectFlag exits with an error if the flag value is empty
+func ExpectFlag(flag, value string) {
+	if value == "" {
+		ExitWithErrorMsg(fmt.Sprintf("You must specify the %v flag", flag))
+	}
+}

--- a/pkg/subctl/cmd/version/version.go
+++ b/pkg/subctl/cmd/version/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package version
 
 import (
 	"fmt"
@@ -22,12 +22,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-
 	"github.com/submariner-io/submariner-operator/pkg/version"
 )
 
-// infoCmd represents the info command
-var versionCmd = &cobra.Command{
+// Cmd represents the version command
+var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Get version information on subctl",
 	Long: `This command shows the version tag, and git commit for your
@@ -35,14 +34,11 @@ subctl binary.`,
 	Run: subctlVersion,
 }
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
 func subctlVersion(cmd *cobra.Command, args []string) {
 	PrintSubctlVersion(os.Stdout)
 }
 
+// PrintSubctlVersion will print the version subctl was compiled under
 func PrintSubctlVersion(w io.Writer) {
 	fmt.Fprintf(w, "subctl version: %s\n", version.Version)
 }


### PR DESCRIPTION
Added commands to prepare/cleanup AWS

These commands allow to prepare or cleanup an AWS cloud to submariner by calling `subctl`.

Currently in draft mode as it needs submariner-io/cloud-prepare#2 to work properly