### PR TITLE
Sync the broker secret from the broker

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -21,10 +21,17 @@ package submariner
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/federate"
+	level "github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer"
+	"github.com/submariner-io/admiral/pkg/util"
 	submopv1a1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/broker"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
@@ -35,6 +42,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
@@ -70,6 +78,24 @@ type Config struct {
 type Reconciler struct {
 	config Config
 	log    logr.Logger
+
+	// We need to synchronize changes to the SA used to connect to the broker ("cluster-" + clusterID, see pkg/broker/rbac.go
+	// and broker.ClusterSAName()), of two kinds:
+	// - changes to the token in the secret used by the SA;
+	// - changes to the SA itself.
+	// The secrets are communicated to the pods which need them by mounting them. This ensures that changes to the secret
+	// itself get propagated to any running pods, and picked up by client-go. It implies however that the secret itself
+	// can't be swapped out at runtime; so pods mount a constant secret, whose name is given to them in an environment
+	// variable (see Admiral), and is specified in the Submariner CR.
+	// So we need to:
+	// - watch for changes to the SA, and if the secret name changes (as happens if it's deleted), update the target secret
+	//   using the information from the new secret;
+	// - watch for changes to the secret, and if it changes, update the target secret.
+	// Tokens map back to their SA, so we can do both the above by watching tokens only.
+	// Since the synchronisation ends up being specific to a Submariner CR secret, we track one syncer per Submariner CR secret name.
+	// We don't keep track of the secret syncers themselves, just their cancel functions.
+	secretSyncCancelFuncs map[string]context.CancelFunc
+	syncerMutex           sync.Mutex
 }
 
 // blank assignment to verify that Reconciler implements reconcile.Reconciler.
@@ -78,8 +104,9 @@ var _ reconcile.Reconciler = &Reconciler{}
 // NewReconciler returns a new Reconciler.
 func NewReconciler(config *Config) *Reconciler {
 	return &Reconciler{
-		config: *config,
-		log:    ctrl.Log.WithName("controllers").WithName("Submariner"),
+		config:                *config,
+		log:                   ctrl.Log.WithName("controllers").WithName("Submariner"),
+		secretSyncCancelFuncs: make(map[string]context.CancelFunc),
 	}
 }
 
@@ -112,8 +139,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if instance.ObjectMeta.DeletionTimestamp != nil {
-		// Graceful deletion has been requested, ignore the object
+		// Graceful deletion has been requested, ignore the object after cancelling any secret syncer
+		r.cancelSecretSyncer(instance)
 		return reconcile.Result{}, nil
+	}
+
+	// Ensure we have a secret syncer
+	if err := r.setupSecretSyncer(instance, reqLogger, request.Namespace); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	initialStatus := instance.Status.DeepCopy()
@@ -259,4 +292,89 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.DaemonSet{}).
 		Watches(&source.Kind{Type: &submv1.Gateway{}}, handler.EnqueueRequestsFromMapFunc(mapFn)).
 		Complete(r)
