### PR TITLE
Avoid running tests on every PR edit

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -3,7 +3,7 @@ name: Cross-Build Checks
 
 on:
   pull_request:
-    types: [ready_for_review, opened, edited, reopened, synchronize, converted_to_draft, labeled]
+    types: [ready_for_review, opened, reopened, synchronize, converted_to_draft, labeled]
 
 jobs:
   cross:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ name: End to End Default
 
 on:
   pull_request:
-    types: [ready_for_review, opened, edited, reopened, synchronize, converted_to_draft, labeled]
+    types: [ready_for_review, opened, reopened, synchronize, converted_to_draft, labeled]
 
 jobs:
   e2e:

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -3,7 +3,7 @@ name: Upgrade
 
 on:
   pull_request:
-    types: [ready_for_review, opened, edited, reopened, synchronize, converted_to_draft, labeled]
+    types: [ready_for_review, opened, reopened, synchronize, converted_to_draft, labeled]
 
 jobs:
   upgrade-e2e:


### PR DESCRIPTION
Using the "edited" type for pull request filters causes the
corresponding jobs to run on every PR edit, which isn't desirable.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
