### PR TITLE
refactor: separate between the component and the image names

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -224,8 +224,8 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery) *appsv1.Deploym
 					Containers: []corev1.Container{
 						{
 							Name:            "submariner-lighthouse-agent",
-							Image:           getImagePath(cr, names.ServiceDiscoveryImage),
-							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.ServiceDiscoveryImage]),
+							Image:           getImagePath(cr, names.ServiceDiscoveryImage, names.ServiceDiscoveryComponent),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.ServiceDiscoveryComponent]),
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
@@ -324,8 +324,8 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 					Containers: []corev1.Container{
 						{
 							Name:            lighthouseCoreDNSName,
-							Image:           getImagePath(cr, names.LighthouseCoreDNSImage),
-							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSImage]),
+							Image:           getImagePath(cr, names.LighthouseCoreDNSImage, names.LighthouseCoreDNSComponent),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSComponent]),
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
 							},
@@ -578,8 +578,8 @@ func updateOpenshiftClusterDNSOperator(instance *submarinerv1alpha1.ServiceDisco
 	return retryErr
 }
 
-func getImagePath(submariner *submarinerv1alpha1.ServiceDiscovery, componentImage string) string {
-	return images.GetImagePath(submariner.Spec.Repository, submariner.Spec.Version, componentImage,
+func getImagePath(submariner *submarinerv1alpha1.ServiceDiscovery, imageName, componentName string) string {
+	return images.GetImagePath(submariner.Spec.Repository, submariner.Spec.Version, imageName, componentName,
 		submariner.Spec.ImageOverrides)
 }
 

--- a/controllers/submariner/netwokplugin_syncer.go
+++ b/controllers/submariner/netwokplugin_syncer.go
@@ -62,8 +62,8 @@ func newNetworkPluginSyncerDeployment(cr *submopv1a1.Submariner, clusterNetwork 
 					Containers: []corev1.Container{
 						{
 							Name:            "submariner-routeagent",
-							Image:           getImagePath(cr, names.NetworkPluginSyncerImage),
-							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.NetworkPluginSyncerImage]),
+							Image:           getImagePath(cr, names.NetworkPluginSyncerImage, names.NetworkPluginSyncerComponent),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.NetworkPluginSyncerComponent]),
 							Command:         []string{"submariner-networkplugin-syncer.sh"},
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -487,8 +487,8 @@ func newGatewayPodTemplate(cr *submopv1a1.Submariner) corev1.PodTemplateSpec {
 			Containers: []corev1.Container{
 				{
 					Name:            "submariner-gateway",
-					Image:           getImagePath(cr, names.GatewayImage),
-					ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GatewayImage]),
+					Image:           getImagePath(cr, names.GatewayImage, names.GatewayComponent),
+					ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GatewayComponent]),
 					Command:         []string{"submariner.sh"},
 					SecurityContext: &securityContextAllCapsPrivileged,
 					Env: []corev1.EnvVar{
@@ -604,8 +604,8 @@ func newRouteAgentDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					Containers: []corev1.Container{
 						{
 							Name:            "submariner-routeagent",
-							Image:           getImagePath(cr, names.RouteAgentImage),
-							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.RouteAgentImage]),
+							Image:           getImagePath(cr, names.RouteAgentImage, names.RouteAgentComponent),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.RouteAgentComponent]),
 							// FIXME: Should be entrypoint script, find/use correct file for routeagent
 							Command:         []string{"submariner-route-agent.sh"},
 							SecurityContext: &securityContextAllCapAllowEscal,
@@ -681,8 +681,8 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					Containers: []corev1.Container{
 						{
 							Name:            "submariner-globalnet",
-							Image:           getImagePath(cr, names.GlobalnetImage),
-							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GlobalnetImage]),
+							Image:           getImagePath(cr, names.GlobalnetImage, names.GlobalnetComponent),
+							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GlobalnetComponent]),
 							SecurityContext: &securityContextAllCapAllowEscal,
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
@@ -719,8 +719,8 @@ func newServiceDiscoveryCR(namespace string) *submopv1a1.ServiceDiscovery {
 	}
 }
 
