### PR TITLE
Subctl diagnose all should run on all clusters

### DIFF
--- a/pkg/subctl/cmd/diagnose/all.go
+++ b/pkg/subctl/cmd/diagnose/all.go
@@ -47,25 +47,25 @@ func diagnoseAll(cluster *cmd.Cluster) bool {
 		return success
 	}
 
-	success = success && checkCNIConfig(cluster)
+	success = checkCNIConfig(cluster) && success
 	fmt.Println()
 
-	success = success && checkConnections(cluster)
+	success = checkConnections(cluster) && success
 	fmt.Println()
 
-	success = success && checkPods(cluster)
+	success = checkPods(cluster) && success
 	fmt.Println()
 
-	success = success && checkOverlappingCIDRs(cluster)
+	success = checkOverlappingCIDRs(cluster) && success
 	fmt.Println()
 
-	success = success && checkKubeProxyMode(cluster)
+	success = checkKubeProxyMode(cluster) && success
 	fmt.Println()
 
-	success = success && checkFirewallMetricsConfig(cluster)
+	success = checkFirewallMetricsConfig(cluster) && success
 	fmt.Println()
 
-	success = success && checkVxLANConfig(cluster)
+	success = checkVxLANConfig(cluster) && success
 	fmt.Println()
 
 	fmt.Printf("Skipping tunnel firewall check as it requires two kubeconfigs." +

--- a/pkg/subctl/cmd/execute.go
+++ b/pkg/subctl/cmd/execute.go
@@ -99,7 +99,7 @@ func ExecuteMultiCluster(run func(*Cluster) bool) {
 			continue
 		}
 
-		success = success && run(cluster)
+		success = run(cluster) && success
 		fmt.Println()
 	}
 


### PR DESCRIPTION
Make sure that subctl diagnose all will execute all checks
even if one check failed
Also applys to ExecuteMultiCluster when need to execute
command on multiple clusters

Signed-off-by: Maayan Friedman <maafried@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
