### PR TITLE
Fix subctl diagnose intra-cluster vxlan issue

### DIFF
--- a/pkg/subctl/cmd/diagnose/firewall.go
+++ b/pkg/subctl/cmd/diagnose/firewall.go
@@ -129,7 +129,7 @@ func getLocalEndpointResource(cluster *cmd.Cluster, status *cli.Status) *subv1.E
 	}
 
 	for _, endpoint := range endpoints.Items {
-		if endpoint.Spec.ClusterID == cluster.Name {
+		if endpoint.Spec.ClusterID == cluster.Submariner.Spec.ClusterID {
 			return &endpoint
 		}
 	}
@@ -146,7 +146,7 @@ func getAnyRemoteEndpointResource(cluster *cmd.Cluster, status *cli.Status) *sub
 	}
 
 	for _, endpoint := range endpoints.Items {
-		if endpoint.Spec.ClusterID != cluster.Name {
+		if endpoint.Spec.ClusterID != cluster.Submariner.Spec.ClusterID {
 			return &endpoint
 		}
 	}


### PR DESCRIPTION
Fixes issue: https://github.com/open-cluster-management/backlog/issues/17124
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
