### PR TITLE
Allow lighthouse-agent access to globalingressips

### DIFF
--- a/config/rbac/lighthouse-agent/cluster_role.yaml
+++ b/config/rbac/lighthouse-agent/cluster_role.yaml
@@ -32,6 +32,7 @@ rules:
       - submariner.io
     resources:
       - "gateways"
+      - "globalingressips"
     verbs:
       - get
       - list


### PR DESCRIPTION
Lighthouse agent needs get/list/watch access to `globalingressips` for
Globalnet v2 use cases.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>