### PR TITLE
Refactor deploy.Broker to use the client.Producer

### DIFF
--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -23,15 +23,15 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/internal/cli"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/exit"
 	"github.com/submariner-io/submariner-operator/pkg/deploy"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 )
 
 var (
 	deployflags       deploy.BrokerOptions
-	defaultComponents = []string{components.ServiceDiscovery, components.Connectivity}
+	defaultComponents = []string{component.ServiceDiscovery, component.Connectivity}
 )
 
 // deployBroker represents the deployBroker command.

--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -43,20 +43,20 @@ var deployBroker = &cobra.Command{
 	Use:   "deploy-broker",
 	Short: "Deploys the broker",
 	Run: func(cmd *cobra.Command, args []string) {
+		status := cli.NewReporter()
+
 		config, err := restConfigProducer.ForCluster()
-		exit.OnError("Error creating REST config", err)
+		exit.OnError(status.Error(err, "Error creating REST config"))
 
 		clientProducer, err := client.NewProducerFromRestConfig(config)
-		exit.OnError("Error creating client producer", err)
+		exit.OnError(status.Error(err, "Error creating client producer"))
 
-		status := cli.NewReporter()
 		err = deploy.Broker(&deployflags, clientProducer, status)
-		if err == nil {
-			err = broker.WriteInfoToFile(config, deployflags.BrokerNamespace, ipsecSubmFile,
-				stringset.New(deployflags.BrokerSpec.Components...), deployflags.BrokerSpec.DefaultCustomDomains, status)
-		}
+		exit.OnError(err)
 
-		exit.OnError("", err)
+		err = broker.WriteInfoToFile(config, deployflags.BrokerNamespace, ipsecSubmFile,
+			stringset.New(deployflags.BrokerSpec.Components...), deployflags.BrokerSpec.DefaultCustomDomains, status)
+		exit.OnError(err)
 	},
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -251,6 +251,9 @@ func (s *Status) Warning(message string, a ...interface{}) {
 
 func (s *Status) Error(err error, message string, args ...interface{}) error {
 	err = errors.Wrapf(err, message, args...)
+	if err == nil {
+		return nil
+	}
 
 	capitalizeFirst := func(str string) string {
 		for i, v := range str {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -210,24 +210,42 @@ func CheckForError(err error) Result {
 // Failure queues up a message, which will be displayed once
 // the status ends (using the failure format).
 func (s *Status) Failure(message string, a ...interface{}) {
-	if message != "" {
+	if message == "" {
+		return
+	}
+
+	if s.status != "" {
 		s.failureQueue = append(s.failureQueue, fmt.Sprintf(message, a...))
+	} else {
+		s.logger.V(0).Infof(s.failureFormat, message)
 	}
 }
 
 // Success queues up a message, which will be displayed once
 // the status ends (using the warning format).
 func (s *Status) Success(message string, a ...interface{}) {
-	if message != "" {
+	if message == "" {
+		return
+	}
+
+	if s.status != "" {
 		s.successQueue = append(s.successQueue, fmt.Sprintf(message, a...))
+	} else {
+		s.logger.V(0).Infof(s.successFormat, message)
 	}
 }
 
 // Warning queues up a message, which will be displayed once
 // the status ends (using the warning format).
 func (s *Status) Warning(message string, a ...interface{}) {
-	if message != "" {
+	if message == "" {
+		return
+	}
+
+	if s.status != "" {
 		s.warningQueue = append(s.warningQueue, fmt.Sprintf(message, a...))
+	} else {
+		s.logger.V(0).Infof(s.warningFormat, message)
 	}
 }
 

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package components
+package component
 
 const (
 	Connectivity     = "connectivity"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -20,4 +20,6 @@ package constants
 const (
 	OperatorNamespace      = "submariner-operator"
 	DefaultBrokerNamespace = "submariner-k8s-broker"
+
+	SubmarinerBrokerAdminSA = "submariner-k8s-broker-admin"
 )

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -27,7 +27,12 @@ import (
 // OnError will print your error nicely and exit in case of error.
 func OnError(message string, err error) {
 	if err != nil {
-		WithErrorMsg(fmt.Sprintf("%s: %s", message, err))
+		msg := ""
+		if message != "" {
+			msg = fmt.Sprintf("%s: %s", message, err)
+		}
+
+		WithErrorMsg(msg)
 	}
 }
 

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -24,23 +24,23 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/version"
 )
 
-// OnError will print your error nicely and exit in case of error.
-func OnError(message string, err error) {
+// OnError exits in case of error.
+func OnError(err error) {
 	if err != nil {
-		msg := ""
-		if message != "" {
-			msg = fmt.Sprintf("%s: %s", message, err)
-		}
-
-		WithErrorMsg(msg)
+		printVersion()
+		os.Exit(1)
 	}
 }
 
-// WithErrorMsg will print the message and quit the program with an error code.
-func WithErrorMsg(message string) {
+// WithMessage will print the message and quit the program with an error code.
+func WithMessage(message string) {
 	fmt.Fprintln(os.Stderr, message)
+	printVersion()
+	os.Exit(1)
+}
+
+func printVersion() {
 	fmt.Fprintln(os.Stderr, "")
 	version.PrintSubctlVersion(os.Stderr)
 	fmt.Fprintln(os.Stderr, "")
-	os.Exit(1)
 }

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -1,0 +1,59 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// maxGeneratedNameLength is the maximum generated length for a token, excluding the random suffix
+// See k8s.io/apiserver/pkg/storage/names.
+const maxGeneratedNameLength = 63 - 5
+
+func GetClientTokenSecret(kubeClient kubernetes.Interface, namespace, serviceAccountName string) (*v1.Secret, error) {
+	sa, err := kubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "ServiceAccount %s get failed", serviceAccountName)
+	}
+
+	if len(sa.Secrets) < 1 {
+		return nil, fmt.Errorf("ServiceAccount %s does not have any secret", sa.Name)
+	}
+
+	tokenPrefix := fmt.Sprintf("%s-token-", serviceAccountName)
+	if len(tokenPrefix) > maxGeneratedNameLength {
+		tokenPrefix = tokenPrefix[:maxGeneratedNameLength]
+	}
+
+	for _, secret := range sa.Secrets {
+		if strings.HasPrefix(secret.Name, tokenPrefix) {
+			// nolint:wrapcheck // No need to wrap here
+			return kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
+		}
+	}
+
+	return nil, fmt.Errorf("ServiceAccount %s does not have a secret of type token", serviceAccountName)
+}

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -25,11 +25,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/rbac"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/utils"
 	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
 	v1 "k8s.io/api/core/v1"
@@ -50,17 +50,17 @@ func Ensure(config *rest.Config, componentArr []string, crds bool, namespace str
 
 		for i := range componentArr {
 			switch componentArr[i] {
-			case components.Connectivity:
-				err = gateway.Ensure(crdCreator)
+			case component.Connectivity:
+				err := gateway.Ensure(crdCreator)
 				if err != nil {
 					return errors.Wrap(err, "error setting up the connectivity requirements")
 				}
-			case components.ServiceDiscovery:
+			case component.ServiceDiscovery:
 				_, err = lighthouse.Ensure(crdCreator, lighthouse.BrokerCluster)
 				if err != nil {
 					return errors.Wrap(err, "error setting up the service discovery requirements")
 				}
-			case components.Globalnet:
+			case component.Globalnet:
 				// Globalnet needs the Lighthouse CRDs too
 				_, err = lighthouse.Ensure(crdCreator, lighthouse.BrokerCluster)
 				if err != nil {

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/rbac"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
@@ -90,7 +91,7 @@ func Ensure(config *rest.Config, componentArr []string, crds bool, namespace str
 		return err
 	}
 
-	_, err = WaitForClientToken(clientset, SubmarinerBrokerAdminSA, namespace)
+	_, err = WaitForClientToken(clientset, constants.SubmarinerBrokerAdminSA, namespace)
 
 	return err
 }
@@ -141,7 +142,7 @@ func CreateSAForCluster(clientset *kubernetes.Clientset, clusterID, namespace st
 
 func createBrokerAdministratorRoleAndSA(clientset *kubernetes.Clientset, namespace string) error {
 	// Create the SA we need for the managing the broker (from subctl, etc..).
-	_, err := CreateNewBrokerSA(clientset, SubmarinerBrokerAdminSA, namespace)
+	_, err := CreateNewBrokerSA(clientset, constants.SubmarinerBrokerAdminSA, namespace)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error creating the broker admin service account")
 	}
@@ -153,7 +154,7 @@ func createBrokerAdministratorRoleAndSA(clientset *kubernetes.Clientset, namespa
 	}
 
 	// Create the role binding
-	_, err = CreateNewBrokerRoleBinding(clientset, SubmarinerBrokerAdminSA, submarinerBrokerAdminRole, namespace)
+	_, err = CreateNewBrokerRoleBinding(clientset, constants.SubmarinerBrokerAdminSA, submarinerBrokerAdminRole, namespace)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error creating the broker rolebinding")
 	}

--- a/pkg/broker/file.go
+++ b/pkg/broker/file.go
@@ -43,8 +43,7 @@ func WriteInfoToFile(restConfig *rest.Config, brokerNamespace, ipsecFile string,
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		// TODO return reporter.Error(err, "error creating Kubernetes client")
-		return errors.Wrap(err, "error creating Kubernetes client")
+		return status.Error(err, "error creating Kubernetes client")
 	}
 
 	data, err := newDataFrom(kubeClient, brokerNamespace, ipsecFile)
@@ -57,8 +56,7 @@ func WriteInfoToFile(restConfig *rest.Config, brokerNamespace, ipsecFile string,
 
 	newFilename, err := backupIfExists(InfoFileName)
 	if err != nil {
-		// TODO return reporter.Error(err, "error backing up the broker file")
-		return errors.Wrap(err, "error backing up the broker file")
+		return status.Error(err, "error backing up the broker file")
 	}
 
 	if newFilename != "" {

--- a/pkg/broker/file.go
+++ b/pkg/broker/file.go
@@ -1,0 +1,136 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner-operator/internal/component"
+	"github.com/submariner-io/submariner-operator/internal/constants"
+	"github.com/submariner-io/submariner-operator/internal/rbac"
+	"github.com/submariner-io/submariner-operator/pkg/reporter"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const InfoFileName = "broker-info.subm"
+
+func WriteInfoToFile(restConfig *rest.Config, brokerNamespace, ipsecFile string, components stringset.Interface,
+	customDomains []string, status reporter.Interface) error {
+	status.Start("Saving broker info to file %q", InfoFileName)
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		// TODO return reporter.Error(err, "error creating Kubernetes client")
+		return errors.Wrap(err, "error creating Kubernetes client")
+	}
+
+	data, err := newDataFrom(kubeClient, brokerNamespace, ipsecFile)
+	if err != nil {
+		// TODO return reporter.Error(err, "error initializing broker info")
+		return err
+	}
+
+	data.BrokerURL = restConfig.Host + restConfig.APIPath
+
+	newFilename, err := backupIfExists(InfoFileName)
+	if err != nil {
+		// TODO return reporter.Error(err, "error backing up the broker file")
+		return errors.Wrap(err, "error backing up the broker file")
+	}
+
+	if newFilename != "" {
+		status.Success("Backed up previous file %q to %q", InfoFileName, newFilename)
+	}
+
+	data.ServiceDiscovery = components.Contains(component.ServiceDiscovery)
+	data.Components = components.Elements()
+
+	if len(customDomains) > 0 {
+		data.CustomDomains = &customDomains
+	}
+
+	err = data.writeToFile(InfoFileName)
+	if err != nil {
+		return status.Error(data.writeToFile(InfoFileName), "error saving broker info")
+	}
+
+	status.End()
+
+	return nil
+}
+
+func ReadInfoFromFile(filename string) (*Info, error) {
+	raw, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading file %q", filename)
+	}
+
+	data := &Info{}
+
+	bytes, err := base64.URLEncoding.DecodeString(string(raw))
+	if err != nil {
+		return nil, errors.Wrapf(err, "error decoding data from file %q", filename)
+	}
+
+	return data, errors.Wrap(json.Unmarshal(bytes, data), "error unmarshalling data")
+}
+
+func newDataFrom(kubeClient kubernetes.Interface, brokerNamespace, ipsecFile string) (*Info, error) {
+	var err error
+	data := &Info{}
+
+	data.ClientToken, err = rbac.GetClientTokenSecret(kubeClient, brokerNamespace, constants.SubmarinerBrokerAdminSA)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting broker client secret")
+	}
+
+	if ipsecFile != "" {
+		ipsecData, err := ReadInfoFromFile(ipsecFile)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error importing IPsec PSK from file %q", ipsecFile)
+		}
+
+		data.IPSecPSK = ipsecData.IPSecPSK
+
+		return data, err
+	}
+
+	data.IPSecPSK, err = newIPSECPSKSecret()
+
+	return data, err
+}
+
+func backupIfExists(fileName string) (string, error) {
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	now := time.Now()
+	nowStr := strings.ReplaceAll(now.Format(time.RFC3339), ":", "_")
+	newFilename := fileName + "." + nowStr
+
+	return newFilename, os.Rename(fileName, newFilename) // nolint:wrapcheck // No need to wrap here
+}

--- a/pkg/broker/info.go
+++ b/pkg/broker/info.go
@@ -1,0 +1,112 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/resource"
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+type Info struct {
+	BrokerURL        string         `json:"brokerURL"`
+	ClientToken      *corev1.Secret `omitempty,json:"clientToken"`
+	IPSecPSK         *corev1.Secret `omitempty,json:"ipsecPSK"`
+	ServiceDiscovery bool           `omitempty,json:"serviceDiscovery"`
+	Components       []string       `json:",omitempty"`
+	CustomDomains    *[]string      `omitempty,json:"customDomains"`
+}
+
+func (d *Info) writeToFile(filename string) error {
+	dataStr, err := d.encode()
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filename, []byte(dataStr), 0o600); err != nil {
+		return errors.Wrapf(err, "error writing to file %q", filename)
+	}
+
+	return nil
+}
+
+func (d *Info) encode() (string, error) {
+	jsonBytes, err := json.Marshal(d)
+	if err != nil {
+		return "", errors.Wrap(err, "error marshalling data")
+	}
+
+	return base64.URLEncoding.EncodeToString(jsonBytes), nil
+}
+
+func (d *Info) GetBrokerAdministratorConfig() (*rest.Config, error) {
+	// We need to try a connection to determine whether the trust chain needs to be provided
+	config, err := d.getAndCheckBrokerAdministratorConfig(false)
+	if resource.IsUnknownAuthorityError(err) {
+		// Certificate error, try with the trust chain
+		config, err = d.getAndCheckBrokerAdministratorConfig(true)
+	}
+
+	return config, err
+}
+
+func (d *Info) getAndCheckBrokerAdministratorConfig(private bool) (*rest.Config, error) {
+	config := d.getBrokerAdministratorConfig(private)
+
+	submClientset, err := submarinerClientset.NewForConfig(config)
+	if err != nil {
+		return config, errors.Wrap(err, "error creating client")
+	}
+
+	// This attempts to determine whether we can connect, by trying to access a Submariner object
+	// Successful connections result in either the object, or a “not found” error; anything else
+	// likely means we couldn’t connect
+	_, err = submClientset.SubmarinerV1().Clusters(string(d.ClientToken.Data["namespace"])).List(
+		context.TODO(), metav1.ListOptions{})
+	if apierrors.IsNotFound(err) {
+		err = nil
+	}
+
+	return config, err
+}
+
+func (d *Info) getBrokerAdministratorConfig(private bool) *rest.Config {
+	tlsClientConfig := rest.TLSClientConfig{}
+	if private {
+		tlsClientConfig.CAData = d.ClientToken.Data["ca.crt"]
+	}
+
+	bearerToken := d.ClientToken.Data["token"]
+	restConfig := rest.Config{
+		Host:            d.BrokerURL,
+		TLSClientConfig: tlsClientConfig,
+		BearerToken:     string(bearerToken),
+	}
+
+	return &restConfig
+}

--- a/pkg/broker/ipsec_psk.go
+++ b/pkg/broker/ipsec_psk.go
@@ -1,0 +1,58 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"crypto/rand"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ipsecPSKSecretName = "submariner-ipsec-psk"
+	ipsecSecretLength  = 48
+)
+
+// generateRandomPSK returns securely generated n-byte array.
+func generateRandomPSK(n int) ([]byte, error) {
+	psk := make([]byte, n)
+	_, err := rand.Read(psk)
+
+	return psk, err // nolint:wrapcheck // No need to wrap here
+}
+
+func newIPSECPSKSecret() (*v1.Secret, error) {
+	psk, err := generateRandomPSK(ipsecSecretLength)
+	if err != nil {
+		return nil, err
+	}
+
+	pskSecretData := make(map[string][]byte)
+	pskSecretData["psk"] = psk
+
+	pskSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ipsecPSKSecretName,
+		},
+		Data: pskSecretData,
+	}
+
+	return pskSecret, nil
+}

--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -29,7 +29,6 @@ import (
 const (
 	submarinerBrokerClusterRole      = "submariner-k8s-broker-cluster"
 	submarinerBrokerAdminRole        = "submariner-k8s-broker-admin"
-	SubmarinerBrokerAdminSA          = "submariner-k8s-broker-admin"
 	submarinerBrokerClusterSAFmt     = "cluster-%s"
 	submarinerBrokerClusterDefaultSA = "submariner-k8s-broker-client" // for backwards compatibility with documentation
 )

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -24,13 +24,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/stringset"
 	submarinerv1a1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/image"
 	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/reporter"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
@@ -48,7 +48,7 @@ type BrokerOptions struct {
 	BrokerSpec          submarinerv1a1.BrokerSpec
 }
 
-var ValidComponents = []string{components.ServiceDiscovery, components.Connectivity}
+var ValidComponents = []string{component.ServiceDiscovery, component.Connectivity}
 
 const brokerDetailsFilename = "broker-info.subm"
 
@@ -63,7 +63,7 @@ func Broker(options *BrokerOptions, restConfigProducer restconfig.Producer, stat
 	}
 
 	if options.BrokerSpec.GlobalnetEnabled {
-		componentSet.Add(components.Globalnet)
+		componentSet.Add(component.Globalnet)
 	}
 
 	if err := checkGlobalnetConfig(options); err != nil {
@@ -105,7 +105,7 @@ func Broker(options *BrokerOptions, restConfigProducer restconfig.Producer, stat
 		status.Success("Backed up previous %s to %s", brokerDetailsFilename, newFilename)
 	}
 
-	subctlData.ServiceDiscovery = componentSet.Contains(components.ServiceDiscovery)
+	subctlData.ServiceDiscovery = componentSet.Contains(component.ServiceDiscovery)
 	subctlData.SetComponents(componentSet)
 
 	if len(options.BrokerSpec.DefaultCustomDomains) > 0 {

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -47,9 +47,6 @@ type BrokerOptions struct {
 
 var ValidComponents = []string{component.ServiceDiscovery, component.Connectivity}
 
-// Ignoring th cyclic complexity of Broker function because it is being refactored in
-// https://github.com/submariner-io/submariner-operator/pull/1717.
-//gocyclo:ignore
 func Broker(options *BrokerOptions, clientProducer client.Producer, status reporter.Interface) error {
 	componentSet := stringset.New(options.BrokerSpec.Components...)
 

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 type Info struct {
@@ -327,8 +326,8 @@ func ValidateGlobalnetConfiguration(globalnetInfo *Info, netconfig Config) (stri
 	return globalnetCIDR, nil
 }
 
-func GetGlobalNetworks(k8sClientset *kubernetes.Clientset, brokerNamespace string) (*Info, *v1.ConfigMap, error) {
-	configMap, err := broker.GetGlobalnetConfigMap(k8sClientset, brokerNamespace)
+func GetGlobalNetworks(kubeClient kubernetes.Interface, brokerNamespace string) (*Info, *v1.ConfigMap, error) {
+	configMap, err := broker.GetGlobalnetConfigMap(kubeClient, brokerNamespace)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error retrieving globalnet ConfigMap")
 	}
@@ -443,13 +442,8 @@ func IsValidCIDR(cidr string) error {
 	return nil
 }
 
-func ValidateExistingGlobalNetworks(config *rest.Config, namespace string) error {
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return errors.Wrap(err, "error creating the kubernetes clientset")
-	}
-
-	globalnetInfo, _, err := GetGlobalNetworks(clientset, namespace)
+func ValidateExistingGlobalNetworks(kubeClient kubernetes.Interface, namespace string) error {
+	globalnetInfo, _, err := GetGlobalNetworks(kubeClient, namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -26,11 +26,11 @@ import (
 	"github.com/submariner-io/admiral/pkg/stringset"
 	submarinerv1a1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/cli"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/image"
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/datafile"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop"
@@ -53,8 +53,8 @@ var (
 )
 
 var (
-	defaultComponents = []string{components.ServiceDiscovery, components.Connectivity}
-	validComponents   = []string{components.ServiceDiscovery, components.Connectivity}
+	defaultComponents = []string{component.ServiceDiscovery, component.Connectivity}
+	validComponents   = []string{component.ServiceDiscovery, component.Connectivity}
 )
 
 func init() {
@@ -98,7 +98,7 @@ var deployBroker = &cobra.Command{
 		}
 
 		if globalnetEnable {
-			componentSet.Add(components.Globalnet)
+			componentSet.Add(component.Globalnet)
 		}
 
 		if valid, err := isValidGlobalnetConfig(); !valid {
@@ -154,7 +154,7 @@ var deployBroker = &cobra.Command{
 			status.QueueSuccessMessage(fmt.Sprintf("Backed up previous %s to %s", brokerDetailsFilename, newFilename))
 		}
 
-		subctlData.ServiceDiscovery = componentSet.Contains(components.ServiceDiscovery)
+		subctlData.ServiceDiscovery = componentSet.Contains(component.ServiceDiscovery)
 		subctlData.SetComponents(componentSet)
 
 		if len(defaultCustomDomains) > 0 {

--- a/pkg/subctl/cmd/gather/gather.go
+++ b/pkg/subctl/cmd/gather/gather.go
@@ -27,12 +27,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/internal/cli"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	subOperatorClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/brokercr"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	corev1 "k8s.io/api/core/v1"
@@ -54,10 +54,10 @@ const (
 )
 
 var gatherModuleFlags = map[string]bool{
-	components.Connectivity:     false,
-	components.ServiceDiscovery: false,
-	components.Broker:           false,
-	components.Operator:         false,
+	component.Connectivity:     false,
+	component.ServiceDiscovery: false,
+	component.Broker:           false,
+	component.Operator:         false,
 }
 
 var gatherTypeFlags = map[string]bool{
@@ -66,10 +66,10 @@ var gatherTypeFlags = map[string]bool{
 }
 
 var gatherFuncs = map[string]func(string, Info) bool{
-	components.Connectivity:     gatherConnectivity,
-	components.ServiceDiscovery: gatherDiscovery,
-	components.Broker:           gatherBroker,
-	components.Operator:         gatherOperator,
+	component.Connectivity:     gatherConnectivity,
+	component.ServiceDiscovery: gatherDiscovery,
+	component.Broker:           gatherBroker,
+	component.Operator:         gatherOperator,
 }
 
 func init() {

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -33,6 +33,7 @@ import (
 	"github.com/submariner-io/submariner-operator/internal/image"
 	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/broker"
+	"github.com/submariner-io/submariner-operator/pkg/client"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
@@ -221,6 +222,9 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 
 	checkRequirements(clientConfig)
 
+	clientProducer, err := client.NewProducerFromRestConfig(clientConfig)
+	utils.ExitOnError("Error creating client producer", err)
+
 	if subctlData.IsConnectivityEnabled() && labelGateway {
 		err := handleNodeLabels(clientConfig)
 		utils.ExitOnError("Unable to set the gateway node up", err)
@@ -264,7 +268,7 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 
 	operatorImage, err := image.ForOperator(imageVersion, repository, imageOverrideArr)
 	utils.ExitOnError("Error overriding Operator Image", err)
-	err = submarinerop.Ensure(status, clientConfig, OperatorNamespace, operatorImage, operatorDebug)
+	err = submarinerop.Ensure(status, clientProducer, OperatorNamespace, operatorImage, operatorDebug)
 	status.EndWith(cli.CheckForError(err))
 	utils.ExitOnError("Error deploying the operator", err)
 

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -36,10 +36,10 @@ import (
 	_ "github.com/submariner-io/lighthouse/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
@@ -248,8 +248,8 @@ func checkVerifyArguments() error {
 }
 
 var verifyE2EPatterns = map[string]string{
-	components.Connectivity:     "\\[dataplane",
-	components.ServiceDiscovery: "\\[discovery",
+	component.Connectivity:     "\\[dataplane",
+	component.ServiceDiscovery: "\\[discovery",
 }
 
 var verifyE2EDisruptivePatterns = map[string]string{

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/rbac"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
@@ -129,7 +130,7 @@ func newFromCluster(clientSet clientset.Interface, brokerNamespace, ipsecSubmFil
 	subctlData := &SubctlData{}
 	var err error
 
-	subctlData.ClientToken, err = rbac.GetClientTokenSecret(clientSet, brokerNamespace, broker.SubmarinerBrokerAdminSA)
+	subctlData.ClientToken, err = rbac.GetClientTokenSecret(clientSet, brokerNamespace, constants.SubmarinerBrokerAdminSA)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting broker client secret")
 	}

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -27,9 +27,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner-operator/internal/component"
 	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/rbac"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,11 +61,11 @@ func (data *SubctlData) GetComponents() stringset.Interface {
 }
 
 func (data *SubctlData) IsConnectivityEnabled() bool {
-	return data.GetComponents().Contains(components.Connectivity)
+	return data.GetComponents().Contains(component.Connectivity)
 }
 
 func (data *SubctlData) IsServiceDiscoveryEnabled() bool {
-	return data.GetComponents().Contains(components.ServiceDiscovery) || data.ServiceDiscovery
+	return data.GetComponents().Contains(component.ServiceDiscovery) || data.ServiceDiscovery
 }
 
 func (data *SubctlData) ToString() (string, error) {

--- a/pkg/subctl/datafile/datafile.go
+++ b/pkg/subctl/datafile/datafile.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/stringset"
-	"github.com/submariner-io/submariner-operator/pkg/broker"
+	"github.com/submariner-io/submariner-operator/internal/rbac"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
@@ -129,7 +129,7 @@ func newFromCluster(clientSet clientset.Interface, brokerNamespace, ipsecSubmFil
 	subctlData := &SubctlData{}
 	var err error
 
-	subctlData.ClientToken, err = broker.GetClientTokenSecret(clientSet, brokerNamespace, broker.SubmarinerBrokerAdminSA)
+	subctlData.ClientToken, err = rbac.GetClientTokenSecret(clientSet, brokerNamespace, broker.SubmarinerBrokerAdminSA)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting broker client secret")
 	}

--- a/pkg/subctl/operator/brokercr/ensure.go
+++ b/pkg/subctl/operator/brokercr/ensure.go
@@ -28,14 +28,13 @@ import (
 	submarinerClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 )
 
 const (
 	BrokerName = "submariner-broker"
 )
 
-func Ensure(config *rest.Config, namespace string, brokerSpec submariner.BrokerSpec) error {
+func Ensure(client submarinerClientset.Interface, namespace string, brokerSpec submariner.BrokerSpec) error {
 	brokerCR := &submariner.Broker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BrokerName,
@@ -44,13 +43,8 @@ func Ensure(config *rest.Config, namespace string, brokerSpec submariner.BrokerS
 		Spec: brokerSpec,
 	}
 
-	client, err := submarinerClientset.NewForConfig(config)
-	if err != nil {
-		return errors.Wrap(err, "error creating client")
-	}
-
 	// nolint:wrapcheck // No need to wrap errors here
-	_, err = util.CreateAnew(context.TODO(), &resource.InterfaceFuncs{
+	_, err := util.CreateAnew(context.TODO(), &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return client.SubmarinerV1alpha1().Brokers(namespace).Get(ctx, name, options)
 		},

--- a/pkg/subctl/operator/common/deployments/utils.go
+++ b/pkg/subctl/operator/common/deployments/utils.go
@@ -28,11 +28,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 )
 
-func WaitForReady(clientSet *clientset.Clientset, namespace, deployment string, interval, timeout time.Duration) error {
-	deployments := clientSet.AppsV1().Deployments(namespace)
+func WaitForReady(kubeClient kubernetes.Interface, namespace, deployment string, interval, timeout time.Duration) error {
+	deployments := kubeClient.AppsV1().Deployments(namespace)
 
 	// nolint:wrapcheck // No need to wrap here
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {

--- a/pkg/subctl/operator/common/namespace/ensure.go
+++ b/pkg/subctl/operator/common/namespace/ensure.go
@@ -25,20 +25,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Ensure functions updates or installs the operator CRDs in the cluster.
-func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
-	clientSet, err := clientset.NewForConfig(restConfig)
-	if err != nil {
-		return false, errors.Wrap(err, "error creating client")
-	}
-
+func Ensure(kubeClient kubernetes.Interface, namespace string) (bool, error) {
 	ns := &v1.Namespace{ObjectMeta: v1meta.ObjectMeta{Name: namespace}}
 
-	_, err = clientSet.CoreV1().Namespaces().Create(context.TODO(), ns, v1meta.CreateOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, v1meta.CreateOptions{})
 
 	if err == nil {
 		return true, nil

--- a/pkg/subctl/operator/common/scc/utils.go
+++ b/pkg/subctl/operator/common/scc/utils.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -37,12 +36,7 @@ var openshiftSCCGVR = schema.GroupVersionResource{
 	Resource: "securitycontextconstraints",
 }
 
-func UpdateSCC(restConfig *rest.Config, namespace, name string) (bool, error) {
-	dynClient, err := dynamic.NewForConfig(restConfig)
-	if err != nil {
-		return false, errors.Wrap(err, "error creating client")
-	}
-
+func UpdateSCC(dynClient dynamic.Interface, namespace, name string) (bool, error) {
 	sccClient := dynClient.Resource(openshiftSCCGVR)
 
 	created := false

--- a/pkg/subctl/operator/common/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/common/serviceaccount/ensure.go
@@ -25,12 +25,12 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Ensure creates the given service account.
 // nolint:wrapcheck // No need to wrap errors here.
-func Ensure(clientSet *clientset.Clientset, namespace, yaml string) (bool, error) {
+func Ensure(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	sa := &v1.ServiceAccount{}
 
 	err := embeddedyamls.GetObject(yaml, sa)
@@ -38,11 +38,11 @@ func Ensure(clientSet *clientset.Clientset, namespace, yaml string) (bool, error
 		return false, err
 	}
 
-	return utils.CreateOrUpdateServiceAccount(context.TODO(), clientSet, namespace, sa)
+	return utils.CreateOrUpdateServiceAccount(context.TODO(), kubeClient, namespace, sa)
 }
 
 // nolint:wrapcheck // No need to wrap errors here.
-func EnsureRole(clientSet *clientset.Clientset, namespace, yaml string) (bool, error) {
+func EnsureRole(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	role := &rbacv1.Role{}
 
 	err := embeddedyamls.GetObject(yaml, role)
@@ -50,11 +50,11 @@ func EnsureRole(clientSet *clientset.Clientset, namespace, yaml string) (bool, e
 		return false, err
 	}
 
-	return utils.CreateOrUpdateRole(context.TODO(), clientSet, namespace, role)
+	return utils.CreateOrUpdateRole(context.TODO(), kubeClient, namespace, role)
 }
 
 // nolint:wrapcheck // No need to wrap errors here.
-func EnsureRoleBinding(clientSet *clientset.Clientset, namespace, yaml string) (bool, error) {
+func EnsureRoleBinding(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	roleBinding := &rbacv1.RoleBinding{}
 
 	err := embeddedyamls.GetObject(yaml, roleBinding)
@@ -62,11 +62,11 @@ func EnsureRoleBinding(clientSet *clientset.Clientset, namespace, yaml string) (
 		return false, err
 	}
 
-	return utils.CreateOrUpdateRoleBinding(context.TODO(), clientSet, namespace, roleBinding)
+	return utils.CreateOrUpdateRoleBinding(context.TODO(), kubeClient, namespace, roleBinding)
 }
 
 // nolint:wrapcheck // No need to wrap errors here.
-func EnsureClusterRole(clientSet *clientset.Clientset, yaml string) (bool, error) {
+func EnsureClusterRole(kubeClient kubernetes.Interface, yaml string) (bool, error) {
 	clusterRole := &rbacv1.ClusterRole{}
 
 	err := embeddedyamls.GetObject(yaml, clusterRole)
@@ -74,11 +74,11 @@ func EnsureClusterRole(clientSet *clientset.Clientset, yaml string) (bool, error
 		return false, err
 	}
 
-	return utils.CreateOrUpdateClusterRole(context.TODO(), clientSet, clusterRole)
+	return utils.CreateOrUpdateClusterRole(context.TODO(), kubeClient, clusterRole)
 }
 
 // nolint:wrapcheck // No need to wrap errors here.
-func EnsureClusterRoleBinding(clientSet *clientset.Clientset, namespace, yaml string) (bool, error) {
+func EnsureClusterRoleBinding(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 
 	err := embeddedyamls.GetObject(yaml, clusterRoleBinding)
@@ -88,5 +88,5 @@ func EnsureClusterRoleBinding(clientSet *clientset.Clientset, namespace, yaml st
 
 	clusterRoleBinding.Subjects[0].Namespace = namespace
 
-	return utils.CreateOrUpdateClusterRoleBinding(context.TODO(), clientSet, clusterRoleBinding)
+	return utils.CreateOrUpdateClusterRoleBinding(context.TODO(), kubeClient, clusterRoleBinding)
 }

--- a/pkg/subctl/operator/lighthouse/ensure.go
+++ b/pkg/subctl/operator/lighthouse/ensure.go
@@ -22,17 +22,19 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/reporter"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/scc"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse/serviceaccount"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
-func Ensure(status reporter.Interface, config *rest.Config, operatorNamespace string) (bool, error) {
-	if created, err := serviceaccount.Ensure(config, operatorNamespace); err != nil {
+func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClient dynamic.Interface,
+	operatorNamespace string) (bool, error) {
+	if created, err := serviceaccount.Ensure(kubeClient, operatorNamespace); err != nil {
 		return created, err // nolint:wrapcheck // No need to wrap here
 	} else if created {
 		status.Success("Created lighthouse service account and role")
 	}
 
-	if created, err := scc.Ensure(config, operatorNamespace); err != nil {
+	if created, err := scc.Ensure(dynClient, operatorNamespace); err != nil {
 		return created, err // nolint:wrapcheck // No need to wrap here
 	} else if created {
 		status.Success("Updated the privileged SCC")

--- a/pkg/subctl/operator/lighthouse/scc/ensure.go
+++ b/pkg/subctl/operator/lighthouse/scc/ensure.go
@@ -22,10 +22,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/scc"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/dynamic"
 )
 
-func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
+func Ensure(dynClient dynamic.Interface, namespace string) (bool, error) {
 	agentSaName, err := embeddedyamls.GetObjectName(embeddedyamls.Config_rbac_lighthouse_agent_service_account_yaml)
 	if err != nil {
 		return false, errors.Wrap(err, "error parsing the agent ServiceAccount resource")
@@ -36,12 +36,12 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 		return false, errors.Wrap(err, "error parsing the coredns ServiceAccount resource")
 	}
 
-	updateAgentSCC, err := scc.UpdateSCC(restConfig, namespace, agentSaName)
+	updateAgentSCC, err := scc.UpdateSCC(dynClient, namespace, agentSaName)
 	if err != nil {
 		return false, errors.Wrap(err, "error updating the SCC resource")
 	}
 
-	updateCoreDNSSCC, err := scc.UpdateSCC(restConfig, namespace, coreDNSSaName)
+	updateCoreDNSSCC, err := scc.UpdateSCC(dynClient, namespace, coreDNSSaName)
 
 	return updateAgentSCC || updateCoreDNSSCC, errors.Wrap(err, "error updating the SCC resource")
 }

--- a/pkg/subctl/operator/submarinerop/crds/ensure.go
+++ b/pkg/subctl/operator/submarinerop/crds/ensure.go
@@ -25,16 +25,10 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	"github.com/submariner-io/submariner-operator/pkg/utils"
 	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
-	"k8s.io/client-go/rest"
 )
 
 // Ensure functions updates or installs the operator CRDs in the cluster.
-func Ensure(restConfig *rest.Config) (bool, error) {
-	crdUpdater, err := crdutils.NewFromRestConfig(restConfig)
-	if err != nil {
-		return false, errors.Wrap(err, "error creating CRDUpdater")
-	}
-
+func Ensure(crdUpdater crdutils.CRDUpdater) (bool, error) {
 	// Attempt to update or create the CRD definitions.
 	// TODO(majopela): In the future we may want to report when we have updated the existing
 	//                 CRD definition with new versions

--- a/pkg/subctl/operator/submarinerop/deployment/ensure.go
+++ b/pkg/subctl/operator/submarinerop/deployment/ensure.go
@@ -21,10 +21,10 @@ package deployment
 import (
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/operatorpod"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Ensure the operator is deployed, and running.
-func Ensure(restConfig *rest.Config, namespace, image string, debug bool) (bool, error) {
-	return operatorpod.Ensure(restConfig, namespace, names.OperatorComponent, image, debug) // nolint:wrapcheck // No need to wrap here
+func Ensure(kubeClient kubernetes.Interface, namespace, image string, debug bool) (bool, error) {
+	return operatorpod.Ensure(kubeClient, namespace, names.OperatorComponent, image, debug) // nolint:wrapcheck // No need to wrap here
 }

--- a/pkg/subctl/operator/submarinerop/ensure.go
+++ b/pkg/subctl/operator/submarinerop/ensure.go
@@ -19,6 +19,7 @@ limitations under the License.
 package submarinerop
 
 import (
+	"github.com/submariner-io/submariner-operator/pkg/client"
 	"github.com/submariner-io/submariner-operator/pkg/reporter"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/namespace"
 	lighthouseop "github.com/submariner-io/submariner-operator/pkg/subctl/operator/lighthouse"
@@ -27,44 +28,42 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/scc"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinerop/serviceaccount"
 	crdutils "github.com/submariner-io/submariner-operator/pkg/utils/crds"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 )
 
 // nolint:wrapcheck // No need to wrap errors here.
-func Ensure(status reporter.Interface, crdUpdater crdutils.CRDUpdater, kubeClient kubernetes.Interface, dynClient dynamic.Interface,
-	operatorNamespace, operatorImage string, debug bool) error {
-	if created, err := crds.Ensure(crdUpdater); err != nil {
+func Ensure(status reporter.Interface, clientProducer client.Producer, operatorNamespace, operatorImage string, debug bool) error {
+	if created, err := crds.Ensure(crdutils.NewFromClientSet(clientProducer.ForCRD())); err != nil {
 		return err
 	} else if created {
 		status.Success("Created operator CRDs")
 	}
 
-	if created, err := namespace.Ensure(kubeClient, operatorNamespace); err != nil {
+	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace); err != nil {
 		return err
 	} else if created {
 		status.Success("Created operator namespace: %s", operatorNamespace)
 	}
 
-	if created, err := serviceaccount.Ensure(kubeClient, operatorNamespace); err != nil {
+	if created, err := serviceaccount.Ensure(clientProducer.ForKubernetes(), operatorNamespace); err != nil {
 		return err
 	} else if created {
 		status.Success("Created operator service account and role")
 	}
 
-	if created, err := scc.Ensure(dynClient, operatorNamespace); err != nil {
+	if created, err := scc.Ensure(clientProducer.ForDynamic(), operatorNamespace); err != nil {
 		return err
 	} else if created {
 		status.Success("Updated the privileged SCC")
 	}
 
-	if created, err := lighthouseop.Ensure(status, kubeClient, dynClient, operatorNamespace); err != nil {
+	if created, err := lighthouseop.Ensure(status, clientProducer.ForKubernetes(), clientProducer.ForDynamic(),
+		operatorNamespace); err != nil {
 		return err
 	} else if created {
 		status.Success("Created Lighthouse service accounts and roles")
 	}
 
-	if created, err := deployment.Ensure(kubeClient, operatorNamespace, operatorImage, debug); err != nil {
+	if created, err := deployment.Ensure(clientProducer.ForKubernetes(), operatorNamespace, operatorImage, debug); err != nil {
 		return err
 	} else if created {
 		status.Success("Deployed the operator successfully")

--- a/pkg/subctl/operator/submarinerop/scc/ensure.go
+++ b/pkg/subctl/operator/submarinerop/scc/ensure.go
@@ -22,10 +22,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/embeddedyamls"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/common/scc"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/dynamic"
 )
 
-func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
+func Ensure(dynClient dynamic.Interface, namespace string) (bool, error) {
 	operatorSaName, err := embeddedyamls.GetObjectName(embeddedyamls.Config_rbac_submariner_operator_service_account_yaml)
 	if err != nil {
 		return false, errors.Wrap(err, "error parsing the operator ServiceAccount resource")
@@ -51,27 +51,27 @@ func Ensure(restConfig *rest.Config, namespace string) (bool, error) {
 		return false, errors.Wrap(err, "error parsing the networkplugin syncer ServiceAccount resource")
 	}
 
-	updateOperatorSCC, err := scc.UpdateSCC(restConfig, namespace, operatorSaName)
+	updateOperatorSCC, err := scc.UpdateSCC(dynClient, namespace, operatorSaName)
 	if err != nil {
 		return false, errors.Wrap(err, "error updating the SCC resource")
 	}
 
-	updateGatewaySCC, err := scc.UpdateSCC(restConfig, namespace, gatewaySaName)
+	updateGatewaySCC, err := scc.UpdateSCC(dynClient, namespace, gatewaySaName)
 	if err != nil {
 		return false, errors.Wrap(err, "error updating the SCC resource")
 	}
 
-	updateRouteAgentSCC, err := scc.UpdateSCC(restConfig, namespace, routeAgentSaName)
+	updateRouteAgentSCC, err := scc.UpdateSCC(dynClient, namespace, routeAgentSaName)
 	if err != nil {
 		return false, errors.Wrap(err, "error updating the SCC resource")
 	}
 
-	updateGlobalnetSCC, err := scc.UpdateSCC(restConfig, namespace, globalnetSaName)
+	updateGlobalnetSCC, err := scc.UpdateSCC(dynClient, namespace, globalnetSaName)
 	if err != nil {
 		return false, errors.Wrap(err, "error updating the SCC resource")
 	}
 
-	updateNPSyncerSCC, err := scc.UpdateSCC(restConfig, namespace, npSyncerSaName)
+	updateNPSyncerSCC, err := scc.UpdateSCC(dynClient, namespace, npSyncerSaName)
 
 	return updateOperatorSCC || updateGatewaySCC || updateRouteAgentSCC || updateGlobalnetSCC || updateNPSyncerSCC,
 		errors.Wrap(err, "error updating the SCC resource")


### PR DESCRIPTION
This requires changing the underlying `Ensure` functions to take client interfaces instead of `rest.Config` and moving other components under _pkg/internal_.  See individual commits for details.

Depends on #1705