### PR TITLE
Configure monitoring as a core service on OCP

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -29,6 +29,8 @@ resources:
   - networkplugin_syncer/service_account.yaml
   - networkplugin_syncer/cluster_role.yaml
   - networkplugin_syncer/cluster_role_binding.yaml
+  - submariner-metrics-reader/role.yaml
+  - submariner-metrics-reader/role_binding.yaml
 # - leader_election/leader_election_role.yaml
 # - leader_election/leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/submariner-metrics-reader/role.yaml
+++ b/config/rbac/submariner-metrics-reader/role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: submariner-metrics-reader
+  namespace: submariner-operator
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]

--- a/config/rbac/submariner-metrics-reader/role_binding.yaml
+++ b/config/rbac/submariner-metrics-reader/role_binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-submariner-metrics
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: submariner-metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -54,3 +54,18 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 
 	"github.com/submariner-io/submariner-operator/controllers/helpers"
+	"github.com/submariner-io/submariner-operator/pkg/metrics"
 
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.60
 	github.com/coreos/go-semver v0.3.0
+	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
 	github.com/go-errors/errors v1.2.0 // indirect
 	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.20.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -485,7 +485,6 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
-github.com/go-ping/ping v0.0.0-20210407214646-e4e642a95741 h1:b0sLP++Tsle+s57tqg5sUk1/OQsC6yMCciVeqNzOcwU=
 github.com/go-ping/ping v0.0.0-20210407214646-e4e642a95741/go.mod h1:35JbSyV/BYqHwwRA6Zr1uVDm1637YlNOU61wI797NPI=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -763,7 +762,6 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 h1:uhL5Gw7BINiiPAo24A2sxkcDI0Jt/sqp1v5xQCniEFA=
 github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
@@ -896,7 +894,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43/go.mod h1:+t7E0lkKfbBsebllff1xdTmyJt8lH37niI6kwFk9OTo=
-github.com/mdlayher/genetlink v1.0.0 h1:OoHN1OdyEIkScEmRgxLEe2M9U8ClMytqA5niynLtfj0=
 github.com/mdlayher/genetlink v1.0.0/go.mod h1:0rJ0h4itni50A86M2kHcgS85ttZazNt7a8H2a2cw0Gc=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
@@ -906,7 +903,6 @@ github.com/mdlayher/netlink v1.2.0/go.mod h1:kwVW1io0AZy9A1E2YYgaD4Cj+C+GPkU6klX
 github.com/mdlayher/netlink v1.2.1/go.mod h1:bacnNlfhqHqqLo4WsYeXSqfyXkInQ9JneWI68v1KwSU=
 github.com/mdlayher/netlink v1.2.2-0.20210123213345-5cc92139ae3e/go.mod h1:bacnNlfhqHqqLo4WsYeXSqfyXkInQ9JneWI68v1KwSU=
 github.com/mdlayher/netlink v1.3.0/go.mod h1:xK/BssKuwcRXHrtN04UBkwQ6dY9VviGGuriDdoPSWys=
-github.com/mdlayher/netlink v1.4.0 h1:n3ARR+Fm0dDv37dj5wSWZXDKcy+U0zwcXS3zKMnSiT0=
 github.com/mdlayher/netlink v1.4.0/go.mod h1:dRJi5IABcZpBD2A3D0Mv/AiX8I9uDEu5oGkAVrekmf8=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -1263,9 +1259,7 @@ github.com/submariner-io/cloud-prepare v0.10.0-m2 h1:hAPO6RzJ+ANUnrWiehjbaPQhY0B
 github.com/submariner-io/cloud-prepare v0.10.0-m2/go.mod h1:AWdiItVQQhazz368QKt+/xr7qxUkHeL+fOT4Qgj984g=
 github.com/submariner-io/lighthouse v0.10.0-m2.0.20210618122405-aef0fb374a53 h1:acOdtETpxCBvfDjV0r1pOzTJ4dfOdbHt7c1m6Zaulfc=
 github.com/submariner-io/lighthouse v0.10.0-m2.0.20210618122405-aef0fb374a53/go.mod h1:GwCazhNXUNZNjW1l5o5jpAi5tfG2f+saKUCM+09pP6I=
