### PR TITLE
Allow installing on older clusters via `--ignore-requirements`

### DIFF
--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -66,6 +66,7 @@ var (
 	forceUDPEncaps                bool
 	colorCodes                    string
 	natTraversal                  bool
+	ignoreRequirements            bool
 	globalnetEnabled              bool
 	ipsecDebug                    bool
 	submarinerDebug               bool
@@ -133,6 +134,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&corednsCustomConfigMap, "coredns-custom-configmap", "",
 		"Name of the custom CoreDNS configmap to configure forwarding to lighthouse. It should be in "+
 			"<namespace>/<name> format where <namespace> is optional and defaults to kube-system")
+	cmd.Flags().BoolVar(&ignoreRequirements, "ignore-requirements", false, "ignore requirement failures (unsupported)")
 }
 
 const (
@@ -233,8 +235,11 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 		for i := range failedRequirements {
 			fmt.Printf("* %s\n", (failedRequirements)[i])
 		}
-		utils.ExitOnError("Unable to check all requirements", err)
-		os.Exit(1)
+
+		if !ignoreRequirements {
+			utils.ExitOnError("Unable to check all requirements", err)
+			os.Exit(1)
+		}
 	}
 	utils.ExitOnError("Unable to check requirements", err)
 


### PR DESCRIPTION
This implements `subctl join --ignore-requirements` which overrides
the requirements check (for example the k8s version)
allowing the usage of older kubernetes versions (with
caveats, like manually needing to install EndpointSlices
CRD, etc..., or only working with dataplane)

The rationale behind this change is to support: https://github.com/kcp-dev/kcp/pull/147 where 1.15 + 1.21 are installed
along each other for some API testing reasons. We know that submariner works as long as we install the EndpointSlice CRD on the older cluster.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
