### PR TITLE
Add verbose output support for subctl validate cmds

### DIFF
--- a/pkg/subctl/cmd/validate_fw_metrics.go
+++ b/pkg/subctl/cmd/validate_fw_metrics.go
@@ -37,6 +37,8 @@ var validateFirewallMetricsCmd = &cobra.Command{
 
 func init() {
 	addValidateFWConfigFlags(validateFirewallMetricsCmd)
+	validateFirewallMetricsCmd.Flags().BoolVar(&verboseOutput, "verbose", false,
+		"produce verbose logs during validation")
 	validateFirewallConfigCmd.AddCommand(validateFirewallMetricsCmd)
 }
 
@@ -89,6 +91,11 @@ func validateFirewallMetricsConfigWithinCluster(config *rest.Config, clusterName
 		message := fmt.Sprintf("Error while waiting for sniffer pod to be finish its execution: %v", err)
 		status.QueueFailureMessage(message)
 		return
+	}
+
+	if verboseOutput {
+		status.QueueSuccessMessage("tcpdump output from Sniffer Pod on Gateway node")
+		status.QueueSuccessMessage(sPod.PodOutput)
 	}
 
 	// Verify that tcpdump output (i.e, from snifferPod) contains the HostIP of clientPod

--- a/pkg/subctl/cmd/validate_fw_vxlan.go
+++ b/pkg/subctl/cmd/validate_fw_vxlan.go
@@ -40,6 +40,8 @@ const (
 
 func init() {
 	addValidateFWConfigFlags(validateFirewallVxLANConfigCmd)
+	validateFirewallVxLANConfigCmd.Flags().BoolVar(&verboseOutput, "verbose", false,
+		"produce verbose logs during validation")
 	validateFirewallConfigCmd.AddCommand(validateFirewallVxLANConfigCmd)
 }
 
@@ -121,6 +123,11 @@ func validateFWConfigWithinCluster(config *rest.Config, submariner *v1alpha1.Sub
 		message := fmt.Sprintf("Error while waiting for sniffer pod to be finish its execution: %v", err)
 		status.QueueFailureMessage(message)
 		return
+	}
+
+	if verboseOutput {
+		status.QueueSuccessMessage("tcpdump output from Sniffer Pod on Gateway node")
+		status.QueueSuccessMessage(sPod.PodOutput)
 	}
 
 	// Verify that tcpdump output (i.e, from snifferPod) contains the remoteClusterIP

--- a/pkg/subctl/cmd/validate_tunnel.go
+++ b/pkg/subctl/cmd/validate_tunnel.go
@@ -147,7 +147,8 @@ func validateTunnelConfigAcrossClusters(localCfg, remoteCfg *rest.Config) {
 	}
 
 	if verboseOutput {
-		status.QueueSuccessMessage(fmt.Sprintf("tcpdump output on Gateway node: %s", sPod.PodOutput))
+		status.QueueSuccessMessage("tcpdump output from Sniffer Pod on Gateway node")
+		status.QueueSuccessMessage(sPod.PodOutput)
 	}
 
 	validateSnifferPodOutput(sPod.PodOutput, clientMessage, localEndpoint.Spec.Hostname, tunnelPort)


### PR DESCRIPTION
Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1278
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>