### PR TITLE
test(bundle): fix periodic test

### DIFF
--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -59,7 +59,7 @@ function verify_subm_operator() {
 
   # Verify SubM Operator role binding
   kubectl get rolebindings --namespace=$subm_ns submariner-operator || \
-  kubectl get roles -n $subm_ns -l olm.owner.namespace=submariner-operator
+  kubectl get rolebindings -n $subm_ns -l olm.owner.namespace=submariner-operator
 
   # Verify SubM Operator deployment
   kubectl get deployments --namespace=$subm_ns submariner-operator
@@ -217,6 +217,9 @@ function verify_subm_cr() {
 
 function verify_subm_op_pod() {
   subm_operator_pod_name=$(kubectl get pods --namespace=$subm_ns -l name=$operator_deployment_name -o=jsonpath='{.items..metadata.name}')
+  if [ -z $subm_operator_pod_name ]; then
+    subm_operator_pod_name=$(kubectl get pods --namespace=$subm_ns -l control-plane=$operator_deployment_name -o=jsonpath='{.items..metadata.name}')
+  fi
 
   # Show SubM Operator pod info
   kubectl get pod $subm_operator_pod_name --namespace=$subm_ns -o json


### PR DESCRIPTION
Deploying submariner using the bundle the operator pod name gets a
random string appended and also the name label is missing.
Make sure we get the correct pod name.

Closes: #1576
Signed-off-by: Steve Mattar <smattar@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
