### PR TITLE
Add CII badge, remove PR-triggered badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Submariner Operator
 
 <!-- markdownlint-disable line-length -->
-[![End to End Tests](https://github.com/submariner-io/submariner-operator/workflows/End%20to%20End%20Tests/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3A%22End+to+End+Tests%22)
-[![Unit Tests](https://github.com/submariner-io/submariner-operator/workflows/Unit%20Tests/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3A%22Unit+Tests%22)
-[![Linting](https://github.com/submariner-io/submariner-operator/workflows/Linting/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3ALinting)
-[![Prometheus Tests](https://github.com/submariner-io/submariner-operator/workflows/Prometheus%20Tests/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3A%22Prometheus+Tests%22)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4865/badge)](https://bestpractices.coreinfrastructure.org/projects/4865)
 [![Release Images](https://github.com/submariner-io/submariner-operator/workflows/Release%20Images/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3A%22Release+Images%22)
-[![Upgrade](https://github.com/submariner-io/submariner-operator/workflows/Upgrade/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3AUpgrade)
 [![Periodic](https://github.com/submariner-io/submariner-operator/workflows/Periodic/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3APeriodic)
 [![Flake Finder](https://github.com/submariner-io/submariner-operator/workflows/Flake%20Finder/badge.svg)](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3A%22Flake+Finder%22)
 <!-- markdownlint-enable line-length -->


### PR DESCRIPTION
Add Submariner's CII Best Practices badge to the README.

Remove badges for workflows triggered by PRs, as their status reflects
tests against proposed/WIP code, not merged code. This causes false red
flags, reducing the utility of the badges overall. Leave badges for
workflows run against merged code.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>