### PR TITLE
Add test for oldest K8s version known to work

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -25,6 +25,11 @@ jobs:
           - ovn: 'ovn'
             globalnet: 'globalnet'
         include:
+          # Oldest Kubernetes version thought to work with SubM.
+          # This should match minK8sMajor.minK8sMinor in submariner-operator/pkg/version/version.go.
+          # If this breaks, we may advance the minimum K8s version instead of fixing it. See:
+          # https://submariner.io/development/building-testing/ci-maintenance/
+          - k8s_version: '1.17'
           # All the versions we support
           - k8s_version: '1.19'
           - k8s_version: '1.20'


### PR DESCRIPTION
As a part of cleaning up our Kubernetes version support, move the test
for the oldest K8s version known to work with Submariner to the repo
where this version is consumed. This is currently tested in the main
Submariner repo. Also better document the reason for this test.

Relates-to: submariner-io/submariner-website#624

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