-github.com/submariner-io/shipyard v0.10.0-m2 h1:ZE1x6FW2I21O+koM/FTuj8RuZtB4kzevasuZJSlEEj4=
 github.com/submariner-io/shipyard v0.10.0-m2/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
-github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718 h1:aJEWCnTiw22tf8KQI8kjkUv4aq91aVkhppAmsMRQ0dE=
 github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
 github.com/submariner-io/shipyard v0.10.0-m2.0.20210620123240-3ca03fbbaa06 h1:BoNnKaJj+ZgWKNNASbjIlXkKMuGO55HifJMzHBm0L5E=
 github.com/submariner-io/shipyard v0.10.0-m2.0.20210620123240-3ca03fbbaa06/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
@@ -1307,9 +1301,7 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
-github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vultr/govultr v0.1.4/go.mod h1:9H008Uxr/C4vFNGLqKx232C206GL0PBHzOP0809bGNA=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
@@ -1744,9 +1736,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.zx2c4.com/wireguard v0.0.0-20210427022245-097af6e1351b h1:XDLXhn7ryprJVo+Lpkiib6CIuXE2031GDwtfEm7vLjI=
 golang.zx2c4.com/wireguard v0.0.0-20210427022245-097af6e1351b/go.mod h1:a057zjmoc00UN7gVkaJt2sXVK523kMJcogDTEvPIasg=
