### PR TITLE
Update K8s CI, make 1.23 default and rm 1.19

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        # Default version to test
-        k8s_version: ['1.20']
+        # Run most tests against the latest K8s version
+        k8s_version: ['1.23']
         lighthouse: ['', 'lighthouse']
         ovn: ['', 'ovn']
         exclude:
@@ -30,8 +30,7 @@ jobs:
           # If this breaks, we may advance the minimum K8s version instead of fixing it. See:
           # https://submariner.io/development/building-testing/ci-maintenance/
           - k8s_version: '1.17'
-          # All the versions we support
-          - k8s_version: '1.19'
+          # Run default E2E against all supported K8s versions
           - k8s_version: '1.20'
           - k8s_version: '1.21'
           - k8s_version: '1.22'


### PR DESCRIPTION
Update the versions of Kubernetes tested in E2E CI. Add 1.23 as the new
default that most test will run against, and remove 1.19 as it is EOL.

Relates-to: submariner-io/submariner-website#624

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
