### PR TITLE
Capture logs of crashed pod

### DIFF
--- a/pkg/subctl/cmd/gather/cni.go
+++ b/pkg/subctl/cmd/gather/cni.go
@@ -245,7 +245,7 @@ func logCmdOutput(info Info, pod *v1.Pod, cmd, cmdName string, ignoreError bool)
 	if stdOut != "" {
 		// the first line contains the executed command
 		stdOut = cmd + "\n" + stdOut
-		err := writeLogToFile(stdOut, pod.Spec.NodeName+"_"+cmdName, info)
+		err := writeLogToFile(stdOut, pod.Spec.NodeName+"_"+cmdName, info, ".log")
 		if err != nil {
 			info.Status.QueueFailureMessage(fmt.Sprintf("Error writing output from command %q on pod %q: %v", cmd, pod.Name, err))
 		}

--- a/scripts/kind-e2e/lib_subctl_gather_test.sh
+++ b/scripts/kind-e2e/lib_subctl_gather_test.sh
@@ -13,6 +13,8 @@ function test_subctl_gather() {
 
   ${DAPPER_SOURCE}/bin/subctl gather --dir $out_dir
 
+  ls $out_dir
+
   for cluster in "${clusters[@]}"; do
       with_context "${cluster}" validate_gathered_files
   done


### PR DESCRIPTION
Capture logs of crashed pod

by using Previous (-p) option of PodLogOptions

The logic implemented is

```
Capture the logs with -p
if previous_pod_found
    write_logs_to_file.log.prev
else
   ignore

Capture the logs without -p on the same pod
write_logs_to_file.log
```


Closes: #1289

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>