### PR TITLE
Rename diagnose firewall commands

### DIFF
--- a/pkg/subctl/cmd/diagnose/firewall_tunnel.go
+++ b/pkg/subctl/cmd/diagnose/firewall_tunnel.go
@@ -39,8 +39,8 @@ const (
 
 func init() {
 	command := &cobra.Command{
-		Use:   "tunnel <localkubeconfig> <remotekubeconfig>",
-		Short: "Check firewall access to Gateway node tunnels",
+		Use:   "inter-cluster <localkubeconfig> <remotekubeconfig>",
+		Short: "Check firewall access to setup tunnels between the Gateway node",
 		Long:  "This command checks if the firewall configuration allows tunnels to be configured on the Gateway nodes.",
 		Args: func(command *cobra.Command, args []string) error {
 			if len(args) != 2 {
@@ -63,8 +63,17 @@ func init() {
 
 	addDiagnoseFWConfigFlags(command)
 	addVerboseFlag(command)
-
 	diagnoseFirewallConfigCmd.AddCommand(command)
+
+	deprecatedCommand := &cobra.Command{
+		Use:        "tunnel <localkubeconfig> <remotekubeconfig>",
+		Deprecated: "please use inter-cluster",
+		Short:      command.Short,
+		Long:       command.Long,
+		Args:       command.Args,
+		Run:        command.Run,
+	}
+	diagnoseFirewallConfigCmd.AddCommand(deprecatedCommand)
 }
 
 func validateTunnelConfig(command *cobra.Command, args []string) {

--- a/pkg/subctl/cmd/diagnose/firewall_vxlan.go
+++ b/pkg/subctl/cmd/diagnose/firewall_vxlan.go
@@ -33,9 +33,9 @@ const (
 
 func init() {
 	command := &cobra.Command{
-		Use:   "vxlan",
-		Short: "Check firewall access for Submariner VXLAN traffic",
-		Long:  "This command checks if the firewall configuration allows traffic via the Submariner VXLAN interface.",
+		Use:   "intra-cluster",
+		Short: "Check firewall access for intra-cluster Submariner VxLAN traffic",
+		Long:  "This command checks if the firewall configuration allows traffic over vx-submariner interface.",
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(checkVxLANConfig)
 		},
@@ -43,8 +43,17 @@ func init() {
 
 	addDiagnoseFWConfigFlags(command)
 	addVerboseFlag(command)
-
 	diagnoseFirewallConfigCmd.AddCommand(command)
+
+	deprecatedCommand := &cobra.Command{
+		Use:        "vxlan",
+		Deprecated: "please use intra-cluster",
+		Short:      command.Short,
+		Long:       command.Long,
+		Args:       command.Args,
+		Run:        command.Run,
+	}
+	diagnoseFirewallConfigCmd.AddCommand(deprecatedCommand)
 }
 
 func checkVxLANConfig(cluster *cmd.Cluster) bool {


### PR DESCRIPTION
Now that we have vxlan as one of the cable driver, it could lead
to confusion between verifying firewall config within the local
cluster vs inter-cluster traffic. This PR deprecates and replaces
the following commands to make it more readable.

vxlan  -> intra-cluster
tunnel -> inter-cluster

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
