### PR TITLE
Change globalCIDR to 242.0.0.0/8

### DIFF
--- a/controllers/submariner/broker_controller.go
+++ b/controllers/submariner/broker_controller.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -85,6 +86,11 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	}
 
 	// Globalnet
+	err = globalnet.ValidateExistingGlobalNetworks(r.Config, broker.SubmarinerBrokerNamespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	err = broker.CreateGlobalnetConfigMap(r.Config, instance.Spec.GlobalnetEnabled, instance.Spec.GlobalnetCIDRRange,
 		instance.Spec.DefaultGlobalnetClusterSize, broker.SubmarinerBrokerNamespace)
 	if err != nil {

--- a/pkg/discovery/globalnet/globalnet_test.go
+++ b/pkg/discovery/globalnet/globalnet_test.go
@@ -215,3 +215,37 @@ var _ = Describe("AllocateGlobalCIDR: Fail", func() {
 		})
 	})
 })
+
+var _ = Describe("IsValidCidr", func() {
+	When("Unspecified CIDR", func() {
+		err := IsValidCIDR("")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+		err = IsValidCIDR("1.2")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("Loopback CIDR", func() {
+		err := IsValidCIDR("127.0.0.0/16")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("Link-Local CIDR", func() {
+		err := IsValidCIDR("169.254.0.0/16")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("Link-Local Multicast CIDR", func() {
+		err := IsValidCIDR("224.0.0.0/24")
+		It("Should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Current default globalCIDR of 169.254.x.0 cannot be used for
headless services as EndpointSlices can't have IP in link-local
CIDR range. Change to 242.254.x.0

* Change default Global CIDR to `242.254.0.0/16`
* Add validations for globalCIDRs configured by user

Fixes #1458 

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
