### PR TITLE
Fix panic while running subctl gather

### DIFF
--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -150,7 +150,9 @@ func outputPreviousPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, i
 		defer logStream.Close()
 	}
 
-	podLogInfo.RestartCount = pod.Status.ContainerStatuses[0].RestartCount
+	if len(pod.Status.ContainerStatuses) > 0 {
+		podLogInfo.RestartCount = pod.Status.ContainerStatuses[0].RestartCount
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes issue: https://github.com/submariner-io/submariner-operator/issues/1684
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
