### PR TITLE
Don't test Globalnet for every K8s version in FF

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -20,14 +20,8 @@ jobs:
         lighthouse: ['', 'lighthouse']
         include:
           - k8s_version: '1.20'
-          - k8s_version: '1.20'
-            globalnet: 'globalnet'
           - k8s_version: '1.21'
-          - k8s_version: '1.21'
-            globalnet: 'globalnet'
           - k8s_version: '1.22'
-          - k8s_version: '1.22'
-            globalnet: 'globalnet'
     steps:
       - name: Check out the repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
We currently test Globalnet for every supported K8s version in the Flake
Finder. This was useful when Gloablnet was more experimental, but
recently these tests haven't identified any issues. Stop running them to
save resources.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
