### PR TITLE
Rename clients from submariner and operator repo

### DIFF
--- a/pkg/client/default_producer.go
+++ b/pkg/client/default_producer.go
@@ -19,7 +19,8 @@ limitations under the License.
 package client
 
 import (
-	submarinerclient "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	operatorclient "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	submarinerclient "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -29,6 +30,7 @@ type DefaultProducer struct {
 	CRDClient        apiextclient.Interface
 	KubeClient       kubernetes.Interface
 	DynamicClient    dynamic.Interface
+	OperatorClient   operatorclient.Interface
 	SubmarinerClient submarinerclient.Interface
 }
 
@@ -46,4 +48,8 @@ func (p *DefaultProducer) ForDynamic() dynamic.Interface {
 
 func (p *DefaultProducer) ForSubmariner() submarinerclient.Interface {
 	return p.SubmarinerClient
+}
+
+func (p *DefaultProducer) ForOperator() operatorclient.Interface {
+	return p.OperatorClient
 }

--- a/pkg/client/producer.go
+++ b/pkg/client/producer.go
@@ -19,7 +19,8 @@ limitations under the License.
 package client
 
 import (
-	submarinerClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	operatorClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	apiextClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -31,6 +32,8 @@ type Producer interface {
 	ForKubernetes() kubernetes.Interface
 
 	ForDynamic() dynamic.Interface
+
+	ForOperator() operatorClientset.Interface
 
 	ForSubmariner() submarinerClientset.Interface
 }

--- a/pkg/client/restconfig_producer.go
+++ b/pkg/client/restconfig_producer.go
@@ -20,7 +20,8 @@ package client
 
 import (
 	"github.com/pkg/errors"
-	submarinerClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	operatorClientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	apiextClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -39,6 +40,11 @@ func NewProducerFromRestConfig(config *rest.Config) (Producer, error) {
 	p.DynamicClient, err = dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating dynamic client")
+	}
+
+	p.OperatorClient, err = operatorClientset.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating operator client")
 	}
 
 	p.SubmarinerClient, err = submarinerClientset.NewForConfig(config)

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -108,7 +108,7 @@ func deploy(options *BrokerOptions, status reporter.Interface, clientProducer cl
 
 	status.Start("Deploying the broker")
 
-	err = brokercr.Ensure(clientProducer.ForSubmariner(), options.BrokerNamespace, options.BrokerSpec)
+	err = brokercr.Ensure(clientProducer.ForOperator(), options.BrokerNamespace, options.BrokerSpec)
 	if err != nil {
 		return status.Error(err, "Broker deployment failed")
 	}

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -129,7 +129,7 @@ var deployBroker = &cobra.Command{
 		utils.ExitOnError("Error deploying the operator", err)
 
 		status.Start("Deploying the broker")
-		err = brokercr.Ensure(clientProducer.ForSubmariner(), brokerNamespace, populateBrokerSpec())
+		err = brokercr.Ensure(clientProducer.ForOperator(), brokerNamespace, populateBrokerSpec())
 		if err == nil {
 			status.QueueSuccessMessage("The broker has been deployed")
 			status.EndWith(cli.Success)


### PR DESCRIPTION
Client from operator repo is renamed to `operatorclient`
and the one from Submariner repo is `submarinerclient`

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
