### PR TITLE
Add client Producer interface and implementations

### DIFF
--- a/pkg/client/default_producer.go
+++ b/pkg/client/default_producer.go
@@ -1,0 +1,49 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	submarinerclient "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+type DefaultProducer struct {
+	CRDClient        apiextclient.Interface
+	KubeClient       kubernetes.Interface
+	DynamicClient    dynamic.Interface
+	SubmarinerClient submarinerclient.Interface
+}
+
+func (p *DefaultProducer) ForCRD() apiextclient.Interface {
+	return p.CRDClient
+}
+
+func (p *DefaultProducer) ForKubernetes() kubernetes.Interface {
+	return p.KubeClient
+}
+
+func (p *DefaultProducer) ForDynamic() dynamic.Interface {
+	return p.DynamicClient
+}
+
+func (p *DefaultProducer) ForSubmariner() submarinerclient.Interface {
+	return p.SubmarinerClient
+}

--- a/pkg/client/producer.go
+++ b/pkg/client/producer.go
@@ -1,0 +1,36 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	submarinerClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	apiextClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Producer interface {
+	ForCRD() apiextClient.Interface
+
+	ForKubernetes() kubernetes.Interface
+
+	ForDynamic() dynamic.Interface
+
+	ForSubmariner() submarinerClientset.Interface
+}

--- a/pkg/client/restconfig_producer.go
+++ b/pkg/client/restconfig_producer.go
@@ -1,0 +1,55 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	submarinerClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	apiextClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func NewProducerFromRestConfig(config *rest.Config) (Producer, error) {
+	var err error
+	p := &DefaultProducer{}
+
+	p.KubeClient, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating kube client")
+	}
+
+	p.DynamicClient, err = dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating dynamic client")
+	}
+
+	p.SubmarinerClient, err = submarinerClientset.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating submariner client")
+	}
+
+	p.CRDClient, err = apiextClient.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating api extensions client")
+	}
+
+	return p, nil
+}


### PR DESCRIPTION
...that yields various client set interfaces used throughout the code base. This provides a layer of abstraction in lieu of passing around `rest.Config` instances to enable easier reuse for external apps, eg the **submariner-addon**, and to facilitate unit testing.
