### PR TITLE
Fix subctl release job

### DIFF
--- a/.github/workflows/release_subctl_devel.yml
+++ b/.github/workflows/release_subctl_devel.yml
@@ -8,7 +8,7 @@ on:
       - release-*
 
 jobs:
-  release-subctl-release-0.10:
+  release-subctl-release-0-10:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GH complains the job name in release_subctl_devel.yml is invalid:
    
"_The identifier 'release-subctl-release-0.10' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters._"
    
Replace the '.' with '-'.
