### PR TITLE
Clean up the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     ignore:
-      - dependency-name: github.com/go-logr/logr
-        versions:
-          - "> 0.1.0"
+      # Pinned
+      - dependency-name: github.com/go-openapi/spec
+      # K8s and operator SDK, we need to handle these manually
       - dependency-name: github.com/operator-framework/operator-sdk
-        versions:
-          - "> 0.17.0"
-      - dependency-name: k8s.io/api
-        versions:
-          - "> 0.18.6"
-      - dependency-name: k8s.io/apiextensions-apiserver
-        versions:
-          - "> 0.18.6"
-      - dependency-name: k8s.io/apimachinery
-        versions:
-          - "> 0.18.6"
-      - dependency-name: sigs.k8s.io/controller-runtime
-        versions:
-          - "> 0.6.2"
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
+      # We get this from cloud-prepare
+      - dependency-name: github.com/aws/aws-sdk-go
+      # Our internal dependencies
       - dependency-name: github.com/submariner-io/*

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,9 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
+// When changing pins, check the dependabot configuration too
+// in .github/dependabot.yml
+
 // Pinned to kubernetes-1.17.0
 replace (
 	k8s.io/api => k8s.io/api v0.17.0


### PR DESCRIPTION
We want to ignore pinned dependencies and dependencies which (usually)
require manual handling, and reduce the number of in-flight dependency
PRs so that the process remains manageable.

Signed-off-by: Stephen Kitt <skitt@redhat.com>