### PR TITLE
Restrict the route-agent capabilities

### DIFF
--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -333,9 +333,11 @@ function verify_subm_routeagent_pod() {
     json_file=/tmp/${subm_gateway_pod_name}.${cluster}.json
     kubectl get pod $subm_routeagent_pod_name --namespace=$subm_ns -o json | tee $json_file
     validate_pod_container_equals 'image' "${subm_gateway_image_repo}/submariner-route-agent:$subm_gateway_image_tag"
-    validate_pod_container_has 'securityContext.capabilities.add' 'ALL'
-    validate_pod_container_equals 'securityContext.allowPrivilegeEscalation' 'true'
-    validate_pod_container_equals 'securityContext.privileged' 'true'
+    validate_pod_container_has 'securityContext.capabilities.add' 'dac_override'
+    validate_pod_container_has 'securityContext.capabilities.add' 'net_admin'
+    validate_pod_container_has 'securityContext.capabilities.add' 'net_raw'
+    validate_pod_container_equals 'securityContext.allowPrivilegeEscalation' 'false'
+    validate_pod_container_equals 'securityContext.privileged' 'false'
     validate_pod_container_equals 'securityContext.readOnlyRootFilesystem' 'false'
     validate_pod_container_equals 'securityContext.runAsNonRoot' 'false'
     validate_pod_container_has 'command' 'submariner-route-agent.sh'


### PR DESCRIPTION
This uses an init container to set up entries in /proc (which requires
a privileged container), then runs the main container in
non-privileged mode (with DAC_OVERRIDE, NET_ADMIN, and NET_RAW).

This is still a PoC: the init container needs to determine what the CNI interface is, instead of hard-coding `weave`. I’m interested in @sridhargaddam and @mangelajo’s opinions on setting the default `rp_filter` to 2 to handle `vx-submariner`...

Fixes: #1240
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
