### PR TITLE
Fix panic when setting CoreDNSCustomConfig

### DIFF
--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -50,11 +50,9 @@ func (r *SubmarinerReconciler) serviceDiscoveryReconciler(ctx context.Context, s
 					Namespace:                submariner.Spec.Namespace,
 					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
 					ImageOverrides:           submariner.Spec.ImageOverrides,
+					CoreDNSCustomConfig:      submariner.Spec.CoreDNSCustomConfig,
 				}
-				if submariner.Spec.CoreDNSCustomConfig != nil {
-					sd.Spec.CoreDNSCustomConfig.ConfigMapName = submariner.Spec.CoreDNSCustomConfig.ConfigMapName
-					sd.Spec.CoreDNSCustomConfig.Namespace = submariner.Spec.CoreDNSCustomConfig.Namespace
-				}
+
 				if len(submariner.Spec.CustomDomains) > 0 {
 					sd.Spec.CustomDomains = submariner.Spec.CustomDomains
 				}


### PR DESCRIPTION
sd.Spec.CoreDNSCustomConfig is nil when we try to assign subfields,
this patch implements a simpler solution that copies the whole
structure pointer.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
