### PR TITLE
Centralise RestConfig handling

### DIFF
--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -39,14 +39,14 @@ var deployBroker = &cobra.Command{
 	Short: "Deploys the broker",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("deployBroker called")
-		err := deploy.Broker(&deployflags, kubeConfig, kubeContext)
+		err := deploy.Broker(&deployflags, restConfigProducer)
 		exit.OnError("Error deploying Broker", err)
 	},
 }
 
 func init() {
 	addDeployBrokerFlags()
-	addKubeContextFlag(deployBroker)
+	restConfigProducer.AddKubeContextFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 

--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -18,12 +18,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 )
 
-var (
-	kubeConfig  string
-	kubeContext string
-)
+var restConfigProducer = restconfig.NewProducer()
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -38,15 +36,4 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-// addKubeConfigFlag adds a "kubeconfig" flag.
-func addKubeConfigFlag(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path(s) to the kubeconfig file(s)")
-}
-
-// addKubeContextFlag adds a "kubeconfig" flag and a single "kubecontext" flag that can be used once and only once.
-func addKubeContextFlag(cmd *cobra.Command) {
-	addKubeConfigFlag(cmd)
-	cmd.PersistentFlags().StringVar(&kubeContext, "kubecontext", "", "kubeconfig context to use")
 }

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -21,10 +21,15 @@ package restconfig
 import (
 	"fmt"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	"github.com/submariner-io/submariner-operator/pkg/version"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -39,24 +44,84 @@ type RestConfig struct {
 	ClusterName string
 }
 
-func MustGetForClusters(kubeConfigPath string, kubeContexts []string) []RestConfig {
-	configs, err := ForClusters(kubeConfigPath, kubeContexts)
+type Producer struct {
+	kubeConfig   string
+	kubeContext  string
+	kubeContexts []string
+}
+
+func NewProducer() Producer {
+	return Producer{}
+}
+
+func NewProducerFrom(kubeConfig, kubeContext string) Producer {
+	return Producer{
+		kubeConfig:  kubeConfig,
+		kubeContext: kubeContext,
+	}
+}
+
+func (rcp *Producer) AddKubeConfigFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&rcp.kubeConfig, "kubeconfig", "", "absolute path(s) to the kubeconfig file(s)")
+}
+
+// AddKubeContextFlag adds a "kubeconfig" flag and a single "kubecontext" flag that can be used once and only once.
+func (rcp *Producer) AddKubeContextFlag(cmd *cobra.Command) {
+	rcp.AddKubeConfigFlag(cmd)
+	cmd.PersistentFlags().StringVar(&rcp.kubeContext, "kubecontext", "", "kubeconfig context to use")
+}
+
+// AddKubeContextMultiFlag adds a "kubeconfig" flag and a "kubecontext" flag that can be specified multiple times (or comma separated).
+func (rcp *Producer) AddKubeContextMultiFlag(cmd *cobra.Command, usage string) {
+	rcp.AddKubeConfigFlag(cmd)
+
+	if usage == "" {
+		usage = "comma-separated list of kubeconfig contexts to use, can be specified multiple times.\n" +
+			"If none specified, all contexts referenced by the kubeconfig are used"
+	}
+
+	cmd.PersistentFlags().StringSliceVar(&rcp.kubeContexts, "kubecontexts", nil, usage)
+}
+
+func (rcp *Producer) PopulateTestFramework() {
+	framework.TestContext.KubeContexts = rcp.kubeContexts
+	if rcp.kubeConfig != "" {
+		framework.TestContext.KubeConfig = rcp.kubeConfig
+	}
+}
+
+func (rcp *Producer) MustGetForClusters() []RestConfig {
+	configs, err := rcp.ForClusters()
 	utils.ExitOnError("Error getting REST Config for cluster", err)
 
 	return configs
 }
 
