### PR TITLE
Validate old globalnet only if globalnet enabled

### DIFF
--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -166,8 +166,10 @@ var deployBroker = &cobra.Command{
 
 		utils.ExitOnError("Error setting up service discovery information", err)
 
-		err = globalnet.ValidateExistingGlobalNetworks(config, broker.SubmarinerBrokerNamespace)
-		utils.ExitOnError("Error validating existing globalCIDR configmap", err)
+		if globalnetEnable {
+			err = globalnet.ValidateExistingGlobalNetworks(config, broker.SubmarinerBrokerNamespace)
+			utils.ExitOnError("Error validating existing globalCIDR configmap", err)
+		}
 
 		err = broker.CreateGlobalnetConfigMap(config, globalnetEnable, globalnetCIDRRange,
 			defaultGlobalnetClusterSize, broker.SubmarinerBrokerNamespace)


### PR DESCRIPTION
During an upgrade we should only check if old globalnet config
is valid if globalnet is currently enabled.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
