### PR TITLE
fix subctl release job

### DIFF
--- a/.github/workflows/release_subctl_devel.yml
+++ b/.github/workflows/release_subctl_devel.yml
@@ -8,7 +8,7 @@ on:
       - release-*
 
 jobs:
-  release-subctl-release-0.9:
+  release-subctl-release-09:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository


### PR DESCRIPTION
```
.github/workflows/release_subctl_devel.yml#L11
The workflow is not valid. .github/workflows/release_subctl_devel.yml (Line: 11, Col: 3): Job name release-subctl-release-0.9 is invalid. Names must start with a letter or '_' and contain only alphanumeric characters, '-', or '_'
```
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
