### PR TITLE
Add E2E GHA to test all K8s versions

### DIFF
--- a/.github/workflows/e2e-all-k8s.yml
+++ b/.github/workflows/e2e-all-k8s.yml
@@ -1,0 +1,40 @@
+---
+name: End to End All K8s
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: "0 0 * * 6"
+
+jobs:
+  e2e:
+    name: E2E
+    if: contains(github.event.pull_request.labels.*.name, 'e2e-all-k8s')
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        globalnet: ['', 'globalnet']
+        k8s_version: ['1.17', '1.20', '1.21', '1.22', '1.23']
+        lighthouse: ['', 'lighthouse']
+        ovn: ['', 'ovn']
+        exclude:
+          - ovn: 'ovn'
+            lighthouse: 'lighthouse'
+          - ovn: 'ovn'
+            globalnet: 'globalnet'
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: Run E2E deployment and tests
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
+          using: ${{ matrix.globalnet }} ${{ matrix.lighthouse }} ${{ matrix.ovn }}
+
+      - name: Post mortem
+        if: failure()
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel


### PR DESCRIPTION
Add GHA to run the E2E tests for the normal matrix but with every
relevant K8s version. This includes the currently supported versions, as
well as the oldest version thought to work with SubM.

Triggered once a week or manually with the "e2e-all-k8s" label.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
