### PR TITLE
Beautify subctl benchmark latency output

### DIFF
--- a/pkg/subctl/benchmark/latency.go
+++ b/pkg/subctl/benchmark/latency.go
@@ -17,6 +17,7 @@ package benchmark
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
@@ -118,4 +119,12 @@ func runLatencyTest(f *framework.Framework, testParams benchmarkTestParams) {
 
 	framework.By(fmt.Sprintf("Waiting for the client pod %q to exit, returning what client sent", nettestClientPod.Pod.Name))
 	nettestClientPod.AwaitFinishVerbose(Verbose)
+	nettestClientPod.CheckSuccessfulFinish()
+	latencyHeaders := strings.Split(nettestClientPod.TerminationMessage, "\n")[1]
+	headers := strings.Split(latencyHeaders, ",")
+	latencyValues := strings.Split(nettestClientPod.TerminationMessage, "\n")[2]
+	values := strings.Split(latencyValues, ",")
+	for i, v := range headers {
+		fmt.Printf("%s:\t%s\n", v, values[i])
+	}
 }

--- a/pkg/subctl/benchmark/throughput.go
+++ b/pkg/subctl/benchmark/throughput.go
@@ -145,4 +145,6 @@ func runThroughputTest(f *framework.Framework, testParams benchmarkTestParams) {
 
 	framework.By(fmt.Sprintf("Waiting for the client pod %q to exit, returning what client sent", nettestClientPod.Pod.Name))
 	nettestClientPod.AwaitFinishVerbose(Verbose)
+	nettestClientPod.CheckSuccessfulFinish()
+	fmt.Println(nettestClientPod.TerminationMessage)
 }


### PR DESCRIPTION
by writing it to a table

Closes: #1273

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>