### PR TITLE
Automated backport of #1635: Add RBAC permission endpointslices/restricted in broker roles

### DIFF
--- a/config/broker/broker-admin/role.yaml
+++ b/config/broker/broker-admin/role.yaml
@@ -54,6 +54,7 @@ rules:
       - discovery.k8s.io
     resources:
       - endpointslices
+      - endpointslices/restricted
     verbs:
       - create
       - get

--- a/config/broker/broker-client/role.yaml
+++ b/config/broker/broker-client/role.yaml
@@ -33,6 +33,7 @@ rules:
       - discovery.k8s.io
     resources:
       - endpointslices
+      - endpointslices/restricted
     verbs:
       - create
       - get

--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -77,7 +77,7 @@ func NewBrokerAdminRole() *rbacv1.Role {
 			{
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"discovery.k8s.io"},
-				Resources: []string{"endpointslices"},
+				Resources: []string{"endpointslices", "endpointslices/restricted"},
 			},
 		},
 	}
@@ -103,7 +103,7 @@ func NewBrokerClusterRole() *rbacv1.Role {
 			{
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"discovery.k8s.io"},
-				Resources: []string{"endpointslices"},
+				Resources: []string{"endpointslices", "endpointslices/restricted"},
 			},
 		},
 	}


### PR DESCRIPTION
Backport of #1635 on release-0.11.

#1635: Add RBAC permission endpointslices/restricted in broker roles

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.