### PR TITLE
Support insecure connections to the broker in SD

### DIFF
--- a/api/submariner/v1alpha1/servicediscovery_types.go
+++ b/api/submariner/v1alpha1/servicediscovery_types.go
@@ -40,6 +40,7 @@ type ServiceDiscoverySpec struct {
 	Version                  string               `json:"version,omitempty"`
 	Debug                    bool                 `json:"debug"`
 	GlobalnetEnabled         bool                 `json:"globalnetEnabled,omitempty"`
+	BrokerK8sInsecure        bool                 `json:"brokerK8sInsecure,omitempty"`
 	CoreDNSCustomConfig      *CoreDNSCustomConfig `json:"coreDNSCustomConfig,omitempty"`
 	// +listType=set
 	CustomDomains  []string          `json:"customDomains,omitempty"`

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -240,6 +240,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery) *appsv1.Deploym
 								{Name: "BROKER_K8S_APISERVERTOKEN", Value: cr.Spec.BrokerK8sApiServerToken},
 								{Name: "BROKER_K8S_REMOTENAMESPACE", Value: cr.Spec.BrokerK8sRemoteNamespace},
 								{Name: "BROKER_K8S_CA", Value: cr.Spec.BrokerK8sCA},
+								{Name: "BROKER_INSECURE", Value: strconv.FormatBool(cr.Spec.BrokerK8sInsecure)},
 							},
 						},
 					},

--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -45,6 +45,7 @@ func (r *SubmarinerReconciler) serviceDiscoveryReconciler(ctx context.Context, s
 					BrokerK8sRemoteNamespace: submariner.Spec.BrokerK8sRemoteNamespace,
 					BrokerK8sApiServerToken:  submariner.Spec.BrokerK8sApiServerToken,
 					BrokerK8sApiServer:       submariner.Spec.BrokerK8sApiServer,
+					BrokerK8sInsecure:        submariner.Spec.BrokerK8sInsecure,
 					Debug:                    submariner.Spec.Debug,
 					ClusterID:                submariner.Spec.ClusterID,
 					Namespace:                submariner.Spec.Namespace,


### PR DESCRIPTION
Propagate support for insecure connections in service discovery.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
