### PR TITLE
Remove mount iptables lock file

### DIFF
--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -183,7 +183,6 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner) corev1.PodTemplateSpec {
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: "ipsecd", MountPath: "/etc/ipsec.d", ReadOnly: false},
 						{Name: "ipsecnss", MountPath: "/var/lib/ipsec/nss", ReadOnly: false},
-						{Name: "host-run-xtables-lock", MountPath: "/run/xtables.lock"},
 					},
 				},
 			},
@@ -198,8 +197,6 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner) corev1.PodTemplateSpec {
 			Volumes: []corev1.Volume{
 				{Name: "ipsecd", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 				{Name: "ipsecnss", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-				{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-					Path: "/run/xtables.lock"}}},
 			},
 		},
 	}


### PR DESCRIPTION
Since the iptables is not used for setting path MTU anymore
it is removed
Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
