### PR TITLE
Cloud prepare support for generic k8s clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/cobra v1.2.0
 	github.com/submariner-io/admiral v0.11.0-rc0
-	github.com/submariner-io/cloud-prepare v0.11.0-rc0
+	github.com/submariner-io/cloud-prepare v0.11.0-rc0.0.20211005005326-4c93f6818e91
 	github.com/submariner-io/lighthouse v0.11.0-rc0
 	github.com/submariner-io/shipyard v0.11.0-rc0
 	github.com/submariner-io/submariner v0.11.0-rc0

--- a/go.sum
+++ b/go.sum
@@ -1308,8 +1308,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.11.0-rc0 h1:aCdEnp8xQ/1QLuD5qtUqnmgEHoW1yc6x5CaKasMl8jQ=
 github.com/submariner-io/admiral v0.11.0-rc0/go.mod h1:JsskboJ7pAYEszmpD/H6F6xn2Z9q3qBVXPRYqfg6oTE=
-github.com/submariner-io/cloud-prepare v0.11.0-rc0 h1:57Ff2+e+2vSmAYVyTl9w3KAM4xgeh3zG1oINgZyO85c=
-github.com/submariner-io/cloud-prepare v0.11.0-rc0/go.mod h1:z9MsmfLGACgozsF13f2qLazuvf7WHAUvlLyN3O6SeLg=
+github.com/submariner-io/cloud-prepare v0.11.0-rc0.0.20211005005326-4c93f6818e91 h1:JRf4Gb8C2qvp1utxfI0Wtco+l3RUR8/a/30CV6t5ypQ=
+github.com/submariner-io/cloud-prepare v0.11.0-rc0.0.20211005005326-4c93f6818e91/go.mod h1:ZMMi0NqH+cfGnflCpxbDB+B5kpScIqEjpMKyJ4w97EQ=
 github.com/submariner-io/lighthouse v0.11.0-rc0 h1:1n3i8BC6/cidKw0W8uJ2v6PszT4OiAOMwWzTh/ZRoXc=
 github.com/submariner-io/lighthouse v0.11.0-rc0/go.mod h1:H2ExrP7PAM9t4W9zVajuKCEdoqLQ8+QmD3bstaOMd1M=
 github.com/submariner-io/shipyard v0.11.0-rc0 h1:6s5JeOZIRx/QwIisjeWdfzPWEVQaW2QONiGx+PKY48A=

--- a/pkg/subctl/cmd/cloud/cleanup/generic.go
+++ b/pkg/subctl/cmd/cloud/cleanup/generic.go
@@ -28,8 +28,8 @@ import (
 func newGenericCleanupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generic",
-		Short: "Clean up a k8s cluster",
-		Long:  "This command cleans up a K8s cluster after Submariner uninstallation.",
+		Short: "Cleans up a cluster after Submariner uninstallation",
+		Long:  "This command cleans up Submariner components in a cluster after Submariner uninstallation.",
 		Run:   cleanupGenericCluster,
 	}
 

--- a/pkg/subctl/cmd/cloud/cleanup/generic.go
+++ b/pkg/subctl/cmd/cloud/cleanup/generic.go
@@ -20,26 +20,27 @@ package cleanup
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/generic"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 )
 
-var (
-	kubeConfig  *string
-	kubeContext *string
-)
-
-// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func newGenericCleanupCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cleanup",
-		Short: "Clean up the cloud",
-		Long:  `This command cleans up the cloud after Submariner uninstallation.`,
+		Use:   "generic",
+		Short: "Clean up a k8s cluster",
+		Long:  "This command cleans up a K8s cluster after Submariner uninstallation.",
+		Run:   cleanupGenericCluster,
 	}
 
-	cmd.AddCommand(newAWSCleanupCommand())
-	cmd.AddCommand(newGCPCleanupCommand())
-	cmd.AddCommand(newGenericCleanupCommand())
-
 	return cmd
+}
+
+func cleanupGenericCluster(cmd *cobra.Command, args []string) {
+	err := generic.RunOnK8sCluster(*kubeConfig, *kubeContext,
+		func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			return gwDeployer.Cleanup(reporter)
+		})
+
+	utils.ExitOnError("Failed to cleanup K8s cluster", err)
 }

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -111,8 +111,7 @@ func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes b
 	clientSet, err := kubernetes.NewForConfig(k8sConfig)
 	utils.ExitOnError("Failed to create Kubernetes client", err)
 
