### PR TITLE
Avoid printing throughput output twice with verbose

### DIFF
--- a/pkg/subctl/benchmark/throughput.go
+++ b/pkg/subctl/benchmark/throughput.go
@@ -151,9 +151,10 @@ func runThroughputTest(f *framework.Framework, testParams benchmarkTestParams) {
 
 	By(fmt.Sprintf("Waiting for the client pod %q to exit, returning what client sent", nettestClientPod.Pod.Name))
 	nettestClientPod.AwaitFinishVerbose(Verbose)
-	nettestClientPod.CheckSuccessfulFinish()
-	fmt.Println(nettestClientPod.TerminationMessage)
-
+	if !Verbose {
+		nettestClientPod.CheckSuccessfulFinish()
+		fmt.Println(nettestClientPod.TerminationMessage)
+	}
 	// In Globalnet deployments, when backend pods finish their execution, kubeproxy-iptables driver tries
 	// to delete the iptables-chain associated with the service (even when the service is present) as there are
 	// no active backend pods. Since the iptables-chain is also referenced by Globalnet Ingress rules, the chain


### PR DESCRIPTION
subctl benchmark throughput --verbose prints the output twice.
This patch makes it print only once.

The output of benchmark latency will be printed twice with verbose
1. raw termination message
2. pretty-printed termination message for a better UX

Closes: #1429 
Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
