### PR TITLE
Avoid redacting with the empty string

### DIFF
--- a/pkg/subctl/cmd/gather/resource.go
+++ b/pkg/subctl/cmd/gather/resource.go
@@ -126,14 +126,14 @@ func scrubSensitiveData(info *Info, dataString string) string {
 	}
 
 	if info.Submariner != nil {
-		dataString = strings.ReplaceAll(dataString, info.Submariner.Spec.BrokerK8sApiServer, "##redacted-api-server##")
-		dataString = strings.ReplaceAll(dataString, info.Submariner.Spec.BrokerK8sApiServerToken, "##redacted-token##")
-		dataString = strings.ReplaceAll(dataString, info.Submariner.Spec.BrokerK8sCA, "##redacted-ca##")
-		dataString = strings.ReplaceAll(dataString, info.Submariner.Spec.CeIPSecPSK, "##redacted-ipsec-psk##")
+		dataString = replaceIfNotEmpty(dataString, info.Submariner.Spec.BrokerK8sApiServer, "##redacted-api-server##")
+		dataString = replaceIfNotEmpty(dataString, info.Submariner.Spec.BrokerK8sApiServerToken, "##redacted-token##")
+		dataString = replaceIfNotEmpty(dataString, info.Submariner.Spec.BrokerK8sCA, "##redacted-ca##")
+		dataString = replaceIfNotEmpty(dataString, info.Submariner.Spec.CeIPSecPSK, "##redacted-ipsec-psk##")
 	} else if info.ServiceDiscovery != nil {
-		dataString = strings.ReplaceAll(dataString, info.ServiceDiscovery.Spec.BrokerK8sApiServer, "##redacted-api-server##")
-		dataString = strings.ReplaceAll(dataString, info.ServiceDiscovery.Spec.BrokerK8sApiServerToken, "##redacted-token##")
-		dataString = strings.ReplaceAll(dataString, info.ServiceDiscovery.Spec.BrokerK8sCA, "##redacted-ca##")
+		dataString = replaceIfNotEmpty(dataString, info.ServiceDiscovery.Spec.BrokerK8sApiServer, "##redacted-api-server##")
+		dataString = replaceIfNotEmpty(dataString, info.ServiceDiscovery.Spec.BrokerK8sApiServerToken, "##redacted-token##")
+		dataString = replaceIfNotEmpty(dataString, info.ServiceDiscovery.Spec.BrokerK8sCA, "##redacted-ca##")
 	}
 
 	return dataString
@@ -141,4 +141,12 @@ func scrubSensitiveData(info *Info, dataString string) string {
 
 func escapeFileName(s string) string {
 	return fileNameRegexp.ReplaceAllString(s, "_")
+}
+
+func replaceIfNotEmpty(s, old, replacement string) string {
+	if old == "" {
+		return s
+	}
+
+	return strings.ReplaceAll(s, old, replacement)
 }


### PR DESCRIPTION
As our token and PSK handling evolves, stored values can end up being
empty; attempting to redact logs when a value to be redacted is empty
replaces between every UTF-8 sequence (see
<https://pkg.go.dev/strings#ReplaceAll>). To avoid this, refrain from
redacting if the relevant value is empty.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
