### PR TITLE
Use go-semver instead of go-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.12
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.36
+	github.com/coreos/go-semver v0.3.0
 	github.com/go-errors/errors v1.2.0 // indirect
 	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.20.3 // indirect
@@ -13,7 +14,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-version v1.3.0
+	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.12 // indirect

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	goversion "github.com/hashicorp/go-version"
+	"github.com/coreos/go-semver/semver"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/pkg/version"
 )
@@ -251,10 +251,10 @@ func checkVersionMismatch(cmd *cobra.Command, args []string) error {
 	submariner := getSubmarinerResource(config)
 
 	if submariner != nil && submariner.Spec.Version != "" {
-		subctlVer, _ := goversion.NewVersion(version.Version)
-		submarinerVer, _ := goversion.NewVersion(submariner.Spec.Version)
+		subctlVer, _ := semver.NewVersion(version.Version)
+		submarinerVer, _ := semver.NewVersion(submariner.Spec.Version)
 
-		if subctlVer != nil && submarinerVer != nil && subctlVer.LessThan(submarinerVer) {
+		if subctlVer != nil && submarinerVer != nil && subctlVer.LessThan(*submarinerVer) {
 			return fmt.Errorf(
 				"the subctl version %q is older than the deployed Submariner version %q. Please upgrade your subctl version",
 				version.Version, submariner.Spec.Version)


### PR DESCRIPTION
go-semver’s license is pre-approved by the CNCF, we’d need an
exception for go-version.

Signed-off-by: Stephen Kitt <skitt@redhat.com>