### PR TITLE
Use devel as subctl default version

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,6 +18,5 @@ limitations under the License.
 package version
 
 var (
-	// Version is updated by scripts/subctl-build at build time
-	Version = "was not built correctly"
+	Version = "devel"
 )


### PR DESCRIPTION
Currently, releases of `subctl` from `devel` use the default `Version`
value of `subctl version: was not built correctly`. This message is
wrong in the normal case, and causes a confusing UX.

Also remove incorrect comment about logic that should update the default
Version value, as it has moved.

Closes: #1577
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
