### PR TITLE
Validate calico cni ippools

### DIFF
--- a/pkg/subctl/cmd/validate_all.go
+++ b/pkg/subctl/cmd/validate_all.go
@@ -52,7 +52,7 @@ func validateAll(cmd *cobra.Command, args []string) {
 		status.End(cli.Success)
 		fmt.Println()
 
-		validateCNIInCluster(item.clusterName, submariner)
+		validateCNIInCluster(item.config, item.clusterName, submariner)
 		fmt.Println()
 		validateConnectionsInCluster(item.config, item.clusterName)
 		fmt.Println()

--- a/pkg/subctl/cmd/validate_cni.go
+++ b/pkg/subctl/cmd/validate_cni.go
@@ -18,9 +18,17 @@ package cmd
 import (
 	"fmt"
 
+	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 )
 
 var supportedNetworkPlugins = []string{"generic", "canal-flannel", "weave-net", "OpenShiftSDN", "OVNKubernetes"}
@@ -31,6 +39,14 @@ var validateCniCmd = &cobra.Command{
 	Long:  "This command checks whether or not the detected CNI network plugin is supported by Submariner.",
 	Run:   validateCniConfig,
 }
+
+var (
+	calicoGVR = schema.GroupVersionResource{
+		Group:    "crd.projectcalico.org",
+		Version:  "v1",
+		Resource: "ippools",
+	}
+)
 
 func init() {
 	validateCmd.AddCommand(validateCniCmd)
@@ -49,11 +65,11 @@ func validateCniConfig(cmd *cobra.Command, args []string) {
 			continue
 		}
 		status.End(cli.Success)
-		validateCNIInCluster(item.clusterName, submariner)
+		validateCNIInCluster(item.config, item.clusterName, submariner)
 	}
 }
 
-func validateCNIInCluster(clusterName string, submariner *v1alpha1.Submariner) {
+func validateCNIInCluster(config *rest.Config, clusterName string, submariner *v1alpha1.Submariner) {
 	message := fmt.Sprintf("Validating Submariner support for the CNI network"+
 		" plugin in cluster %q", clusterName)
 	status.Start(message)
@@ -78,4 +94,123 @@ func validateCNIInCluster(clusterName string, submariner *v1alpha1.Submariner) {
 		submariner.Status.NetworkPlugin)
 	status.QueueSuccessMessage(message)
 	status.End(cli.Success)
+
+	validateCalicoIPPoolsIfCalicoCNI(config)
+}
+
+func doesCalicoConfigMapExist(clientSet kubernetes.Interface) (*v1.ConfigMap, error) {
+	cmList, err := clientSet.CoreV1().ConfigMaps(metav1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cm := range cmList.Items {
+		if cm.Name == "calico-config" {
+			return &cm, nil
+		}
+	}
+	return nil, nil
+}
+
+func validateCalicoIPPoolsIfCalicoCNI(config *rest.Config) {
+	dynClient, clientSet, err := getClients(config)
+	exitOnError("Error creating clients for cluster", err)
+
+	calicoConfig, _ := doesCalicoConfigMapExist(clientSet)
+	if calicoConfig == nil {
+		return
+	}
+
+	message := "Calico CNI detected, verifying if the Submariner IPPool pre-requisites are configured."
+	status.Start(message)
+
+	gateways := getGatewaysResource(config)
+	if gateways == nil {
+		message = "There are no gateways detected on the cluster"
+		status.QueueWarningMessage(message)
+		status.End(cli.Failure)
+		return
+	}
+
+	client := dynClient.Resource(calicoGVR)
+
+	ippoolList, err := client.List(metav1.ListOptions{})
+	if err != nil {
+		message := fmt.Sprintf("Error obtaining IPPools: %v", err)
+		status.QueueFailureMessage(message)
+		status.End(cli.Failure)
+		return
+	}
+
+	if len(ippoolList.Items) < 1 {
+		message := "Could not find any IPPools in the cluster"
+		status.QueueFailureMessage(message)
+		status.End(cli.Failure)
+		return
+	}
+
+	ippools := make(map[string]unstructured.Unstructured)
+	for _, pool := range ippoolList.Items {
+		cidr, found, err := unstructured.NestedString(pool.Object, "spec", "cidr")
+		if err != nil {
+			message := fmt.Sprintf("Error extracting field cidr from IPPool %q", pool.GetName())
+			status.QueueFailureMessage(message)
+			continue
+		}
+
+		if !found {
+			message := fmt.Sprintf("No CIDR found in IPPool %q", pool.GetName())
+			status.QueueFailureMessage(message)
+			continue
+		}
+		ippools[cidr] = pool
+	}
+
+	for _, gateway := range gateways.Items {
+		if gateway.Status.HAStatus != submv1.HAStatusActive {
+			continue
+		}
+
+		for _, connection := range gateway.Status.Connections {
+			for _, subnet := range connection.Endpoint.Subnets {
+				ipPool, found := ippools[subnet]
+				if found {
+					isDisabled, err := getValue(ipPool, "disabled")
+					if err != nil {
+						status.QueueFailureMessage(err.Error())
+						continue
+					}
+
+					// When disabled is set to true, Calico IPAM will not assign addresses from this Pool.
+					// The IPPools configured for Submariner remote CIDRs should have disabled as true.
+					if !isDisabled {
+						status.QueueFailureMessage(fmt.Sprintf("IPPool %q for cidr %q has disabled set to false", ipPool.GetName(), subnet))
+						continue
+					}
+				} else {
+					status.QueueFailureMessage(fmt.Sprintf("Could not find any IPPool for remote cidr %q", subnet))
+					continue
+				}
+			}
+		}
+	}
+
+	result := status.ResultFromMessages()
+	if result == cli.Success {
+		status.QueueSuccessMessage("The necessary Calico IPPools for remote cluster CIDRs are successfully configured.")
+	}
+	status.End(status.ResultFromMessages())
+}
+
+func getValue(pool unstructured.Unstructured, key string) (bool, error) {
+	isDisabled, found, err := unstructured.NestedBool(pool.Object, "spec", key)
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		message := fmt.Sprintf("%s status not found for IPPool %q", key, pool.GetName())
+		return false, fmt.Errorf(message)
+	}
+	return isDisabled, nil
 }


### PR DESCRIPTION
Add to subctl validate cin a check when calico cni
is detected that validate the configuration of IPPools

Fixes issue #1149

Signed-off-by: Maayan Friedman <maafried@redhat.com>
Co-authored-by: Sridhar Gaddam <sgaddam@redhat.com>