### PR TITLE
Add additional parameters to subctl benchmark throughput

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/submariner-io/admiral v0.10.0-rc0.0.20210716074658-80e46214671b
 	github.com/submariner-io/cloud-prepare v0.10.0-rc0.0.20210727150757-5e29b6472b99
 	github.com/submariner-io/lighthouse v0.10.0-rc0.0.20210713134647-2739f14330cd
-	github.com/submariner-io/shipyard v0.10.0-rc0.0.20210719115546-4e6aefed5ecd
+	github.com/submariner-io/shipyard v0.10.0-rc0.0.20210730104545-356f61a119a0
 	github.com/submariner-io/submariner v0.10.0-rc0.0.20210721111558-ee4aa093b719
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/uw-labs/lichen v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1297,6 +1297,8 @@ github.com/submariner-io/lighthouse v0.10.0-rc0.0.20210713134647-2739f14330cd/go
 github.com/submariner-io/shipyard v0.10.0-rc0/go.mod h1:+B8Hrs2vYg7XKFMk61HVg1ev/twSYFIJg3hWiJnCuq0=
 github.com/submariner-io/shipyard v0.10.0-rc0.0.20210719115546-4e6aefed5ecd h1:1Fuq5zXrX9lJUqIkhAg96jS7pBSrqwtKYxIgcvk1e0I=
 github.com/submariner-io/shipyard v0.10.0-rc0.0.20210719115546-4e6aefed5ecd/go.mod h1:+B8Hrs2vYg7XKFMk61HVg1ev/twSYFIJg3hWiJnCuq0=
+github.com/submariner-io/shipyard v0.10.0-rc0.0.20210730104545-356f61a119a0 h1:dguM37aEUeqg8w5IjkTJi3OOziXQm6MqzQBeVBu6JUo=
+github.com/submariner-io/shipyard v0.10.0-rc0.0.20210730104545-356f61a119a0/go.mod h1:+B8Hrs2vYg7XKFMk61HVg1ev/twSYFIJg3hWiJnCuq0=
 github.com/submariner-io/submariner v0.10.0-rc0.0.20210721111558-ee4aa093b719 h1:3wFEWyiC0rWgNApmWiwcfXgWwJVFi9q90Gia4n5lohc=
 github.com/submariner-io/submariner v0.10.0-rc0.0.20210721111558-ee4aa093b719/go.mod h1:QUFVRrVIhZYMED/usHZGzLFWVBBIDpeQAuP/m5A+AZk=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -30,6 +30,8 @@ import (
 var (
 	intraCluster bool
 
+	throughputOptions benchmark.ThroughputTestOptions
+
 	benchmarkCmd = &cobra.Command{
 		Use:   "benchmark",
 		Short: "Benchmark tests",
@@ -40,6 +42,7 @@ var (
 		Short: "Benchmark throughput",
 		Long:  "This command runs throughput tests within a cluster or between two clusters",
 		Args: func(cmd *cobra.Command, args []string) error {
+			throughputOptions.IntraCluster = intraCluster
 			return checkBenchmarkArguments(args, intraCluster)
 		},
 		Run: testThroughput,
@@ -58,6 +61,15 @@ var (
 func init() {
 	addBenchmarkFlags(benchmarkLatencyCmd)
 	addBenchmarkFlags(benchmarkThroughputCmd)
+
+	benchmarkThroughputCmd.PersistentFlags().UintVarP(&throughputOptions.Concurrency, "parallel", "P", 100,
+		"number of parallel client streams to run")
+	benchmarkThroughputCmd.PersistentFlags().UintVarP(&throughputOptions.TCPWindowSizeKB, "window", "w", 256,
+		"set TCP window size in kilobytes")
+	benchmarkThroughputCmd.PersistentFlags().UintVarP(&throughputOptions.TCPMaxMSS, "set-mss", "M", 0,
+		"set TCP MSS in bytes")
+	benchmarkThroughputCmd.PersistentFlags().UintVarP(&throughputOptions.TestTimeSeconds, "time", "t", 10,
+		"test time in seconds")
 
 	benchmarkCmd.AddCommand(benchmarkThroughputCmd)
 	benchmarkCmd.AddCommand(benchmarkLatencyCmd)
@@ -105,7 +117,7 @@ func testThroughput(cmd *cobra.Command, args []string) {
 	if benchmark.Verbose {
 		fmt.Printf("Performing throughput tests\n")
 	}
-	benchmark.StartThroughputTests(intraCluster)
+	benchmark.StartThroughputTests(&throughputOptions)
 }
 
 func testLatency(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This provides additional flexibility to throughput testing,
since not two networks are the same (MTU, capacity, latency), and
sometimes we want to measure the CPU on the gateways.
```
   --parallel -P number of parallel client streams to run
   --window   -w set TCP window size in kilobytes
   --set-mss  -M set TCP MSS in bytes
   --time     -t test time in seconds
```
Depends On submariner-io/shipyard#616
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
