### PR TITLE
Cloud prepare support for GCP clusters running OCP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,9 @@ require (
 	github.com/uw-labs/lichen v0.1.4
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20210506034541-84642328b1f0 // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	google.golang.org/api v0.56.0
 	gopkg.in/ini.v1 v1.62.0
 	k8s.io/api v0.21.0
 	k8s.io/apiextensions-apiserver v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -667,6 +667,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -1406,6 +1407,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.starlark.net v0.0.0-20190528202925-30ae18b8564f/go.mod h1:c1/X6cHgvdXj6pUlmWKMkuqRnW4K8x2vwt6JAaaircg=

--- a/go.sum
+++ b/go.sum
@@ -671,6 +671,7 @@ github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/googleapis/gax-go/v2 v2.1.0 h1:6DWmvNpomjL1+3liNSZbVns3zsYzzCjm6pRBO1tLeso=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -1887,6 +1888,7 @@ google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtuk
 google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
 google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00sOU=
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=
+google.golang.org/api v0.56.0 h1:08F9XVYTLOGeSQb3xI9C0gXMuQanhdGed0cWFhDozbI=
 google.golang.org/api v0.56.0/go.mod h1:38yMfeP1kfjsl8isn0tliTjIb1rJXcQi4UXlbqivdVE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1957,6 +1959,7 @@ google.golang.org/genproto v0.0.0-20210728212813-7823e685a01f/go.mod h1:ob2IJxKr
 google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
 google.golang.org/genproto v0.0.0-20210813162853-db860fec028c/go.mod h1:cFeNkxwySK631ADgubI+/XFU/xp8FD5KIVV4rj8UC5w=
 google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
+google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71 h1:z+ErRPu0+KS02Td3fOAgdX+lnPDh/VyaABEJPD4JRQs=
 google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -1991,6 +1994,7 @@ google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
+google.golang.org/grpc v1.40.0 h1:AGJ0Ih4mHjSeibYkFGh1dD9KJ/eOtZ93I6hoHhukQ5Q=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/pkg/subctl/cmd/cloud/cleanup/cleanup.go
+++ b/pkg/subctl/cmd/cloud/cleanup/cleanup.go
@@ -38,6 +38,7 @@ func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
 	}
 
 	cmd.AddCommand(newAWSCleanupCommand())
+	cmd.AddCommand(newGCPCleanupCommand())
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/cleanup/gcp.go
+++ b/pkg/subctl/cmd/cloud/cleanup/gcp.go
@@ -1,0 +1,55 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/gcp"
+
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+)
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+func newGCPCleanupCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gcp",
+		Short: "Clean up a GCP cloud",
+		Long:  "This command cleans up a GCP based cloud after Submariner uninstallation.",
+		Run:   cleanupGCP,
+	}
+
+	gcp.AddGCPFlags(cmd)
+
+	return cmd
+}
+
+func cleanupGCP(cmd *cobra.Command, args []string) {
+	err := gcp.RunOnGCP("", *kubeConfig, *kubeContext, false,
+		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			err := gwDeployer.Cleanup(reporter)
+			if err != nil {
+				return err
+			}
+
+			return cloud.CleanupAfterSubmariner(reporter)
+		})
+
+	utils.ExitOnError("Failed to cleanup GCP cloud", err)
+}

--- a/pkg/subctl/cmd/cloud/cleanup/gcp.go
+++ b/pkg/subctl/cmd/cloud/cleanup/gcp.go
@@ -26,12 +26,12 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 )
 
-// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
+// newGCPCleanupCommand returns a new cobra.Command used to prepare a cloud infrastructure
 func newGCPCleanupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gcp",
 		Short: "Clean up a GCP cloud",
