### PR TITLE
Don't run some GHAs on drafts

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -3,10 +3,12 @@ name: Cross-Build Checks
 
 on:
   pull_request:
+    types: [ready_for_review, opened, edited, reopened, synchronize, converted_to_draft, labeled]
 
 jobs:
   cross:
     name: Cross-Build
+    if: github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test-draft')
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,10 +3,12 @@ name: End to End Default
 
 on:
   pull_request:
+    types: [ready_for_review, opened, edited, reopened, synchronize, converted_to_draft, labeled]
 
 jobs:
   e2e:
     name: E2E
+    if: github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test-draft')
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -3,10 +3,12 @@ name: Upgrade
 
 on:
   pull_request:
+    types: [ready_for_review, opened, edited, reopened, synchronize, converted_to_draft, labeled]
 
 jobs:
   upgrade-e2e:
     name: Latest Release to Latest Version
+    if: github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test-draft')
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
1. This PR enables skipping default e2e, cross builds and
upgrade GHA on PRs marked as draft.
2. When marked ready_for_review, these GHA will run on the PRs.
3. GHA will run if the draft PR has a label `test-draft`

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