-golang.zx2c4.com/wireguard/wgctrl v0.0.0-20210427135350-f9ad6d392236 h1:GFCcxW+maN/OeacJ6wdXvvkXTj1D9agylUJ3iUCLb5k=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20210427135350-f9ad6d392236/go.mod h1:xIClSzcl5wKHz6F+yl+khQTO8qVdUqbH8qb0HNKi9lY=
 gomodules.xyz/jsonpatch/v2 v2.1.0 h1:Phva6wqu+xR//Njw6iorylFFgn/z547tw5Ne3HZPQ+k=
 gomodules.xyz/jsonpatch/v2 v2.1.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright Contributors to the Submariner project.
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/util"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("metrics")
+
+const (
+	// OperatorPortName defines the default operator metrics port name used in the metrics Service.
+	OperatorPortName = "http-metrics"
+	// CRPortName defines the custom resource specific metrics' port name used in the metrics Service.
+	CRPortName = "cr-metrics"
+)
+
+// CreateMetricsService creates a Kubernetes Service to expose the passed metrics
+// port(s) with the given name(s).
+func CreateMetricsService(ctx context.Context, cfg *rest.Config, servicePorts []v1.ServicePort) (*v1.Service, error) {
+	if len(servicePorts) < 1 {
+		return nil, fmt.Errorf("failed to create metrics Serice; service ports were empty")
+	}
+	client, err := crclient.New(cfg, crclient.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new client: %w", err)
+	}
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+	s, err := initOperatorService(ctx, client, servicePorts)
+	if err != nil {
+		if err == k8sutil.ErrNoNamespace || err == k8sutil.ErrRunLocal {
+			log.Info("Skipping metrics Service creation; not running in a cluster.")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to initialize service object for metrics: %w", err)
+	}
+	_, err = util.CreateOrUpdate(ctx, resource.ForService(clientSet, s.Namespace),
+		s, func(existing runtime.Object) (runtime.Object, error) {
+			existingService := existing.(*v1.Service)
+			if existingService.Spec.Type == v1.ServiceTypeClusterIP {
+				s.Spec.ClusterIP = existingService.Spec.ClusterIP
+			}
+			return s, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return clientSet.CoreV1().Services(s.Namespace).Get(ctx, s.Name, metav1.GetOptions{})
+}
+
+// initOperatorService returns the static service which exposes specified port(s).
+func initOperatorService(ctx context.Context, client crclient.Client, sp []v1.ServicePort) (*v1.Service, error) {
+	operatorName, err := k8sutil.GetOperatorName()
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+	label := map[string]string{"name": operatorName}
+
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-metrics", operatorName),
+			Namespace: namespace,
+			Labels:    label,
+		},
+		Spec: v1.ServiceSpec{
+			Ports:    sp,
+			Selector: label,
+		},
+	}
+
+	ownRef, err := getPodOwnerRef(ctx, client, namespace)
+	if err != nil {
+		return nil, err
+	}
+	service.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
+
+	return service, nil
+}
+
+func getPodOwnerRef(ctx context.Context, client crclient.Client, ns string) (*metav1.OwnerReference, error) {
+	// Get current Pod the operator is running in
+	pod, err := k8sutil.GetPod(ctx, client, ns)
+	if err != nil {
+		return nil, err
+	}
+	podOwnerRefs := metav1.NewControllerRef(pod, pod.GroupVersionKind())
+	// Get Owner that the Pod belongs to
+	ownerRef := metav1.GetControllerOf(pod)
+	finalOwnerRef, err := findFinalOwnerRef(ctx, client, ns, ownerRef)
+	if err != nil {
+		return nil, err
+	}
+	if finalOwnerRef != nil {
+		return finalOwnerRef, nil
+	}
+
+	// Default to returning Pod as the Owner
+	return podOwnerRefs, nil
+}
+
+// findFinalOwnerRef tries to locate the final controller/owner based on the owner reference provided.
+func findFinalOwnerRef(ctx context.Context, client crclient.Client, ns string,
+	ownerRef *metav1.OwnerReference) (*metav1.OwnerReference, error) {
+	if ownerRef == nil {
+		return nil, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(ownerRef.APIVersion)
+	obj.SetKind(ownerRef.Kind)
+	err := client.Get(ctx, types.NamespacedName{Namespace: ns, Name: ownerRef.Name}, obj)
+	if err != nil {
+		return nil, err
+	}
+	newOwnerRef := metav1.GetControllerOf(obj)
+	if newOwnerRef != nil {
+		return findFinalOwnerRef(ctx, client, ns, newOwnerRef)
+	}
+
+	log.V(1).Info("Pods owner found", "Kind", ownerRef.Kind, "Name",
+		ownerRef.Name, "Namespace", ns)
+	return ownerRef, nil
+}

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright Contributors to the Submariner project.
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	monclientv1 "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var ErrServiceMonitorNotPresent = fmt.Errorf("no ServiceMonitor registered with the API")
+
+const openshiftMonitoringNS = "openshift-monitoring"
+
+type ServiceMonitorUpdater func(*monitoringv1.ServiceMonitor) error
+
+// CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
+// If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.
+func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service) ([]*monitoringv1.ServiceMonitor, error) {
+	// check if we can even create ServiceMonitors
+	exists, err := hasServiceMonitor(config)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, ErrServiceMonitorNotPresent
+	}
+
+	// On OpenShift, we need to create the service monitors in the OpenShift monitoring namespace, not the
+	// services; we need our own clientset rather than the manager's since the latter hasn't started yet
+	// (so its caching infrastructure isn't available, and reads fail)
+	cs, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := cs.CoreV1().Namespaces().Get(context.TODO(), openshiftMonitoringNS, metav1.GetOptions{}); err == nil {
+		ns = openshiftMonitoringNS
+	} else if !errors.IsNotFound(err) {
+		log.Error(err, "Error checking for the OpenShift monitoring namespace")
+	}
+
+	serviceMonitors := make([]*monitoringv1.ServiceMonitor, len(services))
+	mclient := monclientv1.NewForConfigOrDie(config)
+
+	for _, s := range services {
+		if s == nil {
+			continue
+		}
+		sm := GenerateServiceMonitor(ns, s)
+
+		smc, err := mclient.ServiceMonitors(ns).Create(context.TODO(), sm, metav1.CreateOptions{})
+		if err != nil {
+			return serviceMonitors, err
+		}
+		serviceMonitors = append(serviceMonitors, smc)
+	}
+
+	return serviceMonitors, nil
+}
+
+// GenerateServiceMonitor generates a prometheus-operator ServiceMonitor object
+// based on the passed Service object.
+func GenerateServiceMonitor(ns string, s *v1.Service) *monitoringv1.ServiceMonitor {
+	labels := make(map[string]string)
+	for k, v := range s.ObjectMeta.Labels {
+		labels[k] = v
+	}
+	endpoints := populateEndpointsFromServicePorts(s)
+	boolTrue := true
+
+	// Owner references only work inside the same namespace
+	ownerReferences := []metav1.OwnerReference{}
+	namespaceSelector := monitoringv1.NamespaceSelector{}
+	if ns == s.ObjectMeta.Namespace {
+		ownerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         "v1",
+				BlockOwnerDeletion: &boolTrue,
+				Controller:         &boolTrue,
+				Kind:               "Service",
+				Name:               s.Name,
+				UID:                s.UID,
+			},
+		}
+	} else {
+		namespaceSelector = monitoringv1.NamespaceSelector{
+			MatchNames: []string{s.ObjectMeta.Namespace},
+		}
+	}
+
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            s.ObjectMeta.Name,
+			Namespace:       ns,
+			Labels:          labels,
+			OwnerReferences: ownerReferences,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			NamespaceSelector: namespaceSelector,
+			Endpoints:         endpoints,
+		},
+	}
+}
+
+func populateEndpointsFromServicePorts(s *v1.Service) []monitoringv1.Endpoint {
+	endpoints := make([]monitoringv1.Endpoint, len(s.Spec.Ports))
+	for _, port := range s.Spec.Ports {
+		endpoints = append(endpoints, monitoringv1.Endpoint{Port: port.Name})
+	}
+	return endpoints
+}
+
+// hasServiceMonitor checks if ServiceMonitor is registered in the cluster.
+func hasServiceMonitor(config *rest.Config) (bool, error) {
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	apiVersion := "monitoring.coreos.com/v1"
+	kind := "ServiceMonitor"
+
+	return k8sutil.ResourceExists(dc, apiVersion, kind)
+}

