### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,9 +25,10 @@ Submariner Owners: https://github.com/orgs/submariner-io/teams/submariner-core
 **Environment**:
 - Submariner version (use `subctl version`):
 - Kubernetes version (use `kubectl version`):
+- Diagnose information (use `subctl diagnose all`):
+- Gather information (use `subctl gather`)
 - Cloud provider or hardware configuration:
-- OS (e.g: `cat /etc/os-release`):
-- Kernel (e.g. `uname -a`):
+- OS (e.g `cat /etc/os-release`):
+- Kernel (e.g `uname -a`):
 - Install tools:
-- Network plugin and version (if this is a network-related bug):
 - Others:


### PR DESCRIPTION
Updating the Issue template now that `subctl gather` and `subctl diagnose` are available for users. See also https://github.com/submariner-io/submariner/pull/1304

Signed-off-by: nyechiel <nyechiel@redhat.com>