### PR TITLE
Backport: Fix subctl diagnose hostname mismatch issue

### DIFF
--- a/pkg/subctl/cmd/validate_tunnel.go
+++ b/pkg/subctl/cmd/validate_tunnel.go
@@ -89,7 +89,7 @@ func validateTunnelConfigAcrossClusters(localCfg, remoteCfg *rest.Config) bool {
 	status.Start(fmt.Sprintf("Checking if tunnels can be setup on Gateway node of cluster %q.",
 		submariner.Spec.ClusterID))
 
-	localEndpoint := getEndpointResource(localCfg, submariner.Spec.ClusterID)
+	localEndpoint := getLocalEndpointResource(localCfg, submariner.Spec.ClusterID)
 	if localEndpoint == nil {
 		status.QueueWarningMessage("Could not find the local cluster Endpoint")
 		return false


### PR DESCRIPTION
Submariner Endpoint stores the hostname info as part of the endpoint object.
In most of the K8s clusters, the hostname matches with the nodeName, but on
some clusters, it was seen that nodeName does not match. This PR fixes this
issue.

Also, when more than a single node is labelled as Gateway node, the current
code was not handling it properly, this PR fixes it.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1471
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 9d125f0ef6ddfeda1f3a66f9039cff01a6782439)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
