### PR TITLE
Run benchmark commands in e2e

### DIFF
--- a/pkg/subctl/benchmark/throughput.go
+++ b/pkg/subctl/benchmark/throughput.go
@@ -159,6 +159,7 @@ func runThroughputTest(f *framework.Framework, testParams benchmarkTestParams) {
 	// to remove this dependency with iptables-chain, lets delete the service after the nettest server Pod is terminated.
 	// [*] https://github.com/submariner-io/submariner/issues/1166
 	if framework.TestContext.GlobalnetEnabled && testParams.ClientCluster != testParams.ServerCluster {
+		f.DeletePod(testParams.ServerCluster, nettestServerPod.Pod.Name, f.Namespace)
 		f.DeleteService(testParams.ServerCluster, service.Name)
 		f.DeleteServiceExport(testParams.ServerCluster, service.Name)
 	}

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -49,5 +49,15 @@ test_subctl_gather
 
 ${DAPPER_SOURCE}/bin/subctl diagnose all
 
+# Run benchmark commands for sanity checks
+
+${DAPPER_SOURCE}/bin/subctl benchmark latency --intra-cluster ${KUBECONFIGS_DIR}/kind-config-cluster1
+
+${DAPPER_SOURCE}/bin/subctl benchmark latency ${KUBECONFIGS_DIR}/kind-config-cluster1 ${KUBECONFIGS_DIR}/kind-config-cluster2
+
+${DAPPER_SOURCE}/bin/subctl benchmark throughput --intra-cluster ${KUBECONFIGS_DIR}/kind-config-cluster1
+
+${DAPPER_SOURCE}/bin/subctl benchmark throughput --verbose ${KUBECONFIGS_DIR}/kind-config-cluster1 ${KUBECONFIGS_DIR}/kind-config-cluster2
+
 print_clusters_message
 


### PR DESCRIPTION
... for sanity checks to catch a panic or abnormal exit. Also allows one to see the output in a CI job w/o having to run it locally.
