### PR TITLE
Check for fixup commits in PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,6 +23,14 @@ jobs:
           flags: 'i'
           error: 'Commits addressing code review feedback should typically be squashed into the commits under review'
 
+      - name: 'Verify no "fixup!" commits'
+        uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^(?!fixup!)'
+          flags: 'i'
+          error: 'Fixup commits should be squashed into the commits under review'
+
   crds:
     name: CRDs up-to-date
     runs-on: ubuntu-latest


### PR DESCRIPTION
Commits produced using "git commit --fix" are great for review, but
must be squashed before a PR is merged.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
