### PR TITLE
Fix YAML linting errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: gomod

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,7 +17,7 @@ on:
       - reopened
       - synchronize
   schedule:
-    - cron: '0 0/6 * * *' # every 6 hours
+    - cron: '0 0/6 * * *'  # every 6 hours
 
 jobs:
   check:

--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -1,3 +1,4 @@
+---
 # Licenses other than Apache-2.0 are governed by
 # https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist
 # Note that Allowlist also requires that projects were created

--- a/.submarinerbot.yaml
+++ b/.submarinerbot.yaml
@@ -1,3 +1,4 @@
+---
 label-approved:
   approvals: 2
   label: ready-to-test

--- a/config/broker/kustomization.yaml
+++ b/config/broker/kustomization.yaml
@@ -10,14 +10,14 @@ resources:
   - broker-client/role.yaml
   - broker-client/role_binding.yaml
 
-#vars:
-#  - name: SUBMARINER_BROKER_NAMESPACE
-#    objref:
-#      kind: Namespace
-#      version: v1
-#      name: submariner-k8s-broker
-#    fieldref:
-#      fieldpath: metadata.name
+# vars:
+#   - name: SUBMARINER_BROKER_NAMESPACE
+#     objref:
+#       kind: Namespace
+#       version: v1
+#       name: submariner-k8s-broker
+#     fieldref:
+#       fieldpath: metadata.name
 
 configurations:
   - kustomizeconfig.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,7 +3,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-#  - bases/submariner.io_servicediscoveries.yaml
+  # - bases/submariner.io_servicediscoveries.yaml
   - bases/submariner.io_submariners.yaml
   - bases/submariner.io_brokers.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
@@ -11,16 +11,16 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_submariners.yaml
-#- patches/webhook_in_servicediscoveries.yaml
-#- patches/webhook_in_brokers.yaml
+# - patches/webhook_in_submariners.yaml
+# - patches/webhook_in_servicediscoveries.yaml
+# - patches/webhook_in_brokers.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_submariners.yaml
-#- patches/cainjection_in_servicediscoveries.yaml
-#- patches/cainjection_in_brokers.yaml
+# - patches/cainjection_in_submariners.yaml
+# - patches/cainjection_in_servicediscoveries.yaml
+# - patches/cainjection_in_brokers.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -44,29 +44,29 @@ patchesStrategicMerge:
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-  # - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  #  objref:
-  #    kind: Certificate
-  #    group: cert-manager.io
-  #    version: v1alpha2
-  #    name: serving-cert # this name should match the one in certificate.yaml
-  #  fieldref:
-  #    fieldpath: metadata.namespace
-  # - name: CERTIFICATE_NAME
-  #  objref:
-  #    kind: Certificate
-  #    group: cert-manager.io
-  #    version: v1alpha2
-  #    name: serving-cert # this name should match the one in certificate.yaml
-  # - name: SERVICE_NAMESPACE # namespace of the service
-  #  objref:
-  #    kind: Service
-  #    version: v1
-  #    name: webhook-service
-  #  fieldref:
-  #    fieldpath: metadata.namespace
-  # - name: SERVICE_NAME
-  #  objref:
-  #    kind: Service
-  #    version: v1
-  #    name: webhook-service
+# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+# - name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+# - name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+# - name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,7 +3,7 @@
 resources:
   - submariner_v1alpha1_broker.yaml
   - submariner_v1alpha1_submariner.yaml
-  #- submariner_v1alpha1_servicediscovery.yaml
+  # - submariner_v1alpha1_servicediscovery.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples
 
 configurations:

--- a/config/samples/submariner_v1alpha1_broker.yaml
+++ b/config/samples/submariner_v1alpha1_broker.yaml
@@ -9,5 +9,5 @@ spec:
     - connectivity
   defaultGlobalnetClusterSize: 8192
   globalnetEnabled: false
-  #globalnetCIDRRange: 169.254.0.0/16
+  # globalnetCIDRRange: 169.254.0.0/16
   #  defaultCustomDomains:


### PR DESCRIPTION
It's not currently clear why yamllint didn't flag these before, but
it's flagging them now and `make yamllint` fails on devel.

signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
