### PR TITLE
Skip YAML linting on all generated CRDs

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -10,12 +10,8 @@ rules:
 
 ignore: |
   /vendor
-  /deploy/submariner/crds/submariner.io_gateways.yaml
-  /deploy/submariner/crds/submariner.io_endpoints.yaml
-  /deploy/submariner/crds/submariner.io_clusters.yaml
-  /deploy/crds/submariner.io_brokers.yaml
-  /deploy/crds/submariner.io_submariners.yaml
-  /deploy/crds/submariner.io_servicediscoveries.yaml
+  /deploy/crds
+  /deploy/submariner/crds
   /deploy/mcsapi/crds/multicluster.x_k8s.io_serviceexports.yaml
   /deploy/mcsapi/crds/multicluster.x_k8s.io_serviceimports.yaml
   /config/crd/bases/submariner.io_brokers.yaml


### PR DESCRIPTION
... since we ignore them in .gitignore, we should exclude them from
YAML linting too (since we can't fix them).

Signed-off-by: Stephen Kitt <skitt@redhat.com>