### PR TITLE
Remove non-functional yamllint strict config

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -23,5 +23,3 @@ ignore: |
   /config/bundle/kustomization.yaml
   /bundle
   /packagemanifests
-
-strict: true


### PR DESCRIPTION
Setting yamllint to exit non-zero on warnings doesn't work from the
.yamllint config file.

Set the --strict flag at CLI invocation (submariner-io/shipyard#628).

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
