### PR TITLE
Refactor benchmark cmd

### DIFF
--- a/.github/workflows/e2e-new-subctl.yml
+++ b/.github/workflows/e2e-new-subctl.yml
@@ -46,3 +46,13 @@ jobs:
             --servicecidr 100.1.0.0/16 --clustercidr 10.1.0.0/16
           cmd/bin/subctl join --kubeconfig output/kubeconfigs/kind-config-cluster2 broker-info.subm --clusterid cluster2 --natt=false \
             --servicecidr 100.2.0.0/16 --clustercidr 10.2.0.0/16
+
+      - name: Test benchmark
+        run: |
+          cmd/bin/subctl benchmark latency --kubeconfig output/kubeconfigs/kind-config-cluster1:output/kubeconfigs/kind-config-cluster2 \
+          	--kubecontexts cluster1,cluster2 --verbose
+          cmd/bin/subctl benchmark latency --kubeconfig output/kubeconfigs/kind-config-cluster1 --kubecontexts cluster1 --intra-cluster
+          cmd/bin/subctl benchmark throughput --kubeconfig output/kubeconfigs/kind-config-cluster1:output/kubeconfigs/kind-config-cluster2 \
+          	--kubecontexts cluster1,cluster2
+          cmd/bin/subctl benchmark throughput --kubeconfig output/kubeconfigs/kind-config-cluster1 --kubecontexts cluster1 \
+            --intra-cluster --verbose

--- a/cmd/subctl/benchmark.go
+++ b/cmd/subctl/benchmark.go
@@ -1,0 +1,142 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subctl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/submariner-operator/internal/benchmark"
+	"github.com/submariner-io/submariner-operator/internal/constants"
+	"github.com/submariner-io/submariner-operator/internal/exit"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
+)
+
+const (
+	operationTimeout                = 240
+	connectionTimeout               = 60
+	connectionAttempts              = 2
+	reportDirectory                 = "."
+	verboseConnectivityVerification = false
+)
+
+var (
+	intraCluster bool
+	verbose      bool
+
+	benchmarkCmd = &cobra.Command{
+		Use:   "benchmark",
+		Short: "Benchmark tests",
+		Long:  "This command runs various benchmark tests",
+	}
+	benchmarkThroughputCmd = &cobra.Command{
+		Use:   "throughput --kubecontexts <kubeContext1>[,<kubeContext2>]",
+		Short: "Benchmark throughput",
+		Long:  "This command runs throughput tests within a cluster or between two clusters",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return checkBenchmarkArguments(args, intraCluster)
+		},
+		Run: func(command *cobra.Command, args []string) {
+			err := setUpTestFramework(args, restConfigProducer)
+			exit.OnErrorWithMessage(err, "error setting up test framework")
+			benchmark.StartThroughputTests(intraCluster, verbose)
+		},
+	}
+	benchmarkLatencyCmd = &cobra.Command{
+		Use:   "latency --kubecontexts <kubeContext1>[,<kubeContext2>]",
+		Short: "Benchmark latency",
+		Long:  "This command runs latency benchmark tests within a cluster or between two clusters",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return checkBenchmarkArguments(args, intraCluster)
+		},
+		Run: func(command *cobra.Command, args []string) {
+			err := setUpTestFramework(args, restConfigProducer)
+			exit.OnErrorWithMessage(err, "error setting up test framework")
+			benchmark.StartLatencyTests(intraCluster, verbose)
+		},
+	}
+)
+
+func init() {
+	addBenchmarkFlags(benchmarkLatencyCmd)
+	addBenchmarkFlags(benchmarkThroughputCmd)
+
+	benchmarkCmd.AddCommand(benchmarkThroughputCmd)
+	benchmarkCmd.AddCommand(benchmarkLatencyCmd)
+	rootCmd.AddCommand(benchmarkCmd)
+
+	framework.AddBeforeSuite(detectGlobalnet)
+}
+
+func addBenchmarkFlags(cmd *cobra.Command) {
+	restConfigProducer.AddKubeContextMultiFlag(cmd, "comma-separated list of one or two kubeconfig contexts to use.")
+	cmd.PersistentFlags().BoolVar(&intraCluster, "intra-cluster", false, "run the test within a single cluster")
+	cmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "produce verbose logs during benchmark tests")
+}
+
+func checkBenchmarkArguments(args []string, intraCluster bool) error {
+	if !intraCluster && len(args) != 2 && restConfigProducer.CountRequestedClusters() != 2 {
+		return fmt.Errorf("two kubecontexts must be specified")
+	} else if intraCluster && len(args) != 1 && restConfigProducer.CountRequestedClusters() != 1 {
+		return fmt.Errorf("only one kubecontext should be specified")
+	}
+
+	if len(args) == 2 {
+		if strings.Compare(args[0], args[1]) == 0 {
+			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> cannot be the same file")
+		}
+
+		same, err := compareFiles(args[0], args[1])
+		if err != nil {
+			return err
+		}
+
+		if same {
+			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> need to have a unique content")
+		}
+	}
+
+	return nil
+}
+
+func setUpTestFramework(args []string, restConfigProducer restconfig.Producer) error {
+	if len(args) > 0 {
+		err := restconfig.ConfigureTestFramework(args)
+		if err != nil {
+			return err //nolint:wrapcheck // error can't be wrapped
+		}
+	} else {
+		restConfigProducer.PopulateTestFramework()
+	}
+
+	framework.TestContext.OperationTimeout = operationTimeout
+	framework.TestContext.ConnectionTimeout = connectionTimeout
+	framework.TestContext.ConnectionAttempts = connectionAttempts
+	framework.TestContext.ReportDir = reportDirectory
+	framework.TestContext.ReportPrefix = "subctl"
+	framework.TestContext.SubmarinerNamespace = constants.SubmarinerNamespace
+
+	config.DefaultReporterConfig.Verbose = verboseConnectivityVerification
+	config.DefaultReporterConfig.SlowSpecThreshold = 60
+
+	return nil
+}