-		Long:  "This command cleans up a GCP based cloud after Submariner uninstallation.",
+		Long:  "This command cleans up a GCP-based cloud after Submariner uninstallation.",
 		Run:   cleanupGCP,
 	}
 

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -1,0 +1,165 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package provides common functionality to run cloud prepare/cleanup on GCP Clusters
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	cloudpreparegcp "github.com/submariner-io/cloud-prepare/pkg/gcp"
+	gcpClientIface "github.com/submariner-io/cloud-prepare/pkg/gcp/client"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
+)
+
+const (
+	infraIDFlag   = "infra-id"
+	regionFlag    = "region"
+	projectIDFlag = "project-id"
+)
+
+var (
+	infraID         string
+	region          string
+	projectID       string
+	credentialsFile string
+	ocpMetadataFile string
+)
+
+// AddGCPFlags adds basic flags needed by GCP
+func AddGCPFlags(command *cobra.Command) {
+	command.Flags().StringVar(&infraID, infraIDFlag, "", "GCP infra ID")
+	command.Flags().StringVar(&region, regionFlag, "", "GCP region")
+	command.Flags().StringVar(&projectID, projectIDFlag, "", "GCP project ID")
+	command.Flags().StringVar(&ocpMetadataFile, "ocp-metadata", "",
+		"OCP metadata.json file (or directory containing it) to read GCP infra ID and region from (takes precedence over the flags)")
+
+	dirname, err := os.UserHomeDir()
+	if err != nil {
+		utils.ExitOnError("failed to find home directory", err)
+	}
+
+	defaultCredentials := filepath.FromSlash(fmt.Sprintf("%s/.gcp/osServiceAccount.json", dirname))
+	command.Flags().StringVar(&credentialsFile, "credentials", defaultCredentials, "GCP credentials configuration file")
+}
+
+// RunOnGCP runs the given function on GCP, supplying it with a cloud instance connected to GCP and a reporter that writes to CLI.
+// The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to GCP.
+func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes bool,
+	function func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
+	if ocpMetadataFile != "" {
+		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
+		utils.ExitOnError("Failed to read GCP Cluster information from OCP metadata file", err)
+	} else {
+		utils.ExpectFlag(infraIDFlag, infraID)
+		utils.ExpectFlag(regionFlag, region)
+		utils.ExpectFlag(projectIDFlag, region)
+	}
+
+	reporter := cloudutils.NewCLIReporter()
+	reporter.Started("Retrieving GCP credentials from your GCP configuration")
+	creds, err := getGCPCredentials()
+	if err != nil {
+		reporter.Failed(err)
+		return err
+	}
+	reporter.Succeeded("")
+
+	reporter.Started("Initializing GCP connectivity")
+
+	options := []option.ClientOption{
+		option.WithCredentials(creds),
+		option.WithUserAgent("open-cluster-management.io submarineraddon/v1"),
+	}
+
+	gcpClient, err := gcpClientIface.NewClient(projectID, options)
+	utils.ExitOnError("Failed to initialize a GCP Client", err)
+
+	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
+
+	gcpCloud := cloudpreparegcp.NewCloud(projectID, infraID, region, gcpClient)
+	msDeployer := ocp.NewK8sMachinesetDeployer(k8sConfig)
+	// TODO: Ideally we should be able to specify the image for GWNode, but it was seen that
+	// with certain images, the instance is not coming up. Needs to be investigated further.
+	gwDeployer, err := cloudpreparegcp.NewOcpGatewayDeployer(gcpCloud, msDeployer, gwInstanceType, "", dedicatedGWNodes, k8sConfig)
+	utils.ExitOnError("Failed to initialize a GatewayDeployer config", err)
+
+	return function(gcpCloud, gwDeployer, reporter)
+}
+
+func initializeFlagsFromOCPMetadata(metadataFile string) error {
+	fileInfo, err := os.Stat(metadataFile)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo.IsDir() {
+		metadataFile = filepath.Join(metadataFile, "metadata.json")
+	}
+
+	data, err := ioutil.ReadFile(metadataFile)
+	if err != nil {
+		return err
+	}
+
+	var metadata struct {
+		InfraID string `json:"infraID"`
+		GCP     struct {
+			Region    string `json:"region"`
+			ProjectID string `json:"projectID"`
+		} `json:"gcp"`
+	}
+
+	err = json.Unmarshal(data, &metadata)
+	if err != nil {
+		return err
+	}
+
+	infraID = metadata.InfraID
+	region = metadata.GCP.Region
+	projectID = metadata.GCP.ProjectID
+	return nil
+}
+
+func getGCPCredentials() (*google.Credentials, error) {
+	authJSON, err := ioutil.ReadFile(credentialsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	creds, err := google.CredentialsFromJSON(context.TODO(), authJSON, dns.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	return creds, nil
+}

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -92,10 +92,7 @@ func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes b
 	reporter := cloudutils.NewCLIReporter()
 	reporter.Started("Retrieving GCP credentials from your GCP configuration")
 	creds, err := getGCPCredentials()
-	if err != nil {
-		reporter.Failed(err)
-		return err
-	}
+	utils.ExitOnError("Failed to get GCP credentials", err)
 	reporter.Succeeded("")
 
 	reporter.Started("Initializing GCP connectivity")

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -35,11 +35,11 @@ func newGCPPrepareCommand() *cobra.Command {
 	}
 
 	gcp.AddGCPFlags(cmd)
-	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "n1-standard-4", "Type of gateways instance machine")
+	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
 	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", false,
-		"If a dedicated gateway node has to be deployed (default false)")
+		"Whether a dedicated gateway node has to be deployed (default false)")
 	return cmd
 }
 

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -31,6 +31,14 @@ var (
 	kubeContext      *string
 )
 
+var (
+	gwInstanceType   string
+	gateways         int
+	dedicatedGateway bool
+)
+
+const DefaultNumGateways = 1
+
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
 func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
 	kubeConfig = origKubeConfig
@@ -47,6 +55,7 @@ func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
 	cmd.PersistentFlags().Uint16Var(&metricsPort, "metrics-port", 8080, "Metrics port")
 
 	cmd.AddCommand(newAWSPrepareCommand())
+	cmd.AddCommand(newGCPPrepareCommand())
 
 	return cmd
 }


### PR DESCRIPTION
This PR implements the following

1. Support for configuring Submariner pre-requisites on a
   GCP cluster. Unlike AWS, which requires dedicated gateway
   nodes, for GCP a user has an option to specify if dedicated
   gateway nodes should be used (via the flag dedicated-gateway)
   or if existing nodes should be used as gateway nodes.
2. Support for clean up.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1559
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
