### PR TITLE
Changed credential fetching to use AWS config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/net v0.0.0-20210505214959-0714010a04ed // indirect
 	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 // indirect
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
+	gopkg.in/ini.v1 v1.62.0
 	k8s.io/api v0.21.0
 	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,7 @@ github.com/gophercloud/gophercloud v0.2.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de h1:F7WD09S8QB4LrkEpka0dFPLSotH11HRpCsLIbIcJ7sU=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
@@ -717,6 +718,7 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jsonnet-bundler/jsonnet-bundler v0.3.1/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -1095,8 +1097,10 @@ github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
@@ -1725,6 +1729,8 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.44.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
+gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mcuadros/go-syslog.v2 v2.2.1/go.mod h1:l5LPIyOOyIdQquNg+oU6Z3524YwrcqEm0aKH+5zpt2U=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190730140822-b51389932cbc/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=

--- a/pkg/subctl/cmd/cloud/aws/aws.go
+++ b/pkg/subctl/cmd/cloud/aws/aws.go
@@ -16,7 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+// This package provides common functionality to run cloud prepare/cleanup on AWS
+package aws
 
 import (
 	"context"
@@ -29,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	cloudprepareaws "github.com/submariner-io/cloud-prepare/pkg/aws"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,15 +43,20 @@ const (
 	regionFlag  = "region"
 )
 
+var (
+	infraID string
+	region  string
+)
+
 // AddAWSFlags adds basic flags needed by AWS
-func AddAWSFlags(command *cobra.Command, infraID, region *string) {
-	command.Flags().StringVar(infraID, infraIDFlag, "", "AWS infra ID")
-	command.Flags().StringVar(region, regionFlag, "", "AWS region")
+func AddAWSFlags(command *cobra.Command) {
+	command.Flags().StringVar(&infraID, infraIDFlag, "", "AWS infra ID")
+	command.Flags().StringVar(&region, regionFlag, "", "AWS region")
 }
 
 // RunOnAWS runs the given function on AWS, supplying it with a cloud instance connected to AWS and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to AWS.
-func RunOnAWS(infraID, region, gwInstanceType, kubeConfig, kubeContext string,
+func RunOnAWS(gwInstanceType, kubeConfig, kubeContext string,
 	function func(cloud api.Cloud, reporter api.Reporter) error) error {
 	utils.ExpectFlag(infraIDFlag, infraID)
 	utils.ExpectFlag(regionFlag, region)
@@ -57,7 +64,7 @@ func RunOnAWS(infraID, region, gwInstanceType, kubeConfig, kubeContext string,
 	k8sConfig, err := utils.GetRestConfig(kubeConfig, kubeContext)
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
-	reporter := NewCLIReporter()
+	reporter := cloudutils.NewCLIReporter()
 	reporter.Started("Retrieving AWS credentials from your OpenShift installation")
 	creds, err := getAWSCredentials(k8sConfig)
 	if err != nil {

--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -21,14 +21,9 @@ package cleanup
 import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
-	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/aws"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-)
-
-var (
-	infraID string
-	region  string
 )
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
@@ -40,13 +35,13 @@ func newAWSCleanupCommand() *cobra.Command {
 		Run:   cleanupAws,
 	}
 
-	cloudutils.AddAWSFlags(cmd, &infraID, &region)
+	aws.AddAWSFlags(cmd)
 
 	return cmd
 }
 
 func cleanupAws(cmd *cobra.Command, args []string) {
-	err := cloudutils.RunOnAWS(infraID, region, "", *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS("", *kubeConfig, *kubeContext,
 		func(cloud api.Cloud, reporter api.Reporter) error {
 			return cloud.CleanupAfterSubmariner(reporter)
 		})

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -21,14 +21,12 @@ package prepare
 import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
-	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/aws"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 )
 
 var (
 	gwInstanceType string
-	infraID        string
-	region         string
 	gateways       int
 )
 
@@ -41,7 +39,7 @@ func newAWSPrepareCommand() *cobra.Command {
 		Run:   prepareAws,
 	}
 
-	cloudutils.AddAWSFlags(cmd, &infraID, &region)
+	aws.AddAWSFlags(cmd)
 	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "m5n.large", "Type of gateways instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", 1, "Amount of gateways to prepare (0 = gateway per public subnet)")
 
@@ -60,7 +58,7 @@ func prepareAws(cmd *cobra.Command, args []string) {
 		},
 		Gateways: gateways,
 	}
-	err := cloudutils.RunOnAWS(infraID, region, gwInstanceType, *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS(gwInstanceType, *kubeConfig, *kubeContext,
 		func(cloud api.Cloud, reporter api.Reporter) error {
 			return cloud.PrepareForSubmariner(input, reporter)
 		})


### PR DESCRIPTION
We'll instruct users to use AWS config to initialize their credentials
and read the credentials from the AWS file.

Resolves submariner-io/cloud-prepare#29

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>