-func getImagePath(submariner *submopv1a1.Submariner, componentImage string) string {
-	return images.GetImagePath(submariner.Spec.Repository, submariner.Spec.Version, componentImage,
+func getImagePath(submariner *submopv1a1.Submariner, imageName, componentName string) string {
+	return images.GetImagePath(submariner.Spec.Repository, submariner.Spec.Version, imageName, componentName,
 		submariner.Spec.ImageOverrides)
 }
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -25,7 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func GetImagePath(repo, version, component string, imageOverrides map[string]string) string {
+func GetImagePath(repo, version, image, component string, imageOverrides map[string]string) string {
 	var path string
 
 	if override, ok := imageOverrides[component]; ok {
@@ -36,9 +36,9 @@ func GetImagePath(repo, version, component string, imageOverrides map[string]str
 	// a local repository is used for development, testing and CI when we inject
 	// images in the cluster, for example submariner-gateway:local, or submariner-route-agent:local
 	if repo == "local" {
-		path = component
+		path = image
 	} else {
-		path = fmt.Sprintf("%s/%s%s%s", repo, names.ImagePrefix, component, names.ImagePostfix)
+		path = fmt.Sprintf("%s/%s%s%s", repo, names.ImagePrefix, image, names.ImagePostfix)
 	}
 
 	path = fmt.Sprintf("%s:%s", path, version)

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -15,20 +15,31 @@ limitations under the License.
 */
 package names
 
+/* Component names and other constants */
 const (
+	NetworkPluginSyncerComponent = "submariner-networkplugin-syncer"
+	RouteAgentComponent          = "submariner-route-agent"
+	GatewayComponent             = "submariner-gateway"
+	GlobalnetComponent           = "submariner-globalnet"
+	ServiceDiscoveryComponent    = "lighthouse-agent"
+	LighthouseCoreDNSComponent   = "lighthouse-coredns"
+	OperatorComponent            = "submariner-operator"
+	ServiceDiscoveryCrName       = "service-discovery"
+)
+
+/* These values are used by downstream distributions to override the component default image name */
+var (
 	NetworkPluginSyncerImage = "submariner-networkplugin-syncer"
 	RouteAgentImage          = "submariner-route-agent"
 	GatewayImage             = "submariner-gateway"
 	GlobalnetImage           = "submariner-globalnet"
 	ServiceDiscoveryImage    = "lighthouse-agent"
 	LighthouseCoreDNSImage   = "lighthouse-coredns"
-	ServiceDiscoveryCrName   = "service-discovery"
 	OperatorImage            = "submariner-operator"
 )
 
+/* Deprecated: These values are used by downstream distributions to patch the image names by adding a prefix/suffix */
 var (
-	// ImagePrefix is used by downstream distributions to introduce a prefix in the component
-	ImagePrefix = ""
-	// ImagePostfix is used by downstream distributions to introduce a postfix in the component image
+	ImagePrefix  = ""
 	ImagePostfix = ""
 )

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -605,7 +605,7 @@ func operatorImage() string {
 		repo = versions.DefaultRepo
 	}
 
-	return images.GetImagePath(repo, version, names.OperatorImage, getImageOverrides())
+	return images.GetImagePath(repo, version, names.OperatorImage, names.OperatorComponent, getImageOverrides())
 }
 
 func getImageOverrides() map[string]string {

--- a/pkg/subctl/cmd/show_versions.go
+++ b/pkg/subctl/cmd/show_versions.go
@@ -63,14 +63,14 @@ func getSubmarinerVersion(submariner *v1alpha1.Submariner, versions []versionIma
 }
 
 func getOperatorVersion(clientSet kubernetes.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
-	operatorConfig, err := clientSet.AppsV1().Deployments(OperatorNamespace).Get(names.OperatorImage, v1.GetOptions{})
+	operatorConfig, err := clientSet.AppsV1().Deployments(OperatorNamespace).Get(names.OperatorComponent, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	operatorFullImageStr := operatorConfig.Spec.Template.Spec.Containers[0].Image
 	version, repository := images.ParseOperatorImage(operatorFullImageStr)
-	versions = append(versions, newVersionInfoFrom(repository, names.OperatorImage, version))
+	versions = append(versions, newVersionInfoFrom(repository, names.OperatorComponent, version))
 	return versions, nil
 }
 

--- a/pkg/subctl/operator/submarinerop/deployment/ensure.go
+++ b/pkg/subctl/operator/submarinerop/deployment/ensure.go
@@ -24,5 +24,5 @@ import (
 
 // Ensure the operator is deployed, and running
 func Ensure(restConfig *rest.Config, namespace, image string, debug bool) (bool, error) {
-	return operatorpod.Ensure(restConfig, namespace, names.OperatorImage, image, debug)
+	return operatorpod.Ensure(restConfig, namespace, names.OperatorComponent, image, debug)
 }


### PR DESCRIPTION
The component name is not always equivalent to the image name as we experience
in the downstream environment.
Make this separation and allow overriding the image name during the
project's build.
The imagePrefix and imagePostfix are deprecated now and will be removed in
the next release.

Signed-off-by: Steve Mattar <smattar@redhat.com>
