### PR TITLE
Remove misleading OVN CNI not supported msg

### DIFF
--- a/pkg/subctl/cmd/gather/cni.go
+++ b/pkg/subctl/cmd/gather/cni.go
@@ -98,7 +98,7 @@ func CNIResources(info Info, networkPlugin string) {
 			case typeIPTables:
 				logIPTablesCmds(info, pod)
 			case typeOvn:
-				info.Status.QueueWarningMessage("OVN CNI not supported yet")
+				// no-op. Handled in OVNResources()
 			case typeUnknown:
 				info.Status.QueueFailureMessage("Unsupported CNI Type")
 			}


### PR DESCRIPTION
OVN CNI is now handled explicitly in its own function instead of generic
`CNIResources`. Remove OVN from CNI type check in `CNIResources`

Fixes #1288

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>