### PR TITLE
Refactor restconfig parts to its own module

### DIFF
--- a/pkg/subctl/cmd/cloud/aws/aws.go
+++ b/pkg/subctl/cmd/cloud/aws/aws.go
@@ -35,6 +35,7 @@ import (
 	cloudprepareaws "github.com/submariner-io/cloud-prepare/pkg/aws"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"gopkg.in/ini.v1"
 )
 
@@ -102,7 +103,7 @@ func RunOnAWS(gwInstanceType, kubeConfig, kubeContext string,
 	}
 	reporter.Succeeded("")
 
-	k8sConfig, err := utils.GetRestConfig(kubeConfig, kubeContext)
+	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	gwDeployer := cloudprepareaws.NewK8sMachinesetDeployer(k8sConfig)

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
@@ -108,7 +109,7 @@ var deployBroker = &cobra.Command{
 		if valid, err := isValidGlobalnetConfig(); !valid {
 			exitOnError("Invalid GlobalCIDR configuration", err)
 		}
-		config, err := getRestConfig(kubeConfig, kubeContext)
+		config, err := restconfig.ForCluster(kubeConfig, kubeContext)
 		exitOnError("The provided kubeconfig is invalid", err)
 
 		status := cli.NewStatus()

--- a/pkg/subctl/cmd/diagnose/cni.go
+++ b/pkg/subctl/cmd/diagnose/cni.go
@@ -54,7 +54,6 @@ func init() {
 		},
 	})
 }
