### PR TITLE
Test K8s 1.23 in flake finder, not 1.19

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         cable_driver: ['libreswan', 'wireguard']
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.19']
+        k8s_version: ['1.23']
         lighthouse: ['', 'lighthouse']
         include:
           - k8s_version: '1.20'


### PR DESCRIPTION
Kubernetes 1.19 is EOL and therefore not supported by Submariner. We
should be testing with the latest K8s version by default.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
