### PR TITLE
golangci-lint: switch to fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,11 @@ linters-settings:
       - unnecessaryDefer
   gocyclo:
     min-complexity: 20
+  govet:
+    enable:
+      - fieldalignment
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
 linters:
   disable-all: true
   enable:
@@ -41,7 +42,6 @@ linters:
     # - interfacer
     - lll
     - misspell
-    - maligned
     - nakedret
     - prealloc
     - staticcheck
@@ -72,3 +72,9 @@ issues:
       text: "SA1019: package sigs.k8s.io/controller-runtime/pkg/client/fake is deprecated"
     - path: controllers/submariner/submariner_controller_test.go
       text: "SA1019: package sigs.k8s.io/controller-runtime/pkg/client/fake is deprecated"
+
+    # Ignore pointer bytes in struct alignment tests (this is a very
+    # minor optimisation)
+    - linters:
+        - govet
+      text: "pointer bytes could be"

--- a/apis/submariner/v1alpha1/submariner_types.go
+++ b/apis/submariner/v1alpha1/submariner_types.go
@@ -157,7 +157,7 @@ type BrokerStatus struct {
 // +kubebuilder:resource:path=brokers,scope=Namespaced
 // +genclient
 // +operator-sdk:csv:customresourcedefinitions:displayName="Broker"
-type Broker struct { //nolint:maligned // we want to keep the traditional order
+type Broker struct { //nolint:govet // we want to keep the traditional order
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 


### PR DESCRIPTION
fieldalignment replaces maligned. Errors related to pointer ordering
(for GC) are ignored; see https://github.com/golang/go/issues/44877
for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>