### PR TITLE
Backport: Fix invalid GlobalCidrRange when globalnet disabled (#1669)

### DIFF
--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -407,7 +407,7 @@ func ValidateExistingGlobalNetworks(config *rest.Config, namespace string) error
 		return fmt.Errorf("error getting existing globalnet configmap: %s", err)
 	}
 
-	if globalnetInfo != nil {
+	if globalnetInfo != nil && globalnetInfo.GlobalnetEnabled {
 		if err = IsValidCIDR(globalnetInfo.GlobalnetCidrRange); err != nil {
 			return fmt.Errorf("invalid GlobalnetCidrRange: %s", err)
 		}


### PR DESCRIPTION
* fix invalid globalcidrrange when globalnet disabled

Signed-off-by: jinglinax@163.com <jinglinax@163.com>
(cherry picked from commit e40739bdda7a3b70f1d29b79f672689c2dbe781c)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
