### PR TITLE
Determine the real "from version" for bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ else
 BUNDLE_VERSION := $(shell (git describe --abbrev=0 --tags --match=v[0-9]*\.[0-9]*\.[0-9]* 2>/dev/null || echo v9.9.9) \
 | cut -d'-' -f1 | cut -c2-)
 endif
-FROM_VERSION ?= $(shell (git tag -l --sort=-v:refname v[0-9]*\.[0-9]*\.[0-9]* | grep -v ${BUNDLE_VERSION} 2>/dev/null || echo v0.0.0) \
+FROM_VERSION ?= $(shell (git tag -l --sort=-v:refname v[0-9]*\.[0-9]*\.[0-9]* | awk '/^$(BUNDLE_VERSION)$$/ { seen = 1; next } seen { print; exit } END { exit !seen }' || echo v0.0.0) \
           | head -n1 | cut -d'-' -f1 | cut -c2-)
 SHORT_VERSION := $(shell echo ${BUNDLE_VERSION} | cut -d'.' -f1,2)
 CHANNEL ?= alpha-$(SHORT_VERSION)


### PR DESCRIPTION
Currently, the "from version" for bundles is determined by listing all
the tags in the repository, sorting them in reverse order, excluding
the current version, and picking the first tag left over. This works
on devel, but fails in any release branch since there will be tags
newer than the release tag.

Instead, list all the tags, sort them in reverse order, look for the
current tag, and output the tag after that, which will be the previous
tag in the current release branch.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