+}
+
+func (r *Reconciler) setupSecretSyncer(instance *submopv1a1.Submariner, logger logr.Logger, namespace string) error {
+	r.syncerMutex.Lock()
+	defer r.syncerMutex.Unlock()
+
+	if instance.Spec.BrokerK8sSecret != "" {
+		if _, ok := r.secretSyncCancelFuncs[instance.Spec.BrokerK8sSecret]; !ok {
+			_, gvr, err := util.ToUnstructuredResource(&corev1.Secret{}, r.config.Client.RESTMapper())
+			if err != nil {
+				return errors.Wrap(err, "error calculating the GVR for the Secret type")
+			}
+			// We can't use files here, we don't have a mounted secret
+			brokerConfig, _, err := resource.GetAuthorizedRestConfigFromData(
+				instance.Spec.BrokerK8sApiServer,
+				instance.Spec.BrokerK8sApiServerToken, // TODO Read the secret
+				instance.Spec.BrokerK8sCA,
+				&rest.TLSClientConfig{Insecure: instance.Spec.BrokerK8sInsecure},
+				*gvr,
+				instance.Spec.BrokerK8sRemoteNamespace)
+			if err != nil {
+				return errors.Wrap(err, "error building an authorized RestConfig for the broker")
+			}
+
+			brokerClient, err := dynamic.NewForConfig(brokerConfig)
+			if err != nil {
+				return errors.Wrap(err, "error building a dynamic client for the broker")
+			}
+
+			secretSyncer, err := syncer.NewResourceSyncer(
+				&syncer.ResourceSyncerConfig{
+					Name:            "Broker secret syncer",
+					ResourceType:    &corev1.Secret{},
+					SourceClient:    brokerClient,
+					SourceNamespace: instance.Spec.BrokerK8sRemoteNamespace,
+					Direction:       syncer.None,
+					RestMapper:      r.config.Client.RESTMapper(),
+					Scheme:          r.config.Scheme,
+					Federator: federate.NewCreateOrUpdateFederator(
+						r.config.DynClient, r.config.Client.RESTMapper(), namespace, ""),
+					Transform: func(from runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
+						secret := from.(*corev1.Secret)
+						logger.V(level.TRACE).Info("Transforming secret", "secret", secret)
+						if saName, ok := secret.ObjectMeta.Annotations["kubernetes.io/service-account.name"]; ok &&
+							saName == broker.ClusterSAName(instance.Spec.ClusterID) {
+							transformedSecret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: instance.Spec.BrokerK8sSecret,
+								},
+								Type: corev1.SecretTypeOpaque,
+								Data: secret.Data,
+							}
+							logger.V(level.TRACE).Info("Transformed secret", "transformedSecret", transformedSecret)
+							return transformedSecret, false
+						}
+						return nil, false
+					},
+				})
+			if err != nil {
+				return errors.Wrap(err, "error building a resource syncer for secrets")
+			}
+
+			ctx, cancelFunc := context.WithCancel(context.TODO())
+			if err := secretSyncer.Start(ctx.Done()); err != nil {
+				cancelFunc()
+				return errors.Wrap(err, "error starting the secret syncer")
+			}
+
+			r.secretSyncCancelFuncs[instance.Spec.BrokerK8sSecret] = cancelFunc
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) cancelSecretSyncer(instance *submopv1a1.Submariner) {
+	r.syncerMutex.Lock()
+	defer r.syncerMutex.Unlock()
+
+	if instance.Spec.BrokerK8sSecret != "" {
+		if cancelFunc, ok := r.secretSyncCancelFuncs[instance.Spec.BrokerK8sSecret]; ok {
+			cancelFunc()
+			delete(r.secretSyncCancelFuncs, instance.Spec.BrokerK8sSecret)
+		}
+	}
 }

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -21,7 +21,6 @@ package broker
 import (
 	"context"
 	goerrors "errors"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -109,7 +108,7 @@ func createBrokerClusterRoleAndDefaultSA(kubeClient kubernetes.Interface, namesp
 
 // CreateSAForCluster creates a new SA, and binds it to the submariner cluster role.
 func CreateSAForCluster(kubeClient kubernetes.Interface, clusterID, namespace string) (*v1.Secret, error) {
-	saName := fmt.Sprintf(submarinerBrokerClusterSAFmt, clusterID)
+	saName := ClusterSAName(clusterID)
 
 	_, err := CreateNewBrokerSA(kubeClient, saName, namespace)
 	if err != nil && !apierrors.IsAlreadyExists(err) {

--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -33,6 +33,10 @@ const (
 	submarinerBrokerClusterDefaultSA = "submariner-k8s-broker-client" // for backwards compatibility with documentation
 )
 
+func ClusterSAName(clusterID string) string {
+	return fmt.Sprintf(submarinerBrokerClusterSAFmt, clusterID)
+}
+
 func NewBrokerSA(submarinerBrokerSA string) *v1.ServiceAccount {
 	sa := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -100,6 +104,11 @@ func NewBrokerClusterRole() *rbacv1.Role {
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update", "delete"},
 				APIGroups: []string{"discovery.k8s.io"},
 				Resources: []string{"endpointslices", "endpointslices/restricted"},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
 			},
 		},
 	}


### PR DESCRIPTION
This ensures that the broker secret, used to access the broker, is
kept up-to-date with token updates and secret changes in the service
account.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