--- a/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
+++ b/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
@@ -74,6 +74,8 @@ var files = []string{
 	"config/rbac/networkplugin_syncer/service_account.yaml",
 	"config/rbac/networkplugin_syncer/cluster_role.yaml",
 	"config/rbac/networkplugin_syncer/cluster_role_binding.yaml",
+	"config/rbac/submariner-metrics-reader/role.yaml",
+	"config/rbac/submariner-metrics-reader/role_binding.yaml",
 }
 
 // Reads all .yaml files in the crdDirectory

--- a/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
@@ -176,7 +176,13 @@ func ensureRoles(clientSet *clientset.Clientset, namespace string) (bool, error)
 		return false, err
 	}
 
-	return createdOperatorRole || createdSubmarinerRole || createdRouteAgentRole || createdGlobalnetRole, err
+	createdMetricsReaderRole, err := serviceaccount.EnsureRole(clientSet, namespace,
+		embeddedyamls.Config_rbac_submariner_metrics_reader_role_yaml)
+	if err != nil {
+		return false, err
+	}
+
+	return createdOperatorRole || createdSubmarinerRole || createdRouteAgentRole || createdGlobalnetRole || createdMetricsReaderRole, err
 }
 
 func ensureRoleBindings(clientSet *clientset.Clientset, namespace string) (bool, error) {
@@ -204,5 +210,11 @@ func ensureRoleBindings(clientSet *clientset.Clientset, namespace string) (bool,
 		return false, err
 	}
 
-	return createdOperatorRB || createdSubmarinerRB || createdRouteAgentRB || createdGlobalnetRB, err
+	createdMetricsReaderRB, err := serviceaccount.EnsureRoleBinding(clientSet, namespace,
+		embeddedyamls.Config_rbac_submariner_metrics_reader_role_binding_yaml)
+	if err != nil {
+		return false, err
+	}
+
+	return createdOperatorRB || createdSubmarinerRB || createdRouteAgentRB || createdGlobalnetRB || createdMetricsReaderRB, err
 }


### PR DESCRIPTION
This sets up the ServiceMonitors in the OpenShift monitoring namespace
instead of the monitored services’ namespaces, which enables
monitoring as a core service without user configuration.

Metric-reading roles are set up in all cases for now.

We pull in pkg/metrics from the Operator SDK because the SDK’s version
doesn’t support setting up cross-namespace ServiceMonitors; fixing it
upstream isn’t an option because it has been dropped there in favour
of kustomize handling.

Fixes: #1299
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
