### PR TITLE
When a cluster id is invalid, show the error

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -180,7 +180,8 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 		}
 	}
 
-	if valid, _ := isValidClusterID(clusterID); !valid {
+	if valid, err := isValidClusterID(clusterID); !valid {
+		fmt.Printf("Error: %s\n", err.Error())
 		qs = append(qs, &survey.Question{
 			Name:   "clusterID",
 			Prompt: &survey.Input{Message: "What is your cluster ID?"},


### PR DESCRIPTION
Currently, if the cluster id specified using the relevant option or
generated from the context name is invalid, we ask the user for a
cluster id with no introduction. This patch shows the error before
prompting.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