--- a/internal/benchmark/latency.go
+++ b/internal/benchmark/latency.go
@@ -1,0 +1,144 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type benchmarkTestParams struct {
+	ClientCluster       framework.ClusterIndex
+	ServerCluster       framework.ClusterIndex
+	ServerPodScheduling framework.NetworkPodScheduling
+	ClientPodScheduling framework.NetworkPodScheduling
+}
+
+func StartLatencyTests(intraCluster, verbose bool) {
+	var f *framework.Framework
+
+	if verbose {
+		fmt.Printf("Performing latency tests\n")
+	}
+
+	gomega.RegisterFailHandler(func(message string, callerSkip ...int) {
+		if f != nil {
+			cleanupFramework(f)
+		} else {
+			framework.RunCleanupActions()
+		}
+		panic(message)
+	})
+
+	f = initFramework("latency", verbose)
+
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+
+	if !intraCluster {
+		clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+		if framework.TestContext.GlobalnetEnabled {
+			fmt.Println("Latency test is not supported with Globalnet enabled, skipping the test...")
+			cleanupFramework(f)
+
+			return
+		}
+
+		latencyTestParams := benchmarkTestParams{
+			ClientCluster:       framework.ClusterA,
+			ServerCluster:       framework.ClusterB,
+			ServerPodScheduling: framework.GatewayNode,
+			ClientPodScheduling: framework.GatewayNode,
+		}
+
+		fmt.Printf("Performing latency tests from Gateway pod on cluster %q to Gateway pod on cluster %q\n",
+			clusterAName, clusterBName)
+		runLatencyTest(f, latencyTestParams, verbose)
+
+		latencyTestParams.ServerPodScheduling = framework.NonGatewayNode
+		latencyTestParams.ClientPodScheduling = framework.NonGatewayNode
+
+		fmt.Printf("Performing latency tests from Non-Gateway pod on cluster %q to Non-Gateway pod on cluster %q\n",
+			clusterAName, clusterBName)
+		runLatencyTest(f, latencyTestParams, verbose)
+	} else {
+		latencyTestIntraClusterParams := benchmarkTestParams{
+			ClientCluster:       framework.ClusterA,
+			ServerCluster:       framework.ClusterA,
+			ServerPodScheduling: framework.GatewayNode,
+			ClientPodScheduling: framework.NonGatewayNode,
+		}
+		fmt.Printf("Performing latency tests from Non-Gateway pod to Gateway pod on cluster %q\n", clusterAName)
+		runLatencyTest(f, latencyTestIntraClusterParams, verbose)
+	}
+
+	cleanupFramework(f)
+}
+
+func runLatencyTest(f *framework.Framework, testParams benchmarkTestParams, verbose bool) {
+	clusterAName := framework.TestContext.ClusterIDs[testParams.ClientCluster]
+	clusterBName := framework.TestContext.ClusterIDs[testParams.ServerCluster]
+	var connectionTimeout uint = 5
+	var connectionAttempts uint = 1
+
+	framework.By(fmt.Sprintf("Creating a Nettest Server Pod on %q", clusterBName))
+
+	nettestServerPod := f.NewNetworkPod(&framework.NetworkPodConfig{
+		Type:               framework.LatencyServerPod,
+		Cluster:            testParams.ServerCluster,
+		Scheduling:         testParams.ServerPodScheduling,
+		ConnectionTimeout:  connectionTimeout,
+		ConnectionAttempts: connectionAttempts,
+	})
+
+	podsClusterB := framework.KubeClients[testParams.ServerCluster].CoreV1().Pods(f.Namespace)
+	p1, _ := podsClusterB.Get(context.TODO(), nettestServerPod.Pod.Name, metav1.GetOptions{})
+	framework.By(fmt.Sprintf("Nettest Server Pod %q was created on node %q", nettestServerPod.Pod.Name, nettestServerPod.Pod.Spec.NodeName))
+
+	remoteIP := p1.Status.PodIP
+
+	nettestClientPod := f.NewNetworkPod(&framework.NetworkPodConfig{
+		Type:               framework.LatencyClientPod,
+		Cluster:            testParams.ClientCluster,
+		Scheduling:         testParams.ClientPodScheduling,
+		RemoteIP:           remoteIP,
+		ConnectionTimeout:  connectionTimeout,
+		ConnectionAttempts: connectionAttempts,
+	})
+
+	framework.By(fmt.Sprintf("Nettest Client Pod %q was created on cluster %q, node %q; connect to server pod ip %q",
+		nettestClientPod.Pod.Name, clusterAName, nettestClientPod.Pod.Spec.NodeName, remoteIP))
+
+	framework.By(fmt.Sprintf("Waiting for the client pod %q to exit, returning what client sent", nettestClientPod.Pod.Name))
+	nettestClientPod.AwaitFinishVerbose(verbose)
+	nettestClientPod.CheckSuccessfulFinish()
+	latencyHeaders := strings.Split(nettestClientPod.TerminationMessage, "\n")[1]
+	headers := strings.Split(latencyHeaders, ",")
+	latencyValues := strings.Split(nettestClientPod.TerminationMessage, "\n")[2]
+	values := strings.Split(latencyValues, ",")
+
+	for i, v := range headers {
+		fmt.Printf("%s:\t%s\n", v, values[i])
+	}
+}

