### PR TITLE
Enable specifying an empty instanceType for AWS cluster

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -35,7 +35,7 @@ func newAWSPrepareCommand() *cobra.Command {
 	}
 
 	aws.AddAWSFlags(cmd)
-	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "c5d.large", "Type of gateways instance machine")
+	cmd.Flags().StringVar(&awsGWInstanceType, "gateway-instance", "c5d.large", "Type of gateways instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of dedicated gateways to deploy (Set to `0` when using --load-balancer mode)")
 	return cmd
@@ -62,7 +62,7 @@ func prepareAws(cmd *cobra.Command, args []string) {
 		input.InternalPorts = append(input.InternalPorts, gwPorts...)
 	}
 
-	err := aws.RunOnAWS(gwInstanceType, *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS(awsGWInstanceType, *kubeConfig, *kubeContext,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -35,7 +35,7 @@ func newGCPPrepareCommand() *cobra.Command {
 	}
 
 	gcp.AddGCPFlags(cmd)
-	cmd.Flags().StringVar(&gwInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
+	cmd.Flags().StringVar(&gcpGWInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
 	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", false,
@@ -59,7 +59,7 @@ func prepareGCP(cmd *cobra.Command, args []string) {
 		},
 	}
 
-	err := gcp.RunOnGCP(gwInstanceType, *kubeConfig, *kubeContext, dedicatedGateway,
+	err := gcp.RunOnGCP(gcpGWInstanceType, *kubeConfig, *kubeContext, dedicatedGateway,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -32,9 +32,10 @@ var (
 )
 
 var (
-	gwInstanceType   string
-	gateways         int
-	dedicatedGateway bool
+	awsGWInstanceType string
+	gcpGWInstanceType string
+	gateways          int
+	dedicatedGateway  bool
 )
 
 const DefaultNumGateways = 1


### PR DESCRIPTION
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
