### PR TITLE
Restrict the gateway capabilities

### DIFF
--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -253,7 +253,7 @@ function verify_subm_gateway_pod() {
   kubectl get pod $subm_gateway_pod_name --namespace=$subm_ns -o json | tee $json_file
 
   validate_pod_container_equals 'image' "${subm_gateway_image_repo}/submariner-gateway:local"
-  validate_pod_container_has 'securityContext.capabilities.add' 'ALL'
+  validate_pod_container_has 'securityContext.capabilities.add' 'net_admin'
   validate_pod_container_equals 'securityContext.allowPrivilegeEscalation' 'true'
   validate_pod_container_equals 'securityContext.privileged' 'true'
   validate_pod_container_equals 'securityContext.readOnlyRootFilesystem' 'false'


### PR DESCRIPTION
The gateway only needs CAP_NET_ADMIN.

This patch also documents the privilege settings, without changing
them (yet), and adds some volumes which will ultimately help switch
the root file system read-only.

Fixes: #1239
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
