### PR TITLE
Some fixes for `subctl-devel` release job

### DIFF
--- a/.github/workflows/release_subctl_devel.yml
+++ b/.github/workflows/release_subctl_devel.yml
@@ -19,24 +19,19 @@ jobs:
 
       - name: Generate subctl version
         run: |
-          echo "SUBCTL_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-          echo "RELEASE=release-${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "RELEASE=subctl-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Generate the subctl release artifacts
-        run: make build-cross VERSION=${{ env.SUBCTL_TAG }}
+        run: make build-cross VERSION=${{ env.BRANCH }}
 
-      - name: Install GH CLI
-        run: |
-          curl -sLo /tmp/gh.deb https://github.com/cli/cli/releases/download/v1.11.0/gh_1.11.0_linux_amd64.deb
-          sudo apt install /tmp/gh.deb
-
-      - name: Delete old release
-        run: git push -d origin ${{ env.RELEASE }} || true
-
-      - name: Create the release with the updated artifacts
+      - name: Recreate the release with the updated artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh release delete ${{ env.RELEASE }} -y || true
+          git push -d origin ${{ env.RELEASE }} || true
           gh release create ${{ env.RELEASE }} dist/*.tar.xz --prerelease \
-            --title "Cutting Edge: ${{ env.SUBCTL_TAG }}" \
+            --title "Cutting Edge: ${{ env.BRANCH }}" \
+            --notes "Cutting edge binaries of \`subctl\` for '${{ env.BRANCH }}' branch, always updated to the latest merged code." \
             --target ${GITHUB_SHA}


### PR DESCRIPTION
* Release should be also deleted or it leaves a "draft release".
* Tag name should be `subctl-${BRANCH}` e.g. `subctl-devel`.
* Added notes to the release created in GH to match what we had.
* Seems `gh` CLI is already available, no need to install it.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
