### PR TITLE
Remove deprecated commands and flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ override VALIDATE_ARGS += --skip-dirs pkg/client
 # Process extra flags from the `using=a,b,c` optional flag
 
 ifneq (,$(filter lighthouse,$(_using)))
-override DEPLOY_ARGS += --deploytool_broker_args '--service-discovery'
+override DEPLOY_ARGS += --deploytool_broker_args '--components service-discovery,connectivity'
 endif
 
 GO ?= go

--- a/pkg/subctl/cmd/diagnose/firewall_tunnel.go
+++ b/pkg/subctl/cmd/diagnose/firewall_tunnel.go
@@ -64,16 +64,6 @@ func init() {
 	addDiagnoseFWConfigFlags(command)
 	addVerboseFlag(command)
 	diagnoseFirewallConfigCmd.AddCommand(command)
-
-	deprecatedCommand := &cobra.Command{
-		Use:        "tunnel <localkubeconfig> <remotekubeconfig>",
-		Deprecated: "please use inter-cluster",
-		Short:      command.Short,
-		Long:       command.Long,
-		Args:       command.Args,
-		Run:        command.Run,
-	}
-	diagnoseFirewallConfigCmd.AddCommand(deprecatedCommand)
 }
 
 func validateTunnelConfig(command *cobra.Command, args []string) {

--- a/pkg/subctl/cmd/diagnose/firewall_vxlan.go
+++ b/pkg/subctl/cmd/diagnose/firewall_vxlan.go
@@ -44,16 +44,6 @@ func init() {
 	addDiagnoseFWConfigFlags(command)
 	addVerboseFlag(command)
 	diagnoseFirewallConfigCmd.AddCommand(command)
-
-	deprecatedCommand := &cobra.Command{
-		Use:        "vxlan",
-		Deprecated: "please use intra-cluster",
-		Short:      command.Short,
-		Long:       command.Long,
-		Args:       command.Args,
-		Run:        command.Run,
-	}
-	diagnoseFirewallConfigCmd.AddCommand(deprecatedCommand)
 }
 
 func checkVxLANConfig(cluster *cmd.Cluster) bool {

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -20,7 +20,7 @@ source ${SCRIPTS_DIR}/lib/deploy_operator
 
 ### Variables ###
 
-[[ ! ${DEPLOY_ARGS} =~ "--service-discovery" ]] || lighthouse=true
+[[ ! ${DEPLOY_ARGS} =~ "service-discovery" ]] || lighthouse=true
 timeout="2m" # Used by deploy_resource
 
 ### Main ###
@@ -57,7 +57,7 @@ test_subctl_gather
 # Run subctl diagnose as a sanity check
 
 ${DAPPER_SOURCE}/bin/subctl diagnose all
-${DAPPER_SOURCE}/bin/subctl diagnose firewall tunnel ${KUBECONFIGS_DIR}/kind-config-cluster1 ${KUBECONFIGS_DIR}/kind-config-cluster2
+${DAPPER_SOURCE}/bin/subctl diagnose firewall inter-cluster ${KUBECONFIGS_DIR}/kind-config-cluster1 ${KUBECONFIGS_DIR}/kind-config-cluster2
 
 # Run benchmark commands for sanity checks
 

--- a/scripts/kind-e2e/lib_subctl_gather_test.sh
+++ b/scripts/kind-e2e/lib_subctl_gather_test.sh
@@ -52,14 +52,16 @@ function validate_gathered_files () {
   validate_pod_log_files $subm_ns '-l name=submariner-operator'
 
   # Service Discovery
-  validate_resource_files all 'serviceexports.multicluster.x-k8s.io' 'ServiceExport'
-  validate_resource_files all 'serviceimports.multicluster.x-k8s.io' 'ServiceImport'
-  validate_resource_files all 'endpointslices.discovery.k8s.io' 'EndpointSlice' '-l endpointslice.kubernetes.io/managed-by=lighthouse-agent.submariner.io'
-  validate_resource_files $subm_ns 'configmaps' 'ConfigMap' '-l component=submariner-lighthouse'
-  validate_resource_files kube-system 'configmaps' 'ConfigMap' '--field-selector metadata.name=coredns'
+  if [[ "$lighthouse" == "true" ]]; then
+    validate_resource_files all 'serviceexports.multicluster.x-k8s.io' 'ServiceExport'
+    validate_resource_files all 'serviceimports.multicluster.x-k8s.io' 'ServiceImport'
+    validate_resource_files all 'endpointslices.discovery.k8s.io' 'EndpointSlice' '-l endpointslice.kubernetes.io/managed-by=lighthouse-agent.submariner.io'
+    validate_resource_files $subm_ns 'configmaps' 'ConfigMap' '-l component=submariner-lighthouse'
+    validate_resource_files kube-system 'configmaps' 'ConfigMap' '--field-selector metadata.name=coredns'
 
-  validate_pod_log_files $subm_ns '-l component=submariner-lighthouse'
-  validate_pod_log_files kube-system '-l k8s-app=kube-dns'
+    validate_pod_log_files $subm_ns '-l component=submariner-lighthouse'
+    validate_pod_log_files kube-system '-l k8s-app=kube-dns'
+  fi
 }
 
 function validate_pod_log_files() {


### PR DESCRIPTION
This removes the following commands, deprecated in 0.11 or earlier:
* deploy-broker --service-discovery (replaced by --components)
* diagnose firewall tunnel (replaced by inter-cluster)
* diagnose firewall vxlan (replaced by intra-cluster)

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
