### PR TITLE
Capture sysctl -a as part of the route agent logs in gather

### DIFF
--- a/pkg/subctl/cmd/gather/cni.go
+++ b/pkg/subctl/cmd/gather/cni.go
@@ -36,6 +36,7 @@ var systemCmds = map[string]string{
 	"ip-routes":         "ip route show",
 	"ip-rules":          "ip rule list",
 	"ip-rules-table150": "ip rule show table 150",
+	"sysctl-a":          "sysctl -a",
 }
 
 var ipGatewayCmds = map[string]string{


### PR DESCRIPTION
This is a critical part of the dataplane configuration in Linux
that we need to check for various details.

Depends on submariner-io/submariner#1288

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
