### PR TITLE
Deprecate colour codes, stop sending them to Submariner

### DIFF
--- a/api/submariner/v1alpha1/submariner_types.go
+++ b/api/submariner/v1alpha1/submariner_types.go
@@ -124,7 +124,6 @@ type (
 )
 
 const (
-	DefaultColorCode                     = "blue"
 	K8s                   KubernetesType = "k8s"
 	OCP                                  = "ocp"
 	EKS                                  = "eks"
@@ -219,7 +218,6 @@ func (s *Submariner) UnmarshalJSON(data []byte) error {
 		Spec: SubmarinerSpec{
 			Repository: DefaultRepo,
 			Version:    DefaultSubmarinerVersion,
-			ColorCodes: DefaultColorCode,
 		},
 	}
 

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
-	submariner "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/cli"
 	"github.com/submariner-io/submariner-operator/internal/cluster"
 	"github.com/submariner-io/submariner-operator/internal/constants"
@@ -39,8 +38,9 @@ import (
 )
 
 var (
-	joinFlags    join.Options
-	labelGateway bool
+	joinFlags         join.Options
+	labelGateway      bool
+	ignoredColorCodes string
 )
 
 var joinCmd = &cobra.Command{
@@ -93,7 +93,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&joinFlags.ClusterCIDR, "clustercidr", "", "cluster CIDR")
 	cmd.Flags().StringVar(&joinFlags.Repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&joinFlags.ImageVersion, "version", "", "image version")
-	cmd.Flags().StringVar(&joinFlags.ColorCodes, "colorcodes", submariner.DefaultColorCode, "color codes")
+	cmd.Flags().StringVar(&ignoredColorCodes, "colorcodes", "", "color codes")
+	_ = cmd.Flags().MarkDeprecated("colorcodes", "--colorcodes has no effect and is deprecated")
 	cmd.Flags().IntVar(&joinFlags.NATTPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&joinFlags.IKEPort, "ikeport", 500, "IPsec IKE port")
 	cmd.Flags().BoolVar(&joinFlags.NATTraversal, "natt", true, "enable NAT traversal for IPsec")

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/submariner-io/cloud-prepare v0.12.0-m3.0.20220117145104-8c71f70f26cb
 	github.com/submariner-io/lighthouse v0.12.0-m3
 	github.com/submariner-io/shipyard v0.12.0-m3
-	github.com/submariner-io/submariner v0.12.0-m3
+	github.com/submariner-io/submariner v0.12.0-m3.0.20220118080926-1324572a65c0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/uw-labs/lichen v0.1.4
 	github.com/xlab/treeprint v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1395,8 +1395,8 @@ github.com/submariner-io/lighthouse v0.12.0-m3 h1:pjcgUG+DsUicFoqm2lPX1vJeZakHpc
 github.com/submariner-io/lighthouse v0.12.0-m3/go.mod h1:rku3nIESgPHKg2B2LyylICCfXry+tCLdS315b7hu/eY=
 github.com/submariner-io/shipyard v0.12.0-m3 h1:kMVYrEPLEH9KyAHp49bmVEVsukfrIWWIqgsqgNII4nc=
 github.com/submariner-io/shipyard v0.12.0-m3/go.mod h1:el/lH6ed/1BN1FvEXlptiib7qT2cTwEQ4AMceH3js9g=
-github.com/submariner-io/submariner v0.12.0-m3 h1:/9+7zy4Rtv/LtUWELoViu/F0Ci+e/7uchafzjss92bI=
-github.com/submariner-io/submariner v0.12.0-m3/go.mod h1:gFraUju7PkagXestbQFUYSv3mA67LkqTk2UenBaQl58=
+github.com/submariner-io/submariner v0.12.0-m3.0.20220118080926-1324572a65c0 h1:9vY0I4TaYEYOlrOp5WfpqKW9jIXzcgA7t5v2SnZgDDg=
+github.com/submariner-io/submariner v0.12.0-m3.0.20220118080926-1324572a65c0/go.mod h1:gFraUju7PkagXestbQFUYSv3mA67LkqTk2UenBaQl58=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -46,7 +46,6 @@ type SubmarinerOptions struct {
 	HealthCheckInterval           uint64
 	HealthCheckMaxPacketLossCount uint64
 	ClusterID                     string
-	ColorCodes                    string
 	CableDriver                   string
 	CoreDNSCustomConfigMap        string
 	Repository                    string
@@ -95,7 +94,6 @@ func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info,
 		Broker:                   "k8s",
 		NatEnabled:               options.NATTraversal,
 		Debug:                    options.SubmarinerDebug,
-		ColorCodes:               options.ColorCodes,
 		ClusterID:                options.ClusterID,
 		ServiceCIDR:              netconfig.ServiceCIDR,
 		ClusterCIDR:              netconfig.ClusterCIDR,

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -155,7 +155,6 @@ func submarinerOptionsFrom(joinOptions *Options) *deploy.SubmarinerOptions {
 		HealthCheckInterval:           joinOptions.HealthCheckInterval,
 		HealthCheckMaxPacketLossCount: joinOptions.HealthCheckMaxPacketLossCount,
 		ClusterID:                     joinOptions.ClusterID,
-		ColorCodes:                    joinOptions.ColorCodes,
 		CableDriver:                   joinOptions.CableDriver,
 		CoreDNSCustomConfigMap:        joinOptions.CoreDNSCustomConfigMap,
 		Repository:                    joinOptions.Repository,

--- a/pkg/join/options.go
+++ b/pkg/join/options.go
@@ -40,7 +40,6 @@ type Options struct {
 	GlobalnetCIDR                 string
 	Repository                    string
 	ImageVersion                  string
-	ColorCodes                    string
 	CableDriver                   string
 	CoreDNSCustomConfigMap        string
 	CustomDomains                 []string

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -62,7 +62,7 @@ var (
 	ikePort                       int
 	preferredServer               bool
 	forceUDPEncaps                bool
-	colorCodes                    string
+	ignoredColorCodes             string
 	natTraversal                  bool
 	ignoreRequirements            bool
 	globalnetEnabled              bool
@@ -93,7 +93,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&clusterCIDR, "clustercidr", "", "cluster CIDR")
 	cmd.Flags().StringVar(&repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&imageVersion, "version", "", "image version")
-	cmd.Flags().StringVar(&colorCodes, "colorcodes", submariner.DefaultColorCode, "color codes")
+	cmd.Flags().StringVar(&ignoredColorCodes, "colorcodes", "", "color codes")
+	_ = cmd.Flags().MarkDeprecated("colorcodes", "--colorcodes has no effect and is deprecated")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
 	cmd.Flags().BoolVar(&natTraversal, "natt", true, "enable NAT traversal for IPsec")
@@ -190,18 +191,9 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 		})
 	}
 
-	if colorCodes == "" {
-		qs = append(qs, &survey.Question{
-			Name:     "colorCodes",
-			Prompt:   &survey.Input{Message: "What color codes should be used (e.g. \"blue\")?"},
-			Validate: survey.Required,
-		})
-	}
-
 	if len(qs) > 0 {
 		answers := struct {
-			ClusterID  string
-			ColorCodes string
+			ClusterID string
 		}{}
 
 		err := survey.Ask(qs, &answers)
@@ -210,10 +202,6 @@ func joinSubmarinerCluster(subctlData *datafile.SubctlData) {
 
 		if len(answers.ClusterID) > 0 {
 			clusterID = answers.ClusterID
-		}
-
-		if len(answers.ColorCodes) > 0 {
-			colorCodes = answers.ColorCodes
 		}
 	}
 
@@ -529,7 +517,6 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, brokerSecret, pskSe
 		Broker:                   "k8s",
 		NatEnabled:               natTraversal,
 		Debug:                    submarinerDebug,
-		ColorCodes:               colorCodes,
 		ClusterID:                clusterID,
 		ServiceCIDR:              crServiceCIDR,
 		ClusterCIDR:              crClusterCIDR,

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -31,7 +31,6 @@ function create_subm_vars() {
 
     # FIXME: Actually act on this size request in controller
     subm_gateway_size=3
-    subm_colorcodes=blue
     subm_debug=false
     subm_broker=k8s
     ce_ipsec_debug=false
@@ -208,7 +207,6 @@ function verify_subm_cr() {
   validate_equals '.spec.version' $subm_gateway_image_tag
   validate_equals '.spec.broker' $subm_broker
   echo "Generated cluster id: $(jq -r '.spec.clusterID' $json_file)"
-  validate_equals '.spec.colorCodes' $subm_colorcodes
   validate_equals '.spec.debug' $subm_debug
   validate_equals '.spec.namespace' $subm_ns
   validate_equals '.spec.natEnabled' $natEnabled
@@ -269,7 +267,6 @@ function verify_subm_gateway_pod() {
   validate_pod_container_env 'SUBMARINER_NAMESPACE' $subm_ns
   validate_pod_container_env 'SUBMARINER_SERVICECIDR' ${service_CIDRs[$cluster]}
   validate_pod_container_env 'SUBMARINER_CLUSTERCIDR' ${cluster_CIDRs[$cluster]}
-  validate_pod_container_env 'SUBMARINER_COLORCODES' $subm_colorcodes
   validate_pod_container_env 'SUBMARINER_DEBUG' $subm_debug
   validate_pod_container_env 'SUBMARINER_NATENABLED' $natEnabled
   validate_pod_container_env 'SUBMARINER_BROKER' $subm_broker
@@ -376,7 +373,6 @@ function verify_subm_gateway_container() {
   grep "BROKER_K8S_REMOTENAMESPACE=$SUBMARINER_BROKER_NS" $env_file
   grep "SUBMARINER_SERVICECIDR=${service_CIDRs[$cluster]}" $env_file
   grep "SUBMARINER_CLUSTERCIDR=${cluster_CIDRs[$cluster]}" $env_file
-  grep "SUBMARINER_COLORCODES=$subm_colorcode" $env_file
   grep "SUBMARINER_NATENABLED=$natEnabled" $env_file
   grep "HOME=/root" $env_file
 


### PR DESCRIPTION
These aren't used, let's drop them.

Depends on #1726.
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
