### PR TITLE
Add RBAC permission for endpointslices/restricted

### DIFF
--- a/config/rbac/lighthouse-agent/cluster_role.yaml
+++ b/config/rbac/lighthouse-agent/cluster_role.yaml
@@ -20,6 +20,7 @@ rules:
       - discovery.k8s.io
     resources:
       - endpointslices
+      - endpointslices/restricted
     verbs:
       - create
       - get


### PR DESCRIPTION
Openshift allows only users who have endpointslices/restricted permission
to create an endpointslice with an enpoint having the same IP as the pod IP
in a namespace.

Fixes: submariner-io/lighthouse#627

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
