### PR TITLE
Backport: Support diagnose tunnel on previous Submariner releases

### DIFF
--- a/pkg/subctl/cmd/validate_tunnel.go
+++ b/pkg/subctl/cmd/validate_tunnel.go
@@ -191,7 +191,15 @@ func getGatewayIP(remoteCfg *rest.Config, localClusterID string) string {
 
 		for _, conn := range gw.Status.Connections {
 			if conn.Endpoint.ClusterID == localClusterID {
-				return conn.UsingIP
+				if conn.UsingIP != "" {
+					return conn.UsingIP
+				}
+
+				if conn.Endpoint.NATEnabled {
+					return conn.Endpoint.PublicIP
+				} else {
+					return conn.Endpoint.PrivateIP
+				}
 			}
 		}
 	}


### PR DESCRIPTION
With some minor changes to the code, we will be able to support running
subctl diagnose tunnel command on previous Submariner releases where
NAT discovery is not enabled (or NAT discovery is still in progress).

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 5e5126cccaf7a3add51e45cc31aa8bd0b2041d1d)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
