### PR TITLE
Use order-only prerequisites for tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ build: $(BINARIES)
 build-cross: $(CROSS_TARBALLS)
 
 licensecheck: BUILD_ARGS=--noupx
-licensecheck: build bin/lichen bin/submariner-operator
+licensecheck: build bin/submariner-operator | bin/lichen
 	bin/lichen -c .lichen.yaml $(BINARIES) bin/submariner-operator
 
 bin/lichen: $(VENDOR_MODULES)
@@ -152,7 +152,7 @@ package/Dockerfile.submariner-operator-index: packagemanifests
 
 # Generate deep-copy code
 CONTROLLER_DEEPCOPY := api/submariner/v1alpha1/zz_generated.deepcopy.go
-$(CONTROLLER_DEEPCOPY): $(CONTROLLER_GEN) $(VENDOR_MODULES)
+$(CONTROLLER_DEEPCOPY): $(VENDOR_MODULES) | $(CONTROLLER_GEN)
 	cd api && $(CONTROLLER_GEN) object:headerFile="$(CURDIR)/hack/boilerplate.go.txt,year=$(shell date +"%Y")" paths="./..."
 
 # Generate embedded YAMLs
@@ -209,16 +209,16 @@ $(CONTROLLER_GEN): $(VENDOR_MODULES)
 	mkdir -p $(@D)
 	$(GO) build -o $@ sigs.k8s.io/controller-tools/cmd/controller-gen
 
-deploy/crds/submariner.io_servicediscoveries.yaml: $(CONTROLLER_GEN) ./api/submariner/v1alpha1/servicediscovery_types.go $(VENDOR_MODULES)
+deploy/crds/submariner.io_servicediscoveries.yaml: ./api/submariner/v1alpha1/servicediscovery_types.go $(VENDOR_MODULES) | $(CONTROLLER_GEN)
 	cd api && $(GO) mod vendor && $(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../deploy/crds
 	test -f $@
 
-deploy/crds/submariner.io_brokers.yaml deploy/crds/submariner.io_submariners.yaml: $(CONTROLLER_GEN) ./api/submariner/v1alpha1/submariner_types.go $(VENDOR_MODULES)
+deploy/crds/submariner.io_brokers.yaml deploy/crds/submariner.io_submariners.yaml: ./api/submariner/v1alpha1/submariner_types.go $(VENDOR_MODULES) | $(CONTROLLER_GEN)
 	cd api && $(GO) mod vendor && $(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../deploy/crds
 	test -f $@
 
 # Submariner CRDs
-deploy/submariner/crds/submariner.io_clusters.yaml deploy/submariner/crds/submariner.io_endpoints.yaml deploy/submariner/crds/submariner.io_gateways.yaml: $(CONTROLLER_GEN) $(VENDOR_MODULES)
+deploy/submariner/crds/submariner.io_clusters.yaml deploy/submariner/crds/submariner.io_endpoints.yaml deploy/submariner/crds/submariner.io_gateways.yaml: $(VENDOR_MODULES) | $(CONTROLLER_GEN)
 	cd vendor/github.com/submariner-io/submariner && $(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../../../../deploy/submariner/crds
 	test -f $@
 


### PR DESCRIPTION
Currently, the tools used during the build (e.g. controller-gen) are
rebuilt if their dependencies change, and then the files generated by
the tools are rebuilt because the tool was rebuilt. This isn't
desirable in day-to-day use; to avoid having tool rebuilds cause
regeneration of all the files and thus recompilation of everything in
most cases, this patch changes concrete targets to specify the
required tools using order-only prerequisites.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
