### PR TITLE
fix: image-override should not update the version/repo in submariner cr

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -531,30 +531,20 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, netconfig globalnet
 }
 
 func getImageVersion() string {
-	imageOverrides := getImageOverrides()
 	version := imageVersion
 
 	if imageVersion == "" {
 		version = versions.DefaultSubmarinerOperatorVersion
 	}
 
-	if override, ok := imageOverrides[names.OperatorImage]; ok {
-		version, _ = images.ParseOperatorImage(override)
-	}
-
 	return version
 }
 
 func getImageRepo() string {
-	imageOverrides := getImageOverrides()
 	repo := repository
 
 	if repository == "" {
 		repo = versions.DefaultRepo
-	}
-
-	if override, ok := imageOverrides[names.OperatorImage]; ok {
-		_, repo = images.ParseOperatorImage(override)
 	}
 
 	return repo


### PR DESCRIPTION
The image-override flag was updating the repo and version values.
This behaviour is confusing.

Closes #1303

Signed-off-by: Steve Mattar <smattar@redhat.com>