-
 func checkCNIConfig(cluster *cmd.Cluster) bool {
 	status := cli.NewStatus()
 

--- a/pkg/subctl/cmd/diagnose/tunnel.go
+++ b/pkg/subctl/cmd/diagnose/tunnel.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,10 +71,10 @@ func init() {
 }
 
 func validateTunnelConfig(command *cobra.Command, args []string) {
-	localCfg, err := utils.GetRestConfig(args[0], "")
+	localCfg, err := restconfig.ForCluster(args[0], "")
 	utils.ExitOnError("The provided local kubeconfig is invalid", err)
 
-	remoteCfg, err := utils.GetRestConfig(args[1], "")
+	remoteCfg, err := restconfig.ForCluster(args[1], "")
 	utils.ExitOnError("The provided remote kubeconfig is invalid", err)
 
 	if !validateTunnelConfigAcrossClusters(localCfg, remoteCfg) {

--- a/pkg/subctl/cmd/execute.go
+++ b/pkg/subctl/cmd/execute.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	subClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -88,10 +89,10 @@ func (c *Cluster) GetGateways() (*submarinerv1.GatewayList, error) {
 func ExecuteMultiCluster(run func(*Cluster) bool) {
 	success := true
 
-	for _, config := range mustGetMultipleRestConfigs(kubeConfig, kubeContexts) {
-		fmt.Printf("Cluster %q\n", config.clusterName)
+	for _, config := range restconfig.MustGetForClusters(kubeConfig, kubeContexts) {
+		fmt.Printf("Cluster %q\n", config.ClusterName)
 
-		cluster, errMsg := NewCluster(config.config, config.clusterName)
+		cluster, errMsg := NewCluster(config.Config, config.ClusterName)
 		if cluster == nil {
 			success = false
 			fmt.Println(errMsg)

--- a/pkg/subctl/cmd/export.go
+++ b/pkg/subctl/cmd/export.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/cobra"
 	autil "github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -64,12 +65,12 @@ func exportService(cmd *cobra.Command, args []string) {
 	err := validateArguments(args)
 	exitOnError("Insufficient arguments", err)
 
-	clientConfig := getClientConfig(kubeConfig, kubeContext)
+	clientConfig := restconfig.ClientConfig(kubeConfig, kubeContext)
 	restConfig, err := clientConfig.ClientConfig()
 
 	exitOnError("Error connecting to the target cluster", err)
 
-	dynClient, clientSet, err := getClients(restConfig)
+	dynClient, clientSet, err := restconfig.Clients(restConfig)
 	exitOnError("Error connecting to the target cluster", err)
 	restMapper, err := autil.BuildRestMapper(restConfig)
 

--- a/pkg/subctl/cmd/gather.go
+++ b/pkg/subctl/cmd/gather.go
@@ -30,6 +30,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/gather"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
@@ -102,7 +103,7 @@ func gatherData() {
 	err := checkGatherArguments()
 	exitOnError("Invalid arguments", err)
 
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST configs", err)
 
 	if directory == "" {
@@ -123,26 +124,26 @@ func gatherData() {
 	fmt.Printf("Files are stored under directory %q\n", directory)
 }
 
-func gatherDataByCluster(restConfig restConfig, directory string) {
+func gatherDataByCluster(restConfig restconfig.RestConfig, directory string) {
 	var err error
-	clusterName := restConfig.clusterName
+	clusterName := restConfig.ClusterName
 
 	fmt.Printf("Gathering information from cluster %q\n", clusterName)
 
 	info := gather.Info{
-		RestConfig:           restConfig.config,
+		RestConfig:           restConfig.Config,
 		ClusterName:          clusterName,
 		DirName:              directory,
 		IncludeSensitiveData: includeSensitiveData,
 	}
 
-	info.DynClient, info.ClientSet, err = getClients(restConfig.config)
+	info.DynClient, info.ClientSet, err = restconfig.Clients(restConfig.Config)
 	if err != nil {
 		fmt.Printf("Error getting client: %s\n", err)
 		return
 	}
 
-	submarinerClient, err := subOperatorClientset.NewForConfig(restConfig.config)
+	submarinerClient, err := subOperatorClientset.NewForConfig(restConfig.Config)
 	if err != nil {
 		fmt.Printf("Error getting Submariner client: %s\n", err)
 		return
@@ -236,7 +237,7 @@ func gatherDiscovery(dataType string, info gather.Info) bool {
 func gatherBroker(dataType string, info gather.Info) bool {
 	switch dataType {
 	case Resources:
-		brokerRestConfig, brokerNamespace, err := getBrokerRestConfigAndNamespace(info.Submariner, info.ServiceDiscovery)
+		brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(info.Submariner, info.ServiceDiscovery)
 		if err != nil {
 			info.Status.QueueFailureMessage(fmt.Sprintf("Error getting the broker's rest config: %s", err))
 			return true
@@ -244,7 +245,7 @@ func gatherBroker(dataType string, info gather.Info) bool {
 
 		if brokerRestConfig != nil {
 			info.RestConfig = brokerRestConfig
-			info.DynClient, info.ClientSet, err = getClients(brokerRestConfig)
+			info.DynClient, info.ClientSet, err = restconfig.Clients(brokerRestConfig)
 			if err != nil {
 				info.Status.QueueFailureMessage(fmt.Sprintf("Error getting the broker client: %s", err))
 				return true

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -28,6 +28,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	cmdVersion "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/version"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -152,7 +154,7 @@ var joinCmd = &cobra.Command{
 		exitOnError("Error connecting to broker cluster", err)
 		err = isValidCustomCoreDNSConfig()
 		exitOnError("Invalid Custom CoreDNS configuration", err)
-		config := getClientConfig(kubeConfig, kubeContext)
+		config := restconfig.ClientConfig(kubeConfig, kubeContext)
 		joinSubmarinerCluster(config, kubeContext, subctlData)
 	},
 }
@@ -174,7 +176,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 		rawConfig, err := config.RawConfig()
 		// This will be fatal later, no point in continuing
 		exitOnError("Error connecting to the target cluster", err)
-		clusterName := getClusterNameFromContext(rawConfig, contextName)
+		clusterName := restconfig.ClusterNameFromContext(rawConfig, contextName)
 		if clusterName != nil {
 			clusterID = *clusterName
 		}
@@ -342,7 +344,7 @@ func AllocateAndUpdateGlobalCIDRConfigMap(brokerAdminClientset *kubernetes.Clien
 }
 
 func getNetworkDetails(config *rest.Config) *network.ClusterNetwork {
-	dynClient, clientSet, err := getClients(config)
+	dynClient, clientSet, err := restconfig.Clients(config)
 	exitOnError("Unable to set the Kubernetes cluster connection up", err)
 
 	submarinerClient, err := submarinerclientset.NewForConfig(config)

--- a/pkg/subctl/cmd/show.go
+++ b/pkg/subctl/cmd/show.go
@@ -19,11 +19,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // showCmd represents the show command
@@ -35,33 +31,7 @@ var showCmd = &cobra.Command{
 
 const SubmMissingMessage = "Submariner is not installed"
 
-type restConfig struct {
-	config      *rest.Config
-	clusterName string
-}
-
 func init() {
 	AddKubeContextFlag(showCmd)
 	rootCmd.AddCommand(showCmd)
-}
-
-func getClientConfigAndClusterName(rules *clientcmd.ClientConfigLoadingRules, overrides *clientcmd.ConfigOverrides) (restConfig, error) {
-	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
-	clientConfig, err := config.ClientConfig()
-	if err != nil {
-		return restConfig{}, err
-	}
-
-	raw, err := config.RawConfig()
-	if err != nil {
-		return restConfig{}, err
-	}
-
-	clusterName := getClusterNameFromContext(raw, overrides.CurrentContext)
-
-	if clusterName == nil {
-		return restConfig{}, fmt.Errorf("could not obtain the cluster name from kube config: %#v", raw)
-	}
-
-	return restConfig{config: clientConfig, clusterName: *clusterName}, nil
 }

--- a/pkg/subctl/cmd/show_all.go
+++ b/pkg/subctl/cmd/show_all.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 )
 
 var showAllCmd = &cobra.Command{
@@ -37,18 +38,18 @@ func init() {
 }
 
 func showAll(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {
 		fmt.Println()
-		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
+		fmt.Printf("Showing information for cluster %q:\n", item.ClusterName)
 
 		fmt.Println("Showing Network details")
-		showNetworkSingleCluster(item.config)
+		showNetworkSingleCluster(item.Config)
 		fmt.Println("")
 
-		submariner := getSubmarinerResource(item.config)
+		submariner := getSubmarinerResource(item.Config)
 
 		if submariner == nil {
 			fmt.Println(SubmMissingMessage)
@@ -62,6 +63,6 @@ func showAll(cmd *cobra.Command, args []string) {
 		fmt.Println("\nShowing Gateway details")
 		showGatewaysFor(submariner)
 		fmt.Println("\nShowing version details")
-		showVersionsFor(item.config, submariner)
+		showVersionsFor(item.Config, submariner)
 	}
 }

--- a/pkg/subctl/cmd/show_connections.go
+++ b/pkg/subctl/cmd/show_connections.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/table"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 
@@ -106,12 +107,12 @@ func remoteIPAndNATForConnection(connection submv1.Connection) (string, string) 
 }
 
 func showConnections(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()
-		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
-		submariner := getSubmarinerResource(item.config)
+		fmt.Printf("Showing information for cluster %q:\n", item.ClusterName)
+		submariner := getSubmarinerResource(item.Config)
 
 		if submariner == nil {
 			fmt.Println(SubmMissingMessage)

--- a/pkg/subctl/cmd/show_endpoints.go
+++ b/pkg/subctl/cmd/show_endpoints.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 
 	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 )
@@ -85,12 +86,12 @@ func getEndpointsStatus(submariner *v1alpha1.Submariner) []endpointStatus {
 }
 
 func showEndpoints(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()
-		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
-		submariner := getSubmarinerResource(item.config)
+		fmt.Printf("Showing information for cluster %q:\n", item.ClusterName)
+		submariner := getSubmarinerResource(item.Config)
 
 		if submariner == nil {
 			fmt.Println(SubmMissingMessage)

--- a/pkg/subctl/cmd/show_gateways.go
+++ b/pkg/subctl/cmd/show_gateways.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 
 	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
@@ -84,13 +85,13 @@ func getGatewaysStatus(submariner *v1alpha1.Submariner) []gatewayStatus {
 }
 
 func showGateways(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {
 		fmt.Println()
-		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
-		submariner := getSubmarinerResource(item.config)
+		fmt.Printf("Showing information for cluster %q:\n", item.ClusterName)
+		submariner := getSubmarinerResource(item.Config)
 
 		if submariner == nil {
 			fmt.Println(SubmMissingMessage)

--- a/pkg/subctl/cmd/show_networks.go
+++ b/pkg/subctl/cmd/show_networks.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"k8s.io/client-go/rest"
 )
 
@@ -41,13 +42,13 @@ func init() {
 }
 
 func showNetwork(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 
 	for _, item := range configs {
 		fmt.Println()
-		fmt.Printf("Showing network details for cluster %q:\n", item.clusterName)
-		showNetworkSingleCluster(item.config)
+		fmt.Printf("Showing network details for cluster %q:\n", item.ClusterName)
+		showNetworkSingleCluster(item.Config)
 	}
 }
 
@@ -66,7 +67,7 @@ func showNetworkSingleCluster(config *rest.Config) {
 		}
 	} else {
 		msg = "    Discovered network details"
-		dynClient, clientSet, err := getClients(config)
+		dynClient, clientSet, err := restconfig.Clients(config)
 		exitOnError("Error creating clients for cluster", err)
 
 		submarinerClient, err := submarinerclientset.NewForConfig(config)

--- a/pkg/subctl/cmd/show_versions.go
+++ b/pkg/subctl/cmd/show_versions.go
@@ -26,6 +26,7 @@ import (
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,16 +121,16 @@ func showVersionsFor(config *rest.Config, submariner *v1alpha1.Submariner) {
 }
 
 func showVersions(cmd *cobra.Command, args []string) {
-	configs, err := getMultipleRestConfigs(kubeConfig, kubeContexts)
+	configs, err := restconfig.ForClusters(kubeConfig, kubeContexts)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()
-		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
-		submariner := getSubmarinerResource(item.config)
+		fmt.Printf("Showing information for cluster %q:\n", item.ClusterName)
+		submariner := getSubmarinerResource(item.Config)
 		if submariner == nil {
 			fmt.Println(SubmMissingMessage)
 		} else {
-			showVersionsFor(item.config, submariner)
+			showVersionsFor(item.Config, submariner)
 		}
 	}
 }

--- a/pkg/subctl/cmd/utils/restconfig/restconfig.go
+++ b/pkg/subctl/cmd/utils/restconfig/restconfig.go
@@ -1,0 +1,178 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restconfig
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/submariner-io/admiral/pkg/resource"
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+
+	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+)
+
+type RestConfig struct {
+	Config      *rest.Config
+	ClusterName string
+}
+
+func MustGetForClusters(kubeConfigPath string, kubeContexts []string) []RestConfig {
+	configs, err := ForClusters(kubeConfigPath, kubeContexts)
+	utils.ExitOnError("Error getting REST Config for cluster", err)
+
+	return configs
+}
+
+func ForClusters(kubeConfigPath string, kubeContexts []string) ([]RestConfig, error) {
+	var restConfigs []RestConfig
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+	rules.ExplicitPath = kubeConfigPath
+
+	contexts := []string{}
+	if len(kubeContexts) > 0 {
+		contexts = append(contexts, kubeContexts...)
+	} else {
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+		rawConfig, err := kubeConfig.RawConfig()
+		if err != nil {
+			return restConfigs, err
+		}
+		for context := range rawConfig.Contexts {
+			contexts = append(contexts, context)
+		}
+	}
+
+	for _, context := range contexts {
+		if context != "" {
+			overrides.CurrentContext = context
+			config, err := clientConfigAndClusterName(rules, overrides)
+			if err != nil {
+				return nil, err
+			}
+
+			restConfigs = append(restConfigs, config)
+		}
+	}
+
+	return restConfigs, nil
+}
+
+func ForBroker(submariner *v1alpha1.Submariner, serviceDisc *v1alpha1.ServiceDiscovery) (*rest.Config, string, error) {
+	if submariner != nil {
+		// Try to authorize against the submariner Cluster resource as we know the CRD should exist and the credentials
+		// should allow read access.
+		restConfig, _, err := resource.GetAuthorizedRestConfig(submariner.Spec.BrokerK8sApiServer, submariner.Spec.BrokerK8sApiServerToken,
+			submariner.Spec.BrokerK8sCA, rest.TLSClientConfig{}, schema.GroupVersionResource{
+				Group:    subv1.SchemeGroupVersion.Group,
+				Version:  subv1.SchemeGroupVersion.Version,
+				Resource: "clusters",
+			}, submariner.Spec.BrokerK8sRemoteNamespace)
+
+		return restConfig, submariner.Spec.BrokerK8sRemoteNamespace, err
+	}
+
+	if serviceDisc != nil {
+		// Try to authorize against the ServiceImport resource as we know the CRD should exist and the credentials
+		// should allow read access.
+		restConfig, _, err := resource.GetAuthorizedRestConfig(serviceDisc.Spec.BrokerK8sApiServer, serviceDisc.Spec.BrokerK8sApiServerToken,
+			serviceDisc.Spec.BrokerK8sCA, rest.TLSClientConfig{}, schema.GroupVersionResource{
+				Group:    "multicluster.x-k8s.io",
+				Version:  "v1alpha1",
+				Resource: "serviceimports",
+			}, serviceDisc.Spec.BrokerK8sRemoteNamespace)
+
+		return restConfig, serviceDisc.Spec.BrokerK8sRemoteNamespace, err
+	}
+
+	return nil, "", nil
+}
+
+func clientConfigAndClusterName(rules *clientcmd.ClientConfigLoadingRules, overrides *clientcmd.ConfigOverrides) (RestConfig, error) {
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+	clientConfig, err := config.ClientConfig()
+	if err != nil {
+		return RestConfig{}, err
+	}
+
+	raw, err := config.RawConfig()
+	if err != nil {
+		return RestConfig{}, err
+	}
+
+	clusterName := ClusterNameFromContext(raw, overrides.CurrentContext)
+
+	if clusterName == nil {
+		return RestConfig{}, fmt.Errorf("could not obtain the cluster name from kube config: %#v", raw)
+	}
+
+	return RestConfig{Config: clientConfig, ClusterName: *clusterName}, nil
+}
+
+func Clients(config *rest.Config) (dynamic.Interface, kubernetes.Interface, error) {
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return dynClient, clientSet, nil
+}
+
+func ClusterNameFromContext(rawConfig api.Config, overridesContext string) *string {
+	if overridesContext == "" {
+		// No context provided, use the current context
+		overridesContext = rawConfig.CurrentContext
+	}
+	configContext, ok := rawConfig.Contexts[overridesContext]
+	if !ok {
+		return nil
+	}
+	return &configContext.Cluster
+}
+
+func ForCluster(kubeConfigPath, kubeContext string) (*rest.Config, error) {
+	return ClientConfig(kubeConfigPath, kubeContext).ClientConfig()
+}
+
+// ClientConfig returns a clientcmd.ClientConfig to use when communicating with K8s
+func ClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = kubeConfigPath
+
+	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+	if kubeContext != "" {
+		overrides.CurrentContext = kubeContext
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+}

--- a/pkg/subctl/cmd/utils/utils.go
+++ b/pkg/subctl/cmd/utils/utils.go
@@ -23,8 +23,6 @@ import (
 	"os"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/version"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // PanicOnError will print the subctl version and then panic in case of an actual error
@@ -51,25 +49,6 @@ func ExitWithErrorMsg(message string) {
 	version.PrintSubctlVersion(os.Stderr)
 	fmt.Fprintln(os.Stderr, "")
 	os.Exit(1)
-}
-
-// GetRestConfig returns a rest.Config to use when communicating with K8s
-func GetRestConfig(kubeConfigPath, kubeContext string) (*rest.Config, error) {
-	return GetClientConfig(kubeConfigPath, kubeContext).ClientConfig()
-}
-
-// GetClientConfig returns a clientcmd.ClientConfig to use when communicating with K8s
-func GetClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	rules.ExplicitPath = kubeConfigPath
-
-	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
-	if kubeContext != "" {
-		overrides.CurrentContext = kubeContext
-	}
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
 }
 
 // ExpectFlag exits with an error if the flag value is empty

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/submariner-io/lighthouse/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -195,9 +196,9 @@ func configureTestingFramework(args []string) error {
 }
 
 func clusterNameFromConfig(kubeConfigPath, kubeContext string) string {
-	rawConfig, err := getClientConfig(kubeConfigPath, "").RawConfig()
+	rawConfig, err := restconfig.ClientConfig(kubeConfigPath, "").RawConfig()
 	exitOnError(fmt.Sprintf("Error obtaining the kube config for path %q", kubeConfigPath), err)
-	cluster := getClusterNameFromContext(rawConfig, kubeContext)
+	cluster := restconfig.ClusterNameFromContext(rawConfig, kubeContext)
 	if cluster == nil {
 		exitWithErrorMsg(fmt.Sprintf("Could not obtain the cluster name from kube config: %#v", rawConfig))
 	}


### PR DESCRIPTION
Moves the restconfig functions into its module, so later
we can continue moving each command into separate directories
without causing circular dependencies to the base cmd directory
functions.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
