### PR TITLE
Backport: Mount iptables xtables.lock file in globalnet container

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -678,12 +678,20 @@ func newGlobalnetDaemonSet(cr *submopv1a1.Submariner) *appsv1.DaemonSet {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+							Path: "/run/xtables.lock",
+						}}},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "submariner-globalnet",
 							Image:           getImagePath(cr, names.GlobalnetImage, names.GlobalnetComponent),
 							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.GlobalnetComponent]),
 							SecurityContext: &securityContextAllCapAllowEscal,
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "host-run-xtables-lock", MountPath: "/run/xtables.lock"},
+							},
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},


### PR DESCRIPTION
Basically there was a regression while hardening the Submariner Pods for
security requirements. Earlier, we used to mount the host filesystem to
"/host" mount point on the Pod and use chroot while executing the iptables
commands. The hardening PRs modified this behavior and in this process
we accidentally removed the lock file because of which we are now randomly
seeing flaky issues with Globalnet jobs.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1430
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

(cherry picked from commit 0448fcd60972da03c84c345c24c2cf1c34b6b42b)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