-func ForClusters(kubeConfigPath string, kubeContexts []string) ([]RestConfig, error) {
+func (rcp *Producer) CountRequestedClusters() int {
+	if len(rcp.kubeContexts) > 0 {
+		// Count unique contexts
+		contexts := stringset.New()
+		for i := range rcp.kubeContexts {
+			contexts.Add(rcp.kubeContexts[i])
+		}
+
+		return contexts.Size()
+	}
+	// Current context or rcp.kubeContext
+	return 1
+}
+
+func (rcp *Producer) ForClusters() ([]RestConfig, error) {
 	var restConfigs []RestConfig
 
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
-	rules.ExplicitPath = kubeConfigPath
+	rules.ExplicitPath = rcp.kubeConfig
 
 	contexts := []string{}
-	if len(kubeContexts) > 0 {
-		contexts = append(contexts, kubeContexts...)
+	if len(rcp.kubeContexts) > 0 {
+		contexts = append(contexts, rcp.kubeContexts...)
 	} else {
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
 		rawConfig, err := kubeConfig.RawConfig()
@@ -128,7 +193,7 @@ func clientConfigAndClusterName(rules *clientcmd.ClientConfigLoadingRules, overr
 		return RestConfig{}, errors.Wrap(err, "error creating rest config")
 	}
 
-	clusterName := ClusterNameFromContext(&raw, overrides.CurrentContext)
+	clusterName := clusterNameFromContext(&raw, overrides.CurrentContext)
 
 	if clusterName == nil {
 		return RestConfig{}, fmt.Errorf("could not obtain the cluster name from kube config: %#v", raw)
@@ -151,7 +216,16 @@ func Clients(config *rest.Config) (dynamic.Interface, kubernetes.Interface, erro
 	return dynClient, clientSet, nil
 }
 
-func ClusterNameFromContext(rawConfig *api.Config, overridesContext string) *string {
+func (rcp *Producer) ClusterNameFromContext() (*string, error) {
+	rawConfig, err := rcp.ClientConfig().RawConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "error retrieving raw client configuration")
+	}
+
+	return clusterNameFromContext(&rawConfig, rcp.kubeContext), nil
+}
+
+func clusterNameFromContext(rawConfig *api.Config, overridesContext string) *string {
 	if overridesContext == "" {
 		// No context provided, use the current context.
 		overridesContext = rawConfig.CurrentContext
@@ -165,21 +239,42 @@ func ClusterNameFromContext(rawConfig *api.Config, overridesContext string) *str
 	return &configContext.Cluster
 }
 
-func ForCluster(kubeConfigPath, kubeContext string) (*rest.Config, error) {
-	return ClientConfig(kubeConfigPath, kubeContext).ClientConfig() // nolint:wrapcheck // No need to wrap here
+func (rcp *Producer) ForCluster() (*rest.Config, error) {
+	config, err := rcp.ClientConfig().ClientConfig()
+	return config, errors.Wrap(err, "error retrieving client configuration")
 }
 
 // ClientConfig returns a clientcmd.ClientConfig to use when communicating with K8s.
-func ClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig {
+func (rcp *Producer) ClientConfig() clientcmd.ClientConfig {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	rules.ExplicitPath = kubeConfigPath
+	rules.ExplicitPath = rcp.kubeConfig
 
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
 
-	if kubeContext != "" {
-		overrides.CurrentContext = kubeContext
+	if rcp.kubeContext != "" {
+		overrides.CurrentContext = rcp.kubeContext
 	}
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+}
+
+func (rcp *Producer) CheckVersionMismatch(cmd *cobra.Command, args []string) error {
+	config, err := rcp.ForCluster()
+	utils.ExitOnError("The provided kubeconfig is invalid", err)
+
+	submariner := utils.GetSubmarinerResource(config)
+
+	if submariner != nil && submariner.Spec.Version != "" {
+		subctlVer, _ := semver.NewVersion(version.Version)
+		submarinerVer, _ := semver.NewVersion(submariner.Spec.Version)
+
+		if subctlVer != nil && submarinerVer != nil && subctlVer.LessThan(*submarinerVer) {
+			return fmt.Errorf(
+				"the subctl version %q is older than the deployed Submariner version %q. Please upgrade your subctl version",
+				version.Version, submariner.Spec.Version)
+		}
+	}
+
+	return nil
 }

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -26,10 +26,10 @@ import (
 	submarinerv1a1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/image"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
@@ -52,7 +52,7 @@ var ValidComponents = []string{components.ServiceDiscovery, components.Connectiv
 
 const brokerDetailsFilename = "broker-info.subm"
 
-func Broker(options *BrokerOptions, kubeConfig, kubeContext string) error {
+func Broker(options *BrokerOptions, restConfigProducer restconfig.Producer) error {
 	status := cli.NewStatus()
 	componentSet := stringset.New(options.BrokerSpec.Components...)
 
@@ -68,7 +68,7 @@ func Broker(options *BrokerOptions, kubeConfig, kubeContext string) error {
 		return errors.Wrap(err, "invalid GlobalCIDR configuration")
 	}
 
-	config, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	config, err := restConfigProducer.ForCluster()
 	if err != nil {
 		return errors.Wrap(err, "the provided kubeconfig is invalid")
 	}

--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -66,15 +66,15 @@ func init() {
 }
 
 func addBenchmarkFlags(cmd *cobra.Command) {
-	AddKubeContextMultiFlag(cmd, "comma-separated list of one or two kubeconfig contexts to use.")
+	restConfigProducer.AddKubeContextMultiFlag(cmd, "comma-separated list of one or two kubeconfig contexts to use.")
 	cmd.PersistentFlags().BoolVar(&intraCluster, "intra-cluster", false, "run the test within a single cluster")
 	cmd.PersistentFlags().BoolVar(&benchmark.Verbose, "verbose", false, "produce verbose logs during benchmark tests")
 }
 
 func checkBenchmarkArguments(args []string, intraCluster bool) error {
-	if !intraCluster && len(args) != 2 && len(kubeContexts) != 2 {
+	if !intraCluster && len(args) != 2 && restConfigProducer.CountRequestedClusters() != 2 {
 		return fmt.Errorf("two kubecontexts must be specified")
-	} else if intraCluster && len(args) != 1 && len(kubeContexts) != 1 {
+	} else if intraCluster && len(args) != 1 && restConfigProducer.CountRequestedClusters() != 1 {
 		return fmt.Errorf("only one kubecontext should be specified")
 	}
 
@@ -91,8 +91,6 @@ func checkBenchmarkArguments(args []string, intraCluster bool) error {
 		if same {
 			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> need to have a unique content")
 		}
-	} else if len(kubeContexts) == 2 && strings.Compare(kubeContexts[0], kubeContexts[1]) == 0 {
-		return fmt.Errorf("the two kubecontexts must be different")
 	}
 
 	return nil

--- a/pkg/subctl/cmd/cloud/aws/aws.go
+++ b/pkg/subctl/cmd/cloud/aws/aws.go
@@ -35,9 +35,9 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	cloudprepareaws "github.com/submariner-io/cloud-prepare/pkg/aws"
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"gopkg.in/ini.v1"
 	"k8s.io/client-go/dynamic"
 )
@@ -74,7 +74,7 @@ func AddAWSFlags(command *cobra.Command) {
 
 // RunOnAWS runs the given function on AWS, supplying it with a cloud instance connected to AWS and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to AWS.
-func RunOnAWS(gwInstanceType, kubeConfig, kubeContext string,
+func RunOnAWS(restConfigProducer restconfig.Producer, gwInstanceType string,
 	function func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
@@ -108,7 +108,7 @@ func RunOnAWS(gwInstanceType, kubeConfig, kubeContext string,
 
 	reporter.Succeeded("")
 
-	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	k8sConfig, err := restConfigProducer.ForCluster()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	restMapper, err := util.BuildRestMapper(k8sConfig)

--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -41,7 +41,7 @@ func newAWSCleanupCommand() *cobra.Command {
 }
 
 func cleanupAws(cmd *cobra.Command, args []string) {
-	err := aws.RunOnAWS("", *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS(*parentRestConfigProducer, "",
 		// nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			err := gwDeployer.Cleanup(reporter)

--- a/pkg/subctl/cmd/cloud/cleanup/cleanup.go
+++ b/pkg/subctl/cmd/cloud/cleanup/cleanup.go
@@ -20,22 +20,19 @@ package cleanup
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 )
 
-var (
-	kubeConfig  *string
-	kubeContext *string
-)
+var parentRestConfigProducer *restconfig.Producer
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure.
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func NewCommand(restConfigProducer *restconfig.Producer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "Clean up the cloud",
 		Long:  `This command cleans up the cloud after Submariner uninstallation.`,
 	}
+	parentRestConfigProducer = restConfigProducer
 
 	cmd.AddCommand(newAWSCleanupCommand())
 	cmd.AddCommand(newGCPCleanupCommand())

--- a/pkg/subctl/cmd/cloud/cleanup/gcp.go
+++ b/pkg/subctl/cmd/cloud/cleanup/gcp.go
@@ -40,7 +40,7 @@ func newGCPCleanupCommand() *cobra.Command {
 }
 
 func cleanupGCP(cmd *cobra.Command, args []string) {
-	err := gcp.RunOnGCP("", *kubeConfig, *kubeContext, false,
+	err := gcp.RunOnGCP(*parentRestConfigProducer, "", false,
 		// nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			err := gwDeployer.Cleanup(reporter)

--- a/pkg/subctl/cmd/cloud/cleanup/generic.go
+++ b/pkg/subctl/cmd/cloud/cleanup/generic.go
@@ -37,7 +37,8 @@ func newGenericCleanupCommand() *cobra.Command {
 }
 
 func cleanupGenericCluster(cmd *cobra.Command, args []string) {
-	err := generic.RunOnK8sCluster(*kubeConfig, *kubeContext,
+	err := generic.RunOnK8sCluster(
+		*parentRestConfigProducer,
 		func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			return gwDeployer.Cleanup(reporter) // nolint:wrapcheck // No need to wrap here
 		})

--- a/pkg/subctl/cmd/cloud/cloud.go
+++ b/pkg/subctl/cmd/cloud/cloud.go
@@ -20,20 +20,24 @@ package cloud
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/cleanup"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/prepare"
 )
 
-// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure.
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	cmd := &cobra.Command{
+var (
+	cloudCmd = &cobra.Command{
 		Use:   "cloud",
 		Short: "Cloud operations",
 		Long:  `This command contains cloud operations related to Submariner installation.`,
 	}
+	restConfigProducer = restconfig.NewProducer()
+)
 
-	cmd.AddCommand(prepare.NewCommand(origKubeConfig, origKubeContext))
-	cmd.AddCommand(cleanup.NewCommand(origKubeConfig, origKubeContext))
-
-	return cmd
+func init() {
+	cloudCmd.AddCommand(prepare.NewCommand(&restConfigProducer))
+	cloudCmd.AddCommand(cleanup.NewCommand(&restConfigProducer))
+	restConfigProducer.AddKubeContextFlag(cloudCmd)
+	cmd.AddToRootCommand(cloudCmd)
 }

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -34,9 +34,9 @@ import (
 	gcpClientIface "github.com/submariner-io/cloud-prepare/pkg/gcp/client"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/option"
@@ -78,7 +78,7 @@ func AddGCPFlags(command *cobra.Command) {
 
 // RunOnGCP runs the given function on GCP, supplying it with a cloud instance connected to GCP and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to GCP.
-func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes bool,
+func RunOnGCP(restConfigProducer restconfig.Producer, gwInstanceType string, dedicatedGWNodes bool,
 	function func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
@@ -106,7 +106,7 @@ func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes b
 	gcpClient, err := gcpClientIface.NewClient(projectID, options)
 	utils.ExitOnError("Failed to initialize a GCP Client", err)
 
-	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	k8sConfig, err := restConfigProducer.ForCluster()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	clientSet, err := kubernetes.NewForConfig(k8sConfig)

--- a/pkg/subctl/cmd/cloud/generic/generic.go
+++ b/pkg/subctl/cmd/cloud/generic/generic.go
@@ -22,15 +22,15 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/generic"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"k8s.io/client-go/kubernetes"
 )
 
-func RunOnK8sCluster(kubeConfig, kubeContext string,
+func RunOnK8sCluster(restConfigProducer restconfig.Producer,
 	function func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
-	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	k8sConfig, err := restConfigProducer.ForCluster()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	clientSet, err := kubernetes.NewForConfig(k8sConfig)

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -64,7 +64,7 @@ func prepareAws(cmd *cobra.Command, args []string) {
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := aws.RunOnAWS(awsGWInstanceType, *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS(*parentRestConfigProducer, awsGWInstanceType,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -61,7 +61,7 @@ func prepareGCP(cmd *cobra.Command, args []string) {
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := gcp.RunOnGCP(gcpGWInstanceType, *kubeConfig, *kubeContext, dedicatedGateway,
+	err := gcp.RunOnGCP(*parentRestConfigProducer, gcpGWInstanceType, dedicatedGateway,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/generic.go
+++ b/pkg/subctl/cmd/cloud/prepare/generic.go
@@ -41,7 +41,8 @@ func newGenericPrepareCommand() *cobra.Command {
 
 func prepareGenericCluster(cmd *cobra.Command, args []string) {
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := generic.RunOnK8sCluster(*kubeConfig, *kubeContext,
+	err := generic.RunOnK8sCluster(
+		*parentRestConfigProducer,
 		func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -20,6 +20,7 @@ package prepare
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 )
 
 var (
@@ -27,8 +28,6 @@ var (
 	natDiscoveryPort uint16
 	vxlanPort        uint16
 	metricsPort      uint16
-	kubeConfig       *string
-	kubeContext      *string
 )
 
 var (
@@ -38,12 +37,13 @@ var (
 	dedicatedGateway  bool
 )
 
+var parentRestConfigProducer *restconfig.Producer
+
 const DefaultNumGateways = 1
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure.
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func NewCommand(restConfigProducer *restconfig.Producer) *cobra.Command {
+	parentRestConfigProducer = restConfigProducer
 	cmd := &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare the cloud",

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -30,7 +30,6 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
@@ -82,7 +81,7 @@ func init() {
 
 	deployBroker.PersistentFlags().StringVar(&brokerNamespace, "broker-namespace", defaultBrokerNamespace, "namespace for broker")
 
-	AddKubeContextFlag(deployBroker)
+	restConfigProducer.AddKubeContextFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 
@@ -105,7 +104,7 @@ var deployBroker = &cobra.Command{
 		if valid, err := isValidGlobalnetConfig(); !valid {
 			utils.ExitOnError("Invalid GlobalCIDR configuration", err)
 		}
-		config, err := restconfig.ForCluster(kubeConfig, kubeContext)
+		config, err := restConfigProducer.ForCluster()
 		utils.ExitOnError("The provided kubeconfig is invalid", err)
 
 		status := cli.NewStatus()

--- a/pkg/subctl/cmd/diagnose/diagnose.go
+++ b/pkg/subctl/cmd/diagnose/diagnose.go
@@ -19,12 +19,14 @@ package diagnose
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 )
 
 var (
-	podNamespace  string
-	verboseOutput bool
+	podNamespace       string
+	verboseOutput      bool
+	restConfigProducer = restconfig.NewProducer()
 
 	diagnoseCmd = &cobra.Command{
 		Use:   "diagnose",
@@ -34,7 +36,7 @@ var (
 )
 
 func init() {
-	cmd.AddKubeConfigFlag(diagnoseCmd)
+	restConfigProducer.AddKubeConfigFlag(diagnoseCmd)
 	cmd.AddToRootCommand(diagnoseCmd)
 }
 

--- a/pkg/subctl/cmd/diagnose/firewall_tunnel.go
+++ b/pkg/subctl/cmd/diagnose/firewall_tunnel.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
@@ -67,10 +67,12 @@ func init() {
 }
 
 func validateTunnelConfig(command *cobra.Command, args []string) {
-	localCfg, err := restconfig.ForCluster(args[0], "")
+	localProducer := restconfig.NewProducerFrom(args[0], "")
+	localCfg, err := localProducer.ForCluster()
 	utils.ExitOnError("The provided local kubeconfig is invalid", err)
 
-	remoteCfg, err := restconfig.ForCluster(args[1], "")
+	remoteProducer := restconfig.NewProducerFrom(args[1], "")
+	remoteCfg, err := remoteProducer.ForCluster()
 	utils.ExitOnError("The provided remote kubeconfig is invalid", err)
 
 	if !validateTunnelConfigAcrossClusters(localCfg, remoteCfg) {

--- a/pkg/subctl/cmd/execute.go
+++ b/pkg/subctl/cmd/execute.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	subClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -66,7 +66,7 @@ func NewCluster(config *rest.Config, clusterName string) (*Cluster, string) {
 		return nil, fmt.Sprintf("Error creating Submariner client: %v", err)
 	}
 
-	cluster.Submariner, err = getSubmarinerResourceWithError(cluster.Config)
+	cluster.Submariner, err = utils.GetSubmarinerResourceWithError(cluster.Config)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Sprintf("Error retrieving Submariner resource: %v", err)
 	}
@@ -90,7 +90,7 @@ func (c *Cluster) GetGateways() ([]submarinerv1.Gateway, error) {
 func ExecuteMultiCluster(run func(*Cluster) bool) {
 	success := true
 
-	for _, config := range restconfig.MustGetForClusters(kubeConfig, kubeContexts) {
+	for _, config := range restConfigProducer.MustGetForClusters() {
 		fmt.Printf("Cluster %q\n", config.ClusterName)
 
 		cluster, errMsg := NewCluster(config.Config, config.ClusterName)

--- a/pkg/subctl/cmd/export.go
+++ b/pkg/subctl/cmd/export.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/spf13/cobra"
 	autil "github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -45,14 +45,14 @@ var (
 		Short: "Exports a Service to other clusters",
 		Long: "This command creates a ServiceExport resource with the given name which causes the Service of the same name to be accessible" +
 			" to other clusters",
-		PreRunE: CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run:     exportService,
 	}
 	serviceNamespace string
 )
 
 func init() {
-	AddKubeConfigFlag(exportCmd)
+	restConfigProducer.AddKubeConfigFlag(exportCmd)
 	addServiceExportFlags(exportServiceCmd)
 	exportCmd.AddCommand(exportServiceCmd)
 	rootCmd.AddCommand(exportCmd)
@@ -66,7 +66,7 @@ func exportService(cmd *cobra.Command, args []string) {
 	err := validateArguments(args)
 	utils.ExitOnError("Insufficient arguments", err)
 
-	clientConfig := restconfig.ClientConfig(kubeConfig, kubeContext)
+	clientConfig := restConfigProducer.ClientConfig()
 	restConfig, err := clientConfig.ClientConfig()
 
 	utils.ExitOnError("Error connecting to the target cluster", err)

--- a/pkg/subctl/cmd/gather/gather.go
+++ b/pkg/subctl/cmd/gather/gather.go
@@ -26,12 +26,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	subOperatorClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/internal/cli"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
@@ -45,6 +45,7 @@ var (
 	gatherModule         string
 	directory            string
 	includeSensitiveData bool
+	restConfigProducer   = restconfig.NewProducer()
 )
 
 const (
@@ -72,7 +73,7 @@ var gatherFuncs = map[string]func(string, Info) bool{
 }
 
 func init() {
-	cmd.AddKubeContextMultiFlag(gatherCmd, "")
+	restConfigProducer.AddKubeContextMultiFlag(gatherCmd, "")
 	addGatherFlags(gatherCmd)
 	cmd.AddToRootCommand(gatherCmd)
 }

--- a/pkg/subctl/cmd/resource.go
+++ b/pkg/subctl/cmd/resource.go
@@ -19,46 +19,10 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
-	subOperatorClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1opts "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 )
-
-func getSubmarinerResourceWithError(config *rest.Config) (*v1alpha1.Submariner, error) {
-	submarinerClient, err := subOperatorClientset.NewForConfig(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating client")
-	}
-
-	submariner, err := submarinerClient.SubmarinerV1alpha1().Submariners(OperatorNamespace).
-		Get(context.TODO(), submarinercr.SubmarinerName, v1opts.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving Submariner resource")
-	}
-
-	return submariner, nil
-}
-
-func getSubmarinerResource(config *rest.Config) *v1alpha1.Submariner {
-	submariner, err := getSubmarinerResourceWithError(config)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-
-		utils.ExitOnError("Error obtaining the Submariner resource", err)
-	}
-
-	return submariner
-}
 
 func CompareFiles(file1, file2 string) (bool, error) {
 	first, err := os.ReadFile(file1)

--- a/pkg/subctl/cmd/show/all.go
+++ b/pkg/subctl/cmd/show/all.go
@@ -31,7 +31,7 @@ func init() {
 		Short: "Show information related to a submariner cluster",
 		Long: `This command shows information related to a submariner cluster:
 		      networks, endpoints, gateways, connections and component versions.`,
-		PreRunE: cmd.CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(showAll)
 		},

--- a/pkg/subctl/cmd/show/connections.go
+++ b/pkg/subctl/cmd/show/connections.go
@@ -43,7 +43,7 @@ func init() {
 		Use:     "connections",
 		Short:   "Show cluster connectivity information",
 		Long:    `This command shows information about submariner endpoint connections with other clusters.`,
-		PreRunE: cmd.CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(showConnections)
 		},

--- a/pkg/subctl/cmd/show/endpoints.go
+++ b/pkg/subctl/cmd/show/endpoints.go
@@ -48,7 +48,7 @@ func init() {
 		Use:     "endpoints",
 		Short:   "Show submariner endpoint information",
 		Long:    `This command shows information about submariner endpoints in a cluster.`,
-		PreRunE: cmd.CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(showEndpoints)
 		},

--- a/pkg/subctl/cmd/show/gateways.go
+++ b/pkg/subctl/cmd/show/gateways.go
@@ -37,7 +37,7 @@ func init() {
 		Use:     "gateways",
 		Short:   "Show submariner gateway summary information",
 		Long:    `This command shows summary information about the submariner gateways in a cluster.`,
-		PreRunE: cmd.CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(showGateways)
 		},

--- a/pkg/subctl/cmd/show/networks.go
+++ b/pkg/subctl/cmd/show/networks.go
@@ -34,7 +34,7 @@ func init() {
 		Short: "Get information on your cluster related to submariner",
 		Long: `This command shows the status of submariner in your cluster,
 		      and the relevant network details from your cluster.`,
-		PreRunE: cmd.CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(showNetwork)
 		},

--- a/pkg/subctl/cmd/show/show.go
+++ b/pkg/subctl/cmd/show/show.go
@@ -20,17 +20,21 @@ package show
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 )
 
-// showCmd represents the show command.
-var showCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Show information about submariner",
-	Long:  `This command shows information about some aspect of the submariner deployment in a cluster.`,
-}
+var (
+	// showCmd represents the show command.
+	showCmd = &cobra.Command{
+		Use:   "show",
+		Short: "Show information about submariner",
+		Long:  `This command shows information about some aspect of the submariner deployment in a cluster.`,
+	}
+	restConfigProducer = restconfig.NewProducer()
+)
 
 func init() {
-	cmd.AddKubeConfigFlag(showCmd)
+	restConfigProducer.AddKubeConfigFlag(showCmd)
 	cmd.AddToRootCommand(showCmd)
 }

--- a/pkg/subctl/cmd/show/versions.go
+++ b/pkg/subctl/cmd/show/versions.go
@@ -41,7 +41,7 @@ func init() {
 		Use:     "versions",
 		Short:   "Shows submariner component versions",
 		Long:    `This command shows the versions of the submariner components in the cluster.`,
-		PreRunE: cmd.CheckVersionMismatch,
+		PreRunE: restConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.ExecuteMultiCluster(showVersions)
 		},

--- a/pkg/subctl/cmd/utils/utils.go
+++ b/pkg/subctl/cmd/utils/utils.go
@@ -19,10 +19,18 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	subOperatorClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	"github.com/submariner-io/submariner-operator/pkg/version"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1opts "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 // PanicOnError will print the subctl version and then panic in case of an actual error.
@@ -56,4 +64,33 @@ func ExpectFlag(flag, value string) {
 	if value == "" {
 		ExitWithErrorMsg(fmt.Sprintf("You must specify the %v flag", flag))
 	}
+}
+
+func GetSubmarinerResourceWithError(config *rest.Config) (*v1alpha1.Submariner, error) {
+	submarinerClient, err := subOperatorClientset.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating clientset")
+	}
+
+	// TODO skitt namespace constant
+	submariner, err := submarinerClient.SubmarinerV1alpha1().Submariners("submariner-operator").
+		Get(context.TODO(), submarinercr.SubmarinerName, v1opts.GetOptions{})
+	if err != nil {
+		return nil, errors.WithMessagef(err, "error retrieving Submariner object %s", submarinercr.SubmarinerName)
+	}
+
+	return submariner, nil
+}
+
+func GetSubmarinerResource(config *rest.Config) *v1alpha1.Submariner {
+	submariner, err := GetSubmarinerResourceWithError(config)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		ExitOnError("Error obtaining the Submariner resource", err)
+	}
+
+	return submariner
 }

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -36,9 +36,9 @@ import (
 	_ "github.com/submariner-io/lighthouse/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
@@ -59,7 +59,7 @@ var (
 )
 
 func init() {
-	AddKubeContextMultiFlag(verifyCmd, "comma-separated list of exactly two kubeconfig contexts to use.")
+	restConfigProducer.AddKubeContextMultiFlag(verifyCmd, "comma-separated list of exactly two kubeconfig contexts to use.")
 	verifyCmd.Flags().StringVar(&verifyOnly, "only", strings.Join(getAllVerifyKeys(), ","), "comma separated verifications to be performed")
 	verifyCmd.Flags().BoolVar(&disruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
 	addVerifyFlags(verifyCmd)
@@ -182,13 +182,17 @@ func configureTestingFramework(args []string) error {
 
 		// Read the cluster names from the given kubeconfigs
 		for _, config := range args {
-			framework.TestContext.ClusterIDs = append(framework.TestContext.ClusterIDs, clusterNameFromConfig(config, ""))
+			rcp := restconfig.NewProducerFrom(config, "")
+
+			clusterName, err := rcp.ClusterNameFromContext()
+			if err != nil {
+				return nil // nolint:nilerr // This is intentional.
+			}
+
+			framework.TestContext.ClusterIDs = append(framework.TestContext.ClusterIDs, *clusterName)
 		}
 	} else {
-		framework.TestContext.KubeContexts = kubeContexts
-		if kubeConfig != "" {
-			framework.TestContext.KubeConfig = kubeConfig
-		}
+		restConfigProducer.PopulateTestFramework()
 	}
 
 	framework.TestContext.OperationTimeout = operationTimeout
@@ -204,22 +208,8 @@ func configureTestingFramework(args []string) error {
 	return nil
 }
 
-func clusterNameFromConfig(kubeConfigPath, kubeContext string) string {
-	rawConfig, err := restconfig.ClientConfig(kubeConfigPath, "").RawConfig()
-
-	utils.ExitOnError(fmt.Sprintf("Error obtaining the kube config for path %q", kubeConfigPath), err)
-
-	cluster := restconfig.ClusterNameFromContext(&rawConfig, kubeContext)
-
-	if cluster == nil {
-		utils.ExitWithErrorMsg(fmt.Sprintf("Could not obtain the cluster name from kube config: %#v", rawConfig))
-	}
-
-	return *cluster
-}
-
 func checkValidateArguments(args []string) error {
-	if len(args) != 2 && len(kubeContexts) != 2 {
+	if len(args) != 2 && restConfigProducer.CountRequestedClusters() != 2 {
 		return fmt.Errorf("two kubecontexts must be specified")
 	}
 
@@ -236,8 +226,6 @@ func checkValidateArguments(args []string) error {
 		if same {
 			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> need to have a unique content")
 		}
-	} else if strings.Compare(kubeContexts[0], kubeContexts[1]) == 0 {
-		return fmt.Errorf("the two kubecontexts must be different")
 	}
 
 	if connectionAttempts < 1 {

--- a/pkg/subctl/main.go
+++ b/pkg/subctl/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
+	_ "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud"
 	_ "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/diagnose"
 	_ "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/gather"
 	_ "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/show"


### PR DESCRIPTION
This moves the configuration-handling specifics into restconfig, which
will make it easier to switch to clientcmd while preserving
backwards-compatibility.

Depends on #1681
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
