### PR TITLE
Escape invalid chars in file names for subctl gather

### DIFF
--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -96,7 +96,7 @@ func getLogFromStream(logStream io.ReadCloser) (string, error) {
 }
 
 func writeLogToFile(data, podName string, info Info, fileExtension string) error {
-	fileName := filepath.Join(info.DirName, info.ClusterName+"_"+podName+fileExtension)
+	fileName := filepath.Join(info.DirName, escapeFileName(info.ClusterName+"_"+podName)+fileExtension)
 	f, err := os.Create(fileName)
 	if err != nil {
 		return errors.WithMessagef(err, "error opening file %s", fileName)

--- a/pkg/subctl/cmd/gather/resource.go
+++ b/pkg/subctl/cmd/gather/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -29,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 )
+
+var fileNameRegexp = regexp.MustCompile(`[<>:"/\|?*]`)
 
 func ResourcesToYAMLFile(info Info, ofType schema.GroupVersionResource, namespace string, listOptions metav1.ListOptions) {
 	err := func() error {
@@ -50,7 +53,8 @@ func ResourcesToYAMLFile(info Info, ofType schema.GroupVersionResource, namespac
 		for i := range list.Items {
 			item := &list.Items[i]
 
-			path := filepath.Join(info.DirName, info.ClusterName+"_"+ofType.Resource+"_"+item.GetNamespace()+"_"+item.GetName()+".yaml")
+			path := filepath.Join(info.DirName, escapeFileName(info.ClusterName+"_"+ofType.Resource+"_"+item.GetNamespace()+
+				"_"+item.GetName())+".yaml")
 			file, err := os.Create(path)
 			if err != nil {
 				return errors.WithMessagef(err, "error opening file %s", path)
@@ -118,4 +122,8 @@ func scrubSensitiveData(info Info, dataString string) string {
 	}
 
 	return dataString
+}
+
+func escapeFileName(s string) string {
+	return fileNameRegexp.ReplaceAllString(s, "_")
 }


### PR DESCRIPTION
Convert '/' and other invalid chars on Windows to '_'.

Fixes https://github.com/submariner-io/submariner-operator/issues/1348