--- a/internal/benchmark/throughput.go
+++ b/internal/benchmark/throughput.go
@@ -1,0 +1,177 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package benchmark is under /internal at the moment because it depends a lot on
+// shipyard test Framework which uses a lot of globals and isn't concurrency-safe.
+package benchmark
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/gomega"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func StartThroughputTests(intraCluster, verbose bool) {
+	var f *framework.Framework
+
+	if verbose {
+		fmt.Printf("Performing throughput tests\n")
+	}
+
+	gomega.RegisterFailHandler(func(message string, callerSkip ...int) {
+		if f != nil {
+			cleanupFramework(f)
+		} else {
+			framework.RunCleanupActions()
+		}
+		panic(message)
+	})
+
+	f = initFramework("throughput", verbose)
+
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+
+	if !intraCluster {
+		testParams := benchmarkTestParams{
+			ClientCluster:       framework.ClusterA,
+			ServerCluster:       framework.ClusterB,
+			ServerPodScheduling: framework.GatewayNode,
+			ClientPodScheduling: framework.GatewayNode,
+		}
+
+		clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+		fmt.Printf("Performing throughput tests from Gateway pod on cluster %q to Gateway pod on cluster %q\n",
+			clusterAName, clusterBName)
+		runThroughputTest(f, testParams, verbose)
+
+		testParams.ServerPodScheduling = framework.NonGatewayNode
+		testParams.ClientPodScheduling = framework.NonGatewayNode
+
+		fmt.Printf("Performing throughput tests from Non-Gateway pod on cluster %q to Non-Gateway pod on cluster %q\n",
+			clusterAName, clusterBName)
+		runThroughputTest(f, testParams, verbose)
+	} else {
+		testIntraClusterParams := benchmarkTestParams{
+			ClientCluster:       framework.ClusterA,
+			ServerCluster:       framework.ClusterA,
+			ServerPodScheduling: framework.GatewayNode,
+			ClientPodScheduling: framework.NonGatewayNode,
+		}
+
+		fmt.Printf("Performing throughput tests from Non-Gateway pod to Gateway pod on cluster %q\n", clusterAName)
+		runThroughputTest(f, testIntraClusterParams, verbose)
+	}
+
+	cleanupFramework(f)
+}
+
+func initFramework(baseName string, verbose bool) *framework.Framework {
+	f := framework.NewBareFramework(baseName)
+	framework.SetStatusFunction(func(str string) {
+		if verbose {
+			fmt.Println(str)
+		}
+	})
+
+	framework.ValidateFlags(framework.TestContext)
+	framework.BeforeSuite()
+	f.BeforeEach()
+
+	return f
+}
+
+func cleanupFramework(f *framework.Framework) {
+	f.AfterEach()
+	framework.RunCleanupActions()
+}
+
+func runThroughputTest(f *framework.Framework, testParams benchmarkTestParams, verbose bool) {
+	clientClusterName := framework.TestContext.ClusterIDs[testParams.ClientCluster]
+	serverClusterName := framework.TestContext.ClusterIDs[testParams.ServerCluster]
+	var connectionTimeout uint = 10
+	var connectionAttempts uint = 2
+	iperf3Port := 5201
+
+	framework.By(fmt.Sprintf("Creating a Nettest Server Pod on %q", serverClusterName))
+
+	nettestServerPod := f.NewNetworkPod(&framework.NetworkPodConfig{
+		Type:               framework.ThroughputServerPod,
+		Cluster:            testParams.ServerCluster,
+		Scheduling:         testParams.ServerPodScheduling,
+		ConnectionTimeout:  connectionTimeout,
+		ConnectionAttempts: connectionAttempts,
+		Port:               iperf3Port,
+	})
+
+	podsClusterB := framework.KubeClients[testParams.ServerCluster].CoreV1().Pods(f.Namespace)
+	p1, _ := podsClusterB.Get(context.TODO(), nettestServerPod.Pod.Name, metav1.GetOptions{})
+
+	framework.By(fmt.Sprintf("Nettest Server Pod %q was created on node %q", nettestServerPod.Pod.Name, nettestServerPod.Pod.Spec.NodeName))
+
+	remoteIP := p1.Status.PodIP
+	var service *v1.Service
+
+	if framework.TestContext.GlobalnetEnabled && testParams.ClientCluster != testParams.ServerCluster {
+		framework.By(fmt.Sprintf("Pointing a ClusterIP service to the nettest server pod in cluster %q and exporting it",
+			framework.TestContext.ClusterIDs[testParams.ServerCluster]))
+
+		service = nettestServerPod.CreateService()
+		f.CreateServiceExport(testParams.ServerCluster, service.Name)
+
+		// Wait for the globalIP on the service.
+		remoteIP = f.AwaitGlobalIngressIP(testParams.ServerCluster, service.Name, service.Namespace)
+	}
+
+	nettestClientPod := f.NewNetworkPod(&framework.NetworkPodConfig{
+		Type:               framework.ThroughputClientPod,
+		Cluster:            testParams.ClientCluster,
+		Scheduling:         testParams.ClientPodScheduling,
+		RemoteIP:           remoteIP,
+		ConnectionTimeout:  connectionTimeout,
+		ConnectionAttempts: connectionAttempts,
+		Port:               iperf3Port,
+	})
+
+	framework.By(fmt.Sprintf("Nettest Client Pod %q was created on cluster %q, node %q; connect to server pod ip %q",
+		nettestClientPod.Pod.Name, clientClusterName, nettestClientPod.Pod.Spec.NodeName, remoteIP))
+
+	framework.By(fmt.Sprintf("Waiting for the client pod %q to exit, returning what client sent", nettestClientPod.Pod.Name))
+
+	nettestClientPod.AwaitFinishVerbose(verbose)
+
+	if !verbose {
+		nettestClientPod.CheckSuccessfulFinish()
+		fmt.Println(nettestClientPod.TerminationMessage)
+	}
+	// In Globalnet deployments, when backend pods finish their execution, kubeproxy-iptables driver tries
+	// to delete the iptables-chain associated with the service (even when the service is present) as there are
+	// no active backend pods. Since the iptables-chain is also referenced by Globalnet Ingress rules, the chain
+	// cannot be deleted (kubeproxy errors out and continues to retry) until Globalnet removes the reference.
+	// Globalnet removes the reference only when the service itself is deleted. Until Globalnet is enhanced [*]
+	// to remove this dependency with iptables-chain, lets delete the service after the nettest server Pod is terminated.
+	// [*] https://github.com/submariner-io/submariner/issues/1166
+	if framework.TestContext.GlobalnetEnabled && testParams.ClientCluster != testParams.ServerCluster {
+		f.DeletePod(testParams.ServerCluster, nettestServerPod.Pod.Name, f.Namespace)
+		f.DeleteService(testParams.ServerCluster, service.Name)
+		f.DeleteServiceExport(testParams.ServerCluster, service.Name)
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -15,13 +15,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constants
 
+// Arranged alphabetically.
 const (
-	OperatorNamespace       = "submariner-operator"
 	DefaultBrokerNamespace  = "submariner-k8s-broker"
+	OperatorNamespace       = "submariner-operator"
 	SubmarinerBrokerAdminSA = "submariner-k8s-broker-admin"
-	SubmarinerNamespace     = "submariner-operator"
 	SubmarinerGatewayLabel  = "submariner.io/gateway"
+	SubmarinerName          = "submariner"
+	SubmarinerNamespace     = "submariner-operator"
 	TrueLabel               = "true"
 )

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -39,6 +39,17 @@ func WithMessage(message string) {
 	os.Exit(1)
 }
 
+// OnErrorWithMessage will print the message and quit the program with an error code.
+func OnErrorWithMessage(err error, message string) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s", message, err)
+		fmt.Fprintln(os.Stderr, "")
+		printVersion()
+		fmt.Fprintln(os.Stderr, "")
+		os.Exit(1)
+	}
+}
+
 func printVersion() {
 	fmt.Fprintln(os.Stderr, "")
 	version.PrintSubctlVersion(os.Stderr)


### PR DESCRIPTION
`benchmark` package is under `/internal` at the moment because it replies on shipyard test Framework which uses a lot of globals and isn't concurrency-safe.

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>
