### PR TITLE
Automated cherry pick of #1492: Remove duplicated information
#1484: Proper checks for gateways

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -23,11 +23,9 @@ Submariner Owners: https://github.com/orgs/submariner-io/teams/submariner-core
 **Anything else we need to know?**:
 
 **Environment**:
-- Submariner version (use `subctl version`):
-- Kubernetes version (use `kubectl version`):
+- Diagnose information (use `subctl diagnose all`):
+- Gather information (use `subctl gather`)
 - Cloud provider or hardware configuration:
-- OS (e.g: `cat /etc/os-release`):
-- Kernel (e.g. `uname -a`):
 - Install tools:
 - Network plugin and version (if this is a network-related bug):
 - Others:


### PR DESCRIPTION
Cherry pick of #1492 #1484 on release-0.9.

#1492: Remove duplicated information
#1484: Proper checks for gateways

For details on the cherry pick process, see the [cherry pick requests](https://submariner.io/development/backports/) page.