### PR TITLE
fix(bundle): add the missing gateway clusterrole/clusterrolebinding

### DIFF
--- a/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: submariner-gateway
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - dnses
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - submariner.io
+  resources:
+  - endpoints
+  - gateways
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: submariner-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: submariner-gateway
+subjects:
+- kind: ServiceAccount
+  name: submariner-gateway
+  namespace: submariner-operator

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - submariner-gateway/service_account.yaml
   - submariner-gateway/role.yaml
   - submariner-gateway/role_binding.yaml
+  - submariner-gateway/cluster_role.yaml
+  - submariner-gateway/cluster_role_binding.yaml
   - submariner-route-agent/service_account.yaml
   - submariner-route-agent/role.yaml
   - submariner-route-agent/role_binding.yaml

--- a/packagemanifests/0.9.0/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/packagemanifests/0.9.0/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: submariner-gateway
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - dnses
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - submariner.io
+  resources:
+  - endpoints
+  - gateways
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/packagemanifests/0.9.0/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/packagemanifests/0.9.0/submariner-gateway_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: submariner-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: submariner-gateway
+subjects:
+- kind: ServiceAccount
+  name: submariner-gateway
+  namespace: submariner-operator


### PR DESCRIPTION
Submariner deployment using the bundle v0.9 has missing clusterrole and clusterrolebindings for the gateway service account.

Signed-off-by: Steve Mattar <smattar@redhat.com>
