### PR TITLE
Backport: Escpape invalid chars in file names for subctl gather

### DIFF
--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -95,7 +95,7 @@ func getLogFromStream(logStream io.ReadCloser) (string, error) {
 }
 
 func writeLogToFile(data, podName string, info Info, fileExtension string) error {
-	fileName := filepath.Join(info.DirName, info.ClusterName+"_"+podName+fileExtension)
+	fileName := filepath.Join(info.DirName, escapeFileName(info.ClusterName+"_"+podName)+fileExtension)
 	f, err := os.Create(fileName)
 	if err != nil {
 		return errors.WithMessagef(err, "error opening file %s", fileName)

--- a/pkg/subctl/cmd/gather/resource.go
+++ b/pkg/subctl/cmd/gather/resource.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 )
+
+var fileNameRegexp = regexp.MustCompile(`[<>:"/\|?*]`)
 
 func ResourcesToYAMLFile(info Info, ofType schema.GroupVersionResource, namespace string, listOptions metav1.ListOptions) {
 	err := func() error {
@@ -49,7 +52,8 @@ func ResourcesToYAMLFile(info Info, ofType schema.GroupVersionResource, namespac
 		for i := range list.Items {
 			item := &list.Items[i]
 
-			path := filepath.Join(info.DirName, info.ClusterName+"_"+ofType.Resource+"_"+item.GetNamespace()+"_"+item.GetName()+".yaml")
+			path := filepath.Join(info.DirName, escapeFileName(info.ClusterName+"_"+ofType.Resource+"_"+item.GetNamespace()+
+				"_"+item.GetName())+".yaml")
 			file, err := os.Create(path)
 			if err != nil {
 				return errors.WithMessagef(err, "error opening file %s", path)
@@ -117,4 +121,8 @@ func scrubSensitiveData(info Info, dataString string) string {
 	}
 
 	return dataString
+}
+
+func escapeFileName(s string) string {
+	return fileNameRegexp.ReplaceAllString(s, "_")
 }


### PR DESCRIPTION
Convert '/' and other invalid chars on Windows to '_'.

Fixes https://github.com/submariner-io/submariner-operator/issues/1348

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>
(cherry picked from commit b22c47a31e96ea93e99ea1a465e65f70808bfd71)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
