### PR TITLE
0.8 backport: Truncate token prefixes for long cluster ids

### DIFF
--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -139,6 +139,10 @@ func NewBrokerRoleBinding(serviceAccount, role string) *rbacv1.RoleBinding {
 	return binding
 }
 
+// MaxGeneratedNameLength is the maximum generated length for a token, excluding the random suffix
+// See k8s.io/apiserver/pkg/storage/names
+const MaxGeneratedNameLength = 63 - 5
+
 func GetClientTokenSecret(clientSet clientset.Interface, brokerNamespace, submarinerBrokerSA string) (*v1.Secret, error) {
 	sa, err := clientSet.CoreV1().ServiceAccounts(brokerNamespace).Get(submarinerBrokerSA, metav1.GetOptions{})
 	if err != nil {
@@ -148,6 +152,9 @@ func GetClientTokenSecret(clientSet clientset.Interface, brokerNamespace, submar
 		return nil, fmt.Errorf("ServiceAccount %s does not have any secret", sa.Name)
 	}
 	brokerTokenPrefix := fmt.Sprintf("%s-token-", submarinerBrokerSA)
+	if len(brokerTokenPrefix) > MaxGeneratedNameLength {
+		brokerTokenPrefix = brokerTokenPrefix[:MaxGeneratedNameLength]
+	}
 
 	for _, secret := range sa.Secrets {
 		if strings.HasPrefix(secret.Name, brokerTokenPrefix) {


### PR DESCRIPTION
When an SA is created, Token Controller creates a token for it; that
token's name is auto-generated, with a random suffix, and is at most
63 characters in length, of which 5 are random. Since we look for the
generated token by name, we need to take this into account, and
truncate the prefix using the same rules as the token generator.

Fixes: #1426
Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 4ea3f75d1513757b8c6dd5e664a5331fa32a4753)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
