### PR TITLE
Allow submariner-globalnet role to handle endpoints

### DIFF
--- a/bundle/manifests/submariner-globalnet_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/submariner-globalnet_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
   - services
   - namespaces
   - nodes
+  - endpoints
   verbs:
   - get
   - list


### PR DESCRIPTION
This PR allows submariner-globalnet role to handle endpoints. This is needed to make globalnet controller support headless service without selector.

xref: submariner-io/submariner#1558
fixes: #1581