### PR TITLE
Make sure to strip leading 'v'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BASE_BRANCH ?= devel
 # Denotes the default operator image version, exposed as a variable for the automated release
 DEFAULT_IMAGE_VERSION ?= $(BASE_BRANCH)
 export BASE_BRANCH
+export DEFAULT_IMAGE_VERSION
 
 ifneq (,$(DAPPER_HOST_ARCH))
 
@@ -114,7 +115,7 @@ bin/subctl-%: generate-embeddedyamls $(shell find pkg/subctl/ -name "*.go") vend
 	export GOARCH GOOS; \
 	$(SCRIPTS_DIR)/compile.sh \
 		--ldflags "-X github.com/submariner-io/submariner-operator/pkg/version.Version=$(CALCULATED_VERSION) \
-			   -X=github.com/submariner-io/submariner-operator/pkg/versions.DefaultSubmarinerOperatorVersion=$(DEFAULT_IMAGE_VERSION)" \
+			   -X=github.com/submariner-io/submariner-operator/pkg/versions.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}" \
 		--noupx $@ ./pkg/subctl/main.go
 
 ci: generate-embeddedyamls golangci-lint markdownlint unit build images


### PR DESCRIPTION
Make sure to strip it in the `DEFAULT_IMAGE_VERSION` just in case we're
trying to build with a `vX.Y.Z` version, since the images are published
without the `v` prefix.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>