### PR TITLE
dependabot: ignore all of the operator framework

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       # Pinned
       - dependency-name: github.com/go-openapi/spec
       # K8s and operator SDK, we need to handle these manually
-      - dependency-name: github.com/operator-framework/operator-sdk
+      - dependency-name: github.com/operator-framework/*
       - dependency-name: k8s.io/*
       - dependency-name: sigs.k8s.io/*
       # We get this from cloud-prepare


### PR DESCRIPTION
This has deep ties to the controller runtime and various other
dependencies whose upgrades we need to handle manually.

Signed-off-by: Stephen Kitt <skitt@redhat.com>