### PR TITLE
Avoid crashing when ContainerStatus.Started is nil

### DIFF
--- a/controllers/submariner/daemonsets.go
+++ b/controllers/submariner/daemonsets.go
@@ -61,15 +61,16 @@ func (r *SubmarinerReconciler) checkDaemonSetContainers(ctx context.Context, dae
 	var mismatchedContainerImages = false
 	var nonReadyContainerStates = []corev1.ContainerState{}
 	for i := range *containerStatuses {
+		containerStatus := (*containerStatuses)[i]
 		if containerImageManifest == nil {
-			containerImageManifest = &((*containerStatuses)[i].ImageID)
-		} else if *containerImageManifest != (*containerStatuses)[i].ImageID {
+			containerImageManifest = &(containerStatus.ImageID)
+		} else if *containerImageManifest != containerStatus.ImageID {
 			// Container mismatch
 			mismatchedContainerImages = true
 		}
-		if !*(*containerStatuses)[i].Started {
+		if containerStatus.Started == nil || !*containerStatus.Started {
 			// Not (yet) ready
-			nonReadyContainerStates = append(nonReadyContainerStates, (*containerStatuses)[i].State)
+			nonReadyContainerStates = append(nonReadyContainerStates, containerStatus.State)
 		}
 	}
 	return mismatchedContainerImages, &nonReadyContainerStates, nil


### PR DESCRIPTION
Fixes: #1656
Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 9c1bff0bdda5ce70353036b8f775551f74c38e61)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
