### PR TITLE
Fix usage of kubeconfig flag in subctl verify

### DIFF
--- a/pkg/subctl/cmd/gather.go
+++ b/pkg/subctl/cmd/gather.go
@@ -72,7 +72,7 @@ var gatherFuncs = map[string]func(string, gather.Info) bool{
 }
 
 func init() {
-	AddKubeContextMultiFlag(gatherCmd)
+	AddKubeContextMultiFlag(gatherCmd, "")
 	addGatherFlags(gatherCmd)
 	rootCmd.AddCommand(gatherCmd)
 }

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -80,11 +80,14 @@ func AddKubeContextFlag(cmd *cobra.Command) {
 }
 
 // AddKubeContextMultiFlag adds a "kubeconfig" flag and a "kubecontext" flag that can be specified multiple times (or comma separated)
-func AddKubeContextMultiFlag(cmd *cobra.Command) {
+func AddKubeContextMultiFlag(cmd *cobra.Command, usage string) {
 	AddKubeConfigFlag(cmd)
-	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontexts", nil,
-		"comma separated list of kubeconfig contexts to use, can be specified multiple times.\n"+
-			"If none specified, all contexts referenced by kubeconfig are used")
+	if usage == "" {
+		usage = "comma separated list of kubeconfig contexts to use, can be specified multiple times.\n" +
+			"If none specified, all contexts referenced by kubeconfig are used"
+	}
+
+	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontexts", nil, usage)
 }
 
 const (

--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -83,8 +83,8 @@ func AddKubeContextFlag(cmd *cobra.Command) {
 func AddKubeContextMultiFlag(cmd *cobra.Command, usage string) {
 	AddKubeConfigFlag(cmd)
 	if usage == "" {
-		usage = "comma separated list of kubeconfig contexts to use, can be specified multiple times.\n" +
-			"If none specified, all contexts referenced by kubeconfig are used"
+		usage = "comma-separated list of kubeconfig contexts to use, can be specified multiple times.\n" +
+			"If none specified, all contexts referenced by the kubeconfig are used"
 	}
 
 	cmd.PersistentFlags().StringSliceVar(&kubeContexts, "kubecontexts", nil, usage)

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -58,7 +58,7 @@ var (
 )
 
 func init() {
-	AddKubeContextMultiFlag(verifyCmd)
+	AddKubeContextMultiFlag(verifyCmd, "comma separated list of kubeconfig contexts to use, must specified 2 contexts.")
 	verifyCmd.Flags().StringVar(&verifyOnly, "only", strings.Join(getAllVerifyKeys(), ","), "comma separated verifications to be performed")
 	verifyCmd.Flags().BoolVar(&disruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
 	addVerifyFlags(verifyCmd)
@@ -182,6 +182,9 @@ func configureTestingFramework(args []string) error {
 		}
 	} else {
 		framework.TestContext.KubeContexts = kubeContexts
+		if kubeConfig != "" {
+			framework.TestContext.KubeConfig = kubeConfig
+		}
 	}
 	framework.TestContext.OperationTimeout = operationTimeout
 	framework.TestContext.ConnectionTimeout = connectionTimeout

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -58,7 +58,7 @@ var (
 )
 
 func init() {
-	AddKubeContextMultiFlag(verifyCmd, "comma separated list of kubeconfig contexts to use, must specified 2 contexts.")
+	AddKubeContextMultiFlag(verifyCmd, "comma-separated list of exactly two kubeconfig contexts to use.")
 	verifyCmd.Flags().StringVar(&verifyOnly, "only", strings.Join(getAllVerifyKeys(), ","), "comma separated verifications to be performed")
 	verifyCmd.Flags().BoolVar(&disruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
 	addVerifyFlags(verifyCmd)


### PR DESCRIPTION
1. send kubeconfig flag to test framework so it will not be ignored
2. use a unique help text to kubecontexts flag when called from subctl
   verify

Fixes issue #1448

Signed-off-by: Maayan Friedman <maafried@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
