### PR TITLE
Include the node details as part of summary report

### DIFF
--- a/pkg/subctl/cmd/gather/layout.gohtml
+++ b/pkg/subctl/cmd/gather/layout.gohtml
@@ -63,17 +63,17 @@
   <tr>
     <th style="width: 15%;">Node name</th>
     <th style="width: 30%;">Operating System</th>
-    <th style="width: 25%;">Container Runtime Version</th>
-    <th style="width: 15%;">Kubelet Version</th>
     <th style="width: 15%;">KubeProxy Version</th>
+    <th style="width: 15%;">Internal IP</th>
+    <th style="width: 15%;">External IP</th>
   </tr>
   {{range .NodeConfig}}
     <tr>
       <td>{{.Name}}</td>
       <td>{{.Info.OperatingSystem}} {{.Info.OSImage}} {{.Info.KernelVersion}} {{.Info.Architecture}}</td>
-      <td>{{.Info.ContainerRuntimeVersion}}</td>
-      <td>{{.Info.KubeletVersion}}</td>
       <td>{{.Info.KubeProxyVersion}}</td>
+      <td>{{.InternalIPs}}</td>
+      <td>{{.ExternalIPs}}</td>
     </tr>
   {{end}}
 </table>
@@ -84,6 +84,7 @@
       <th style="width: 20%;">Pod name</th>
       <th style="width: 15%;">Namespace</th>
       <th style="width: 10%;">Pod state</th>
+      <th style="width: 10%;">Node name</th>
       <th style="width: 5%;">Restart count</th>
       <th style="width: 25%;">Log file(s)</th>
     </tr>
@@ -92,6 +93,7 @@
         <td>{{.PodName}}</td>
         <td>{{.Namespace}}</td>
         <td>{{.PodState}}</td>
+        <td>{{.NodeName}}</td>
         {{ if gt .RestartCount 0 }}
           <td style="color: red">{{.RestartCount}}</td>
         {{ else }}

--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -64,6 +64,7 @@ func outputPodLogs(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, info Inf
 	podLogInfo.Namespace = pod.Namespace
 	podLogInfo.PodState = pod.Status.Phase
 	podLogInfo.PodName = pod.Name
+	podLogInfo.NodeName = pod.Spec.NodeName
 	err := outputPreviousPodLog(pod, podLogOptions, info, &podLogInfo)
 	if err != nil {
 		info.Status.QueueFailureMessage(fmt.Sprintf("Error outputting previous log for pod %q: %v", pod.Name, err))

--- a/pkg/subctl/cmd/gather/types.go
+++ b/pkg/subctl/cmd/gather/types.go
@@ -62,13 +62,16 @@ type clusterConfig struct {
 }
 
 type nodeConfig struct {
-	Name string
-	Info v1.NodeSystemInfo
+	Name        string
+	Info        v1.NodeSystemInfo
+	InternalIPs string
+	ExternalIPs string
 }
 
 type LogInfo struct {
 	PodName      string
 	Namespace    string
+	NodeName     string
 	RestartCount int32
 	PodState     v1.PodPhase
 	LogFileName  []string


### PR DESCRIPTION
Currently when subctl gather collects the information from the cluster, it does
not store the node details which is sometimes necessary during debugging. This
PR removes the following info and instead includes the node details

Removed fields:
ContainerRuntimeVersion
KubeletVersion

Added fields:
Node InternalIP
Node ExternalIP
Node Name on which the Submariner pods are scheduled.

Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1623
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
