### PR TITLE
Return NotFound error as-is in GetGlobalNetworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,16 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Ensure we prefer binaries we build
+export PATH := $(CURDIR)/bin:$(PATH)
+
 # Targets to make
 
 images: build
+
+# Build subctl before deploying to ensure we use that
+# (with the PATH set above)
+deploy: bin/subctl
 
 e2e: deploy
 	scripts/kind-e2e/e2e.sh

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -293,7 +293,7 @@ func ValidateGlobalnetConfiguration(globalnetInfo *GlobalnetInfo, netconfig Conf
 func GetGlobalNetworks(k8sClientset *kubernetes.Clientset, brokerNamespace string) (*GlobalnetInfo, *v1.ConfigMap, error) {
 	configMap, err := broker.GetGlobalnetConfigMap(k8sClientset, brokerNamespace)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading configMap: %s", err)
+		return nil, nil, err
 	}
 
 	globalnetInfo := GlobalnetInfo{}


### PR DESCRIPTION
In GetGlobalNetworks we wrap error returned with a custom error.
This breaks the validation check in calling methods if they want
to ignore IsNotFound error. Fix is to return IsNotFound error as is.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
