### PR TITLE
Remove redundant type specification

### DIFF
--- a/pkg/discovery/network/calico_test.go
+++ b/pkg/discovery/network/calico_test.go
@@ -32,7 +32,7 @@ var _ = Describe("discoverCalicoNetwork", func() {
 		initObjs     []runtime.Object
 		clusterNet   *ClusterNetwork
 		err          error
-		calicoCfgMap *v1.ConfigMap = &v1.ConfigMap{
+		calicoCfgMap = &v1.ConfigMap{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name:      "calico-config",
 				Namespace: "kube-system",


### PR DESCRIPTION
Go can infer the type here:

    calicoCfgMap *v1.ConfigMap = &v1.ConfigMap{

This is flagged by gocritic in golangci-lint 1.41.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
