### PR TITLE
Configure RBAC for Globalnet pods on OCP deployments

### DIFF
--- a/config/rbac/submariner-globalnet/cluster_role.yaml
+++ b/config/rbac/submariner-globalnet/cluster_role.yaml
@@ -67,3 +67,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - network.openshift.io
+    resources:
+      - service/externalips
+    verbs:
+      - create
+      - get
+      - list
+      - delete


### PR DESCRIPTION
Globalnet controller now uses internal services with external-ips
to support exported services. On OCP Clusters, we require an explicit
RBAC to create services with external-ips, this PR includes the
necessary RBAC for Globalnet pods.

Related to: https://github.com/submariner-io/submariner/issues/1166
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
