### PR TITLE
Error on invalid --image-override name

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -45,3 +45,6 @@ var (
 	ImagePrefix  = ""
 	ImagePostfix = ""
 )
+
+var ValidImageNames = []string{NetworkPluginSyncerImage, RouteAgentImage, GatewayImage, GlobalnetImage,
+	ServiceDiscoveryImage, LighthouseCoreDNSImage, OperatorImage}

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -573,12 +573,24 @@ func getImageOverrides() map[string]string {
 		imageOverrides := make(map[string]string)
 		for _, s := range imageOverrideArr {
 			key := strings.Split(s, "=")[0]
+			if invalidImageName(key) {
+				utils.ExitWithErrorMsg(fmt.Sprintf("Invalid image name %s provided. Please choose from %q", key, names.ValidImageNames))
+			}
 			value := strings.Split(s, "=")[1]
 			imageOverrides[key] = value
 		}
 		return imageOverrides
 	}
 	return nil
+}
+
+func invalidImageName(key string) bool {
+	for _, name := range names.ValidImageNames {
+		if key == name {
+			return false
+		}
+	}
+	return true
 }
 
 func isValidCustomCoreDNSConfig() error {


### PR DESCRIPTION
`subctl join` now errors out when an invalid image name is
passed to `--image-override` flag.

The error is in the format
Invalid image name `submariner` provided. Please choose from ["submariner-networkplugin-syncer" "submariner-route-agent" "submariner-gateway" "submariner-globalnet" "lighthouse-agent" "lighthouse-coredns" "submariner-operator"]

Depends on #1405 
Closes: #1018 
Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
