### PR TITLE
Run Flake Finder every 2h for 0.10-rc0 testing

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -3,7 +3,7 @@ name: Flake Finder
 
 on:
   schedule:
-    - cron: "0 0,1 * * *"
+    - cron: "0 0/2 * * *"
 
 jobs:
   e2e:


### PR DESCRIPTION
This frequency should be reverted once 0.10.0 RC testing is done.

Run the Flake Finder every 2h to collect a lot of data about RC0 leading
up to Test Day on 2021-07-15.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
