### PR TITLE
Revert "Add .mdignore file, ignore apis/vendor dir"

### DIFF
--- a/.mdignore
+++ b/.mdignore
@@ -1,1 +1,0 @@
-apis/vendor


### PR DESCRIPTION
Reverts submariner-io/submariner-operator#1562

The default handling in Shipyard covers all `vendor` directories, so we don’t need special handling in projects.

Signed-off-by: Stephen Kitt <skitt@redhat.com>