### PR TITLE
Fix broken `--kubecontext`

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -76,7 +76,7 @@ func init() {
 
 	deployBroker.PersistentFlags().BoolVar(&operatorDebug, "operator-debug", false, "enable operator debugging (verbose logging)")
 
-	addKubeconfigFlag(deployBroker)
+	addKubeContextFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 

--- a/pkg/subctl/cmd/export.go
+++ b/pkg/subctl/cmd/export.go
@@ -47,7 +47,7 @@ var (
 )
 
 func init() {
-	addKubeconfigFlag(exportCmd)
+	addKubeContextFlag(exportCmd)
 	addServiceExportFlags(exportServiceCmd)
 	exportCmd.AddCommand(exportServiceCmd)
 	rootCmd.AddCommand(exportCmd)

--- a/pkg/subctl/cmd/gather.go
+++ b/pkg/subctl/cmd/gather.go
@@ -67,8 +67,7 @@ var gatherFuncs = map[string]func(string, gather.Info) bool{
 }
 
 func init() {
-	addKubeconfigFlag(gatherCmd)
-	addKubecontextsFlag(gatherCmd)
+	addKubeContextMultiFlag(gatherCmd)
 	addGatherFlags(gatherCmd)
 	rootCmd.AddCommand(gatherCmd)
 }

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -82,7 +82,7 @@ var (
 
 func init() {
 	addJoinFlags(joinCmd)
-	addKubeconfigFlag(joinCmd)
+	addKubeContextFlag(joinCmd)
 	rootCmd.AddCommand(joinCmd)
 }
 

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -60,20 +60,27 @@ func Execute() error {
 
 func init() {
 	rootCmd.AddCommand(cmdversion.Cmd)
-	rootCmd.AddCommand(cloud.NewCommand(&kubeConfig, &kubeContext))
+	cloudCmd := cloud.NewCommand(&kubeConfig, &kubeContext)
+	addKubeContextFlag(cloudCmd)
+	rootCmd.AddCommand(cloudCmd)
 }
 
-func addKubeconfigFlag(cmd *cobra.Command) {
+func addKubeConfigFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path(s) to the kubeconfig file(s)")
-	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontext", nil, "kubeconfig context to use")
-	if len(kubeContexts) > 0 {
-		kubeContext = kubeContexts[0]
-	}
 }
 
-func addKubecontextsFlag(cmd *cobra.Command) {
+// addKubeContextFlag adds a "kubeconfig" flag and a single "kubecontext" flag that can be used once and only once
+func addKubeContextFlag(cmd *cobra.Command) {
+	addKubeConfigFlag(cmd)
+	cmd.PersistentFlags().StringVar(&kubeContext, "kubecontext", "", "kubeconfig context to use")
+}
+
+// addKubeContextMultiFlag adds a "kubeconfig" flag and a "kubecontext" flag that can be specified multiple times (or comma separated)
+func addKubeContextMultiFlag(cmd *cobra.Command) {
+	addKubeConfigFlag(cmd)
 	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontexts", nil,
-		"comma separated list of kubeconfig contexts to use. If none specified, all contexts referenced by kubeconfig are used")
+		"comma separated list of kubeconfig contexts to use, can be specified multiple times.\n"+
+			"If none specified, all contexts referenced by kubeconfig are used")
 }
 
 const (

--- a/pkg/subctl/cmd/show.go
+++ b/pkg/subctl/cmd/show.go
@@ -39,7 +39,7 @@ type restConfig struct {
 }
 
 func init() {
-	addKubeconfigFlag(showCmd)
+	addKubeContextFlag(showCmd)
 	rootCmd.AddCommand(showCmd)
 }
 

--- a/pkg/subctl/cmd/validate.go
+++ b/pkg/subctl/cmd/validate.go
@@ -28,6 +28,6 @@ var (
 )
 
 func init() {
-	addKubeconfigFlag(validateCmd)
+	addKubeContextFlag(validateCmd)
 	rootCmd.AddCommand(validateCmd)
 }

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -53,7 +53,7 @@ var (
 )
 
 func init() {
-	addKubecontextsFlag(verifyCmd)
+	addKubeContextMultiFlag(verifyCmd)
 	verifyCmd.Flags().StringVar(&verifyOnly, "only", strings.Join(getAllVerifyKeys(), ","), "comma separated verifications to be performed")
 	verifyCmd.Flags().BoolVar(&disruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
 	verifyCmd.Flags().BoolVar(&disruptiveTests, "enable-disruptive", false, "enable disruptive verifications like gateway-failover")


### PR DESCRIPTION
Reverted it to use it's own variable (which works fine).

Also renamed the function names so its easy to distinguish between the
different functionality.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit a9e1c229b396e29f1fa97f1efd0508ba1120b69c)