### PR TITLE
Fix sniffer pod failure on OCP cluster

### DIFF
--- a/pkg/subctl/resource/schedule_pod.go
+++ b/pkg/subctl/resource/schedule_pod.go
@@ -106,6 +106,15 @@ func (np *NetworkPod) schedulePod() error {
 		},
 	}
 
+	if np.Config.Networking == framework.HostNetworking {
+		networkPod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
+			Capabilities: &v1.Capabilities{
+				Add:  []v1.Capability{"NET_ADMIN", "NET_RAW"},
+				Drop: []v1.Capability{"all"},
+			},
+		}
+	}
+
 	pc := np.Config.ClientSet.CoreV1().Pods(np.Config.Namespace)
 	var err error
 	np.Pod, err = pc.Create(&networkPod)


### PR DESCRIPTION
While running subctl validate on OCP cluster it was seen that
Sniffer pod was unable to capture the packets using tcpdump
because of missing capabilities. This PR fixes it.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>