### PR TITLE
Modify AWS GW default image to c5d.large

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -42,7 +42,7 @@ func newAWSPrepareCommand() *cobra.Command {
 	}
 
 	aws.AddAWSFlags(cmd)
-	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "m5n.large", "Type of gateways instance machine")
+	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "c5d.large", "Type of gateways instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultDedicatedGateways,
 		"Number of dedicated gateways to deploy (Set to `0` when using --load-balancer mode)")
 	return cmd


### PR DESCRIPTION
Switching from m5n.large to c5d.large instances improves the GW to GW bandwidth
from 1Gbps to 2.3Gbps when using IPsec as we get better CPU (cascadelake
architecture). Both IPsec and Wireguard have CPU as the bottleneck compared to
the network interface and hence will benefit with this change.

Related to: https://github.com/open-cluster-management/submariner-addon/issues/109
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
