### PR TITLE
Support validate all command

### DIFF
--- a/pkg/subctl/cmd/validate_all.go
+++ b/pkg/subctl/cmd/validate_all.go
@@ -1,0 +1,65 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
+)
+
+var validateAllCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Validate the Submariner deployment and report any issues",
+	Long: "This command validates the Submariner deployment and reports any issues related to cni," +
+		" connections, deployment, k8s-version and kube-proxy-mode",
+	Run: validateAll,
+}
+
+func init() {
+	validateCmd.AddCommand(validateAllCmd)
+}
+
+func validateAll(cmd *cobra.Command, args []string) {
+	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	exitOnError("Error getting REST config for cluster", err)
+
+	for _, item := range configs {
+		validateK8sVersionInCluster(item.config, item.clusterName)
+		fmt.Println()
+
+		status.Start(fmt.Sprintf("Retrieving Submariner resource from %q", item.clusterName))
+		submariner := getSubmarinerResource(item.config)
+		if submariner == nil {
+			status.QueueWarningMessage(submMissingMessage)
+			status.End(cli.Success)
+			continue
+		}
+		status.End(cli.Success)
+		fmt.Println()
+
+		validateCNIInCluster(item.clusterName, submariner)
+		fmt.Println()
+		validateConnectionsInCluster(item.config, item.clusterName)
+		fmt.Println()
+		checkPods(item, submariner, OperatorNamespace)
+		fmt.Println()
+		checkOverlappingCIDRs(item, submariner)
+		fmt.Println()
+		validateKubeProxyModeInCluster(item.config, item.clusterName)
+	}
+}

--- a/pkg/subctl/cmd/validate_deployment.go
+++ b/pkg/subctl/cmd/validate_deployment.go
@@ -64,7 +64,11 @@ func checkOverlappingCIDRs(item restConfig, submariner *v1alpha1.Submariner) {
 	submarinerClient, err := smClientset.NewForConfig(item.config)
 	exitOnError("Unable to get the Submariner client", err)
 
-	status.Start("Checking if cluster CIDRs overlap")
+	if submariner.Spec.GlobalCIDR != "" {
+		status.Start("Checking if globalnet CIDRs overlap")
+	} else {
+		status.Start("Checking if cluster CIDRs overlap")
+	}
 
 	localClusterName := submariner.Status.ClusterID
 	endpointList, err := submarinerClient.SubmarinerV1().Endpoints(submariner.Namespace).List(metav1.ListOptions{})
@@ -105,7 +109,12 @@ func checkOverlappingCIDRs(item restConfig, submariner *v1alpha1.Submariner) {
 		return
 	}
 
-	status.QueueSuccessMessage("Clusters do not have overlapping CIDRs")
+	if submariner.Spec.GlobalCIDR != "" {
+		status.QueueSuccessMessage("Clusters do not have overlapping globalnet CIDRs")
+	} else {
+		status.QueueSuccessMessage("Clusters do not have overlapping CIDRs")
+	}
+
 	status.End(cli.Success)
 }
 


### PR DESCRIPTION
This PR enables validation of cni, connections, deployment, k8s-version and
kube-proxy-mode using a single "validate all" command.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>