### PR TITLE
Limit cluster-id to 63 chars while joining a cluster

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -417,6 +417,12 @@ func isValidClusterID(clusterID string) (bool, error) {
 			"'.' or '-' (and the first and last characters must be alphanumerics).\n"+
 			"%s doesn't meet these requirements", clusterID)
 	}
+
+	if len(clusterID) > 63 {
+		return false, fmt.Errorf("the cluster ID %q has a length of %d characters which exceeds the maximum"+
+			" supported length of 63", clusterID, len(clusterID))
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
ClusterID is now stored as a label on the endpoint object when its
pushed to the Broker. K8s restricts the label values to 63 chars.
So adding the corresponding check.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