-	k8sClientSet, err := k8s.NewK8sInterface(clientSet)
-	utils.ExitOnError("Failed to create cloud-prepare k8s client", err)
+	k8sClientSet := k8s.NewK8sInterface(clientSet)
 
 	restMapper, err := util.BuildRestMapper(k8sConfig)
 	utils.ExitOnError("Failed to create restmapper", err)

--- a/pkg/subctl/cmd/cloud/generic/generic.go
+++ b/pkg/subctl/cmd/cloud/generic/generic.go
@@ -1,0 +1,48 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/cloud-prepare/pkg/generic"
+	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
+	"k8s.io/client-go/kubernetes"
+)
+
+func RunOnK8sCluster(kubeConfig, kubeContext string,
+	function func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
+	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
+
+	clientSet, err := kubernetes.NewForConfig(k8sConfig)
+	utils.ExitOnError("Failed to create Kubernetes client", err)
+
+	k8sClientSet, err := k8s.NewK8sInterface(clientSet)
+	utils.ExitOnError("Failed to create cloud-prepare k8s client", err)
+
+	gwDeployer, err := generic.NewGatewayDeployer(k8sClientSet)
+	utils.ExitOnError("Failed to initialize a GatewayDeployer config", err)
+
+	reporter := cloudutils.NewCLIReporter()
+
+	return function(gwDeployer, reporter)
+}

--- a/pkg/subctl/cmd/cloud/generic/generic.go
+++ b/pkg/subctl/cmd/cloud/generic/generic.go
@@ -36,11 +36,9 @@ func RunOnK8sCluster(kubeConfig, kubeContext string,
 	clientSet, err := kubernetes.NewForConfig(k8sConfig)
 	utils.ExitOnError("Failed to create Kubernetes client", err)
 
-	k8sClientSet, err := k8s.NewK8sInterface(clientSet)
-	utils.ExitOnError("Failed to create cloud-prepare k8s client", err)
+	k8sClientSet := k8s.NewK8sInterface(clientSet)
 
-	gwDeployer, err := generic.NewGatewayDeployer(k8sClientSet)
-	utils.ExitOnError("Failed to initialize a GatewayDeployer config", err)
+	gwDeployer := generic.NewGatewayDeployer(k8sClientSet)
 
 	reporter := cloudutils.NewCLIReporter()
 

--- a/pkg/subctl/cmd/cloud/prepare/generic.go
+++ b/pkg/subctl/cmd/cloud/prepare/generic.go
@@ -1,0 +1,58 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prepare
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/generic"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+)
+
+func newGenericPrepareCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generic",
+		Short: "Prepare a generic K8s Cluster for Submariner",
+		Long:  "This command prepares the K8s cluster for Submariner installation.",
+		Run:   prepareGenericCluster,
+	}
+
+	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
+		"Number of gateways to deploy")
+	return cmd
+}
+
+func prepareGenericCluster(cmd *cobra.Command, args []string) {
+	err := generic.RunOnK8sCluster(*kubeConfig, *kubeContext,
+		func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			if gateways > 0 {
+				gwInput := api.GatewayDeployInput{
+					Gateways: gateways,
+				}
+				err := gwDeployer.Deploy(gwInput, reporter)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+
+	utils.ExitOnError("Failed to prepare generic K8s cluster", err)
+}

--- a/pkg/subctl/cmd/cloud/prepare/generic.go
+++ b/pkg/subctl/cmd/cloud/prepare/generic.go
@@ -28,8 +28,8 @@ import (
 func newGenericPrepareCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generic",
-		Short: "Prepare a generic K8s Cluster for Submariner",
-		Long:  "This command prepares the K8s cluster for Submariner installation.",
+		Short: "Prepares a generic cluster for Submariner",
+		Long:  "This command prepares a generic cluster for Submariner installation.",
 		Run:   prepareGenericCluster,
 	}
 

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -57,6 +57,7 @@ func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
 
 	cmd.AddCommand(newAWSPrepareCommand())
 	cmd.AddCommand(newGCPPrepareCommand())
+	cmd.AddCommand(newGenericPrepareCommand())
 
 	return cmd
 }


### PR DESCRIPTION
This PR includes support for labelling worker nodes as
Submariner gateway nodes on generic k8s clusters.

Depends on https://github.com/submariner-io/cloud-prepare/pull/115
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
