### PR TITLE
Update the submariner/api reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/submariner-io/lighthouse v0.12.0-m0
 	github.com/submariner-io/shipyard v0.12.0-m0
 	github.com/submariner-io/submariner v0.12.0-m0
-	github.com/submariner-io/submariner-operator/api v0.0.0-20210817145008-861856b068a1
+	github.com/submariner-io/submariner-operator/api v0.0.0-20211116094042-78967cc133c2
 	github.com/submariner-io/submariner/pkg/apis v0.0.0-20210816153739-c8e6654e3930
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/uw-labs/lichen v0.1.4


### PR DESCRIPTION
With the switch from /apis to /api, the version reference wasn't
changed; so the dependency points to a commit which doesn't actually
provide /api, breaking further updates in some circumstances (e.g. go
install in the forthcoming support for /cmd).

This patch updates the /api reference to the latest commit.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
