### PR TITLE
Flip the GHA matrix lighthouse flag

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -17,11 +17,11 @@ jobs:
         globalnet: ['', 'globalnet']
         # Default version to test
         k8s_version: ['1.20']
-        lighthouse: ['', 'lighthouse']
+        lighthouse: ['', 'nolighthouse']
         ovn: ['', 'ovn']
         exclude:
           - ovn: 'ovn'
-            lighthouse: 'lighthouse'
+            lighthouse: ''
           - ovn: 'ovn'
             globalnet: 'globalnet'
         include:

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ override VALIDATE_ARGS += --skip-dirs pkg/client
 
 # Process extra flags from the `using=a,b,c` optional flag
 
-ifneq (,$(filter lighthouse,$(_using)))
-override DEPLOY_ARGS += --deploytool_broker_args '--service-discovery'
+ifneq (,$(filter nolighthouse,$(_using)))
+override DEPLOY_ARGS += --deploytool_broker_args '--components connectivity'
 endif
 
 GO ?= go


### PR DESCRIPTION
Our default deployment includes Lighthouse, and our tests assume
that. To produce a consistent experience when tweaking the handling of
components, flip the meaning of the matrix tests: the default includes
Lighthouse, and "nolighthouse" disables it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
