### PR TITLE
Add VPCPeering to subctl

### DIFF
--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -35,13 +35,13 @@ func newAWSCleanupCommand() *cobra.Command {
 		Run: cleanupAws,
 	}
 
-	aws.AddAWSFlags(cmd)
+	aws.ClientArgs.AddAWSFlags(cmd)
 
 	return cmd
 }
 
 func cleanupAws(cmd *cobra.Command, args []string) {
-	err := aws.RunOnAWS(*parentRestConfigProducer, "",
+	err := aws.ClientArgs.RunOnAWS(*parentRestConfigProducer, "",
 		// nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			err := gwDeployer.Cleanup(reporter)

--- a/pkg/subctl/cmd/cloud/cleanup/gcp.go
+++ b/pkg/subctl/cmd/cloud/cleanup/gcp.go
@@ -34,13 +34,13 @@ func newGCPCleanupCommand() *cobra.Command {
 		Run:   cleanupGCP,
 	}
 
-	gcp.AddGCPFlags(cmd)
+	gcp.ClientArgs.AddGCPFlags(cmd)
 
 	return cmd
 }
 
 func cleanupGCP(cmd *cobra.Command, args []string) {
-	err := gcp.RunOnGCP(*parentRestConfigProducer, "", false,
+	err := gcp.ClientArgs.RunOnGCP(*parentRestConfigProducer, "", false,
 		// nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			err := gwDeployer.Cleanup(reporter)

--- a/pkg/subctl/cmd/cloud/cloud.go
+++ b/pkg/subctl/cmd/cloud/cloud.go
@@ -24,6 +24,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/cleanup"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/prepare"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/vpcpeering"
 )
 
 var (
@@ -38,6 +39,7 @@ var (
 func init() {
 	cloudCmd.AddCommand(prepare.NewCommand(&restConfigProducer))
 	cloudCmd.AddCommand(cleanup.NewCommand(&restConfigProducer))
+	cloudCmd.AddCommand(vpcpeering.NewCommand(&restConfigProducer))
 	restConfigProducer.AddKubeContextFlag(cloudCmd)
 	cmd.AddToRootCommand(cloudCmd)
 }

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -31,7 +31,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/gcp"
-	gcpClientIface "github.com/submariner-io/cloud-prepare/pkg/gcp/client"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	"github.com/submariner-io/submariner-operator/internal/exit"
@@ -40,7 +39,6 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
-	"google.golang.org/api/option"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
@@ -51,20 +49,29 @@ const (
 	projectIDFlag = "project-id"
 )
 
-var (
-	infraID         string
-	region          string
-	projectID       string
-	credentialsFile string
-	ocpMetadataFile string
-)
+type Args struct {
+	cloudName       string
+	InfraID         string
+	Region          string
+	ProjectID       string
+	CredentialsFile string
+	OcpMetadataFile string
+}
+
+var ClientArgs = NewArgs("")
+
+func NewArgs(name string) *Args {
+	return &Args{
+		cloudName: name,
+	}
+}
 
 // AddGCPFlags adds basic flags needed by GCP.
-func AddGCPFlags(command *cobra.Command) {
-	command.Flags().StringVar(&infraID, infraIDFlag, "", "GCP infra ID")
-	command.Flags().StringVar(&region, regionFlag, "", "GCP region")
-	command.Flags().StringVar(&projectID, projectIDFlag, "", "GCP project ID")
-	command.Flags().StringVar(&ocpMetadataFile, "ocp-metadata", "",
+func (args *Args) AddGCPFlags(command *cobra.Command) {
+	command.Flags().StringVar(&args.InfraID, infraIDFlag, "", "GCP infra ID")
+	command.Flags().StringVar(&args.Region, regionFlag, "", "GCP region")
+	command.Flags().StringVar(&args.ProjectID, projectIDFlag, "", "GCP project ID")
+	command.Flags().StringVar(&args.OcpMetadataFile, "ocp-metadata", "",
 		"OCP metadata.json file (or the directory containing it) from which to read the GCP infra ID "+
 			"and region from (takes precedence over the specific flags)")
 
@@ -74,38 +81,39 @@ func AddGCPFlags(command *cobra.Command) {
 	}
 
 	defaultCredentials := filepath.FromSlash(fmt.Sprintf("%s/.gcp/osServiceAccount.json", dirname))
-	command.Flags().StringVar(&credentialsFile, "credentials", defaultCredentials, "GCP credentials configuration file")
+	command.Flags().StringVar(&args.CredentialsFile, "credentials", defaultCredentials, "GCP credentials configuration file")
+}
+
+// ValidateFlags if the OcpMetadataFile is provided it overrides the infra-id and region flags.
+func (args *Args) ValidateFlags() {
+	if args.OcpMetadataFile != "" {
+		err := args.initializeFlagsFromOCPMetadata()
+		exit.OnErrorWithMessage(err, "Failed to read GCP Cluster information from OCP metadata file")
+	} else {
+		utils.ExpectFlag(args.getFlagName(infraIDFlag), args.InfraID)
+		utils.ExpectFlag(args.getFlagName(regionFlag), args.Region)
+		utils.ExpectFlag(args.getFlagName(projectIDFlag), args.ProjectID)
+	}
 }
 
 // RunOnGCP runs the given function on GCP, supplying it with a cloud instance connected to GCP and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to GCP.
-func RunOnGCP(restConfigProducer restconfig.Producer, gwInstanceType string, dedicatedGWNodes bool,
+func (args *Args) RunOnGCP(restConfigProducer restconfig.Producer, gwInstanceType string, dedicatedGWNodes bool,
 	function func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
-	if ocpMetadataFile != "" {
-		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
-		exit.OnErrorWithMessage(err, "Failed to read GCP Cluster information from OCP metadata file")
-	} else {
-		utils.ExpectFlag(infraIDFlag, infraID)
-		utils.ExpectFlag(regionFlag, region)
-		utils.ExpectFlag(projectIDFlag, region)
-	}
+	ClientArgs.ValidateFlags()
 
 	reporter := cloudutils.NewStatusReporter()
-	reporter.Started("Retrieving GCP credentials from your GCP configuration")
-
-	creds, err := getGCPCredentials()
-	exit.OnErrorWithMessage(err, "Failed to get GCP credentials")
-	reporter.Succeeded("")
 
 	reporter.Started("Initializing GCP connectivity")
 
-	options := []option.ClientOption{
-		option.WithCredentials(creds),
-		option.WithUserAgent("open-cluster-management.io submarineraddon/v1"),
+	gcpCloudInfo, err := gcp.NewCloudInfoFromSettings(args.CredentialsFile, args.ProjectID, args.InfraID, args.Region)
+	if err != nil {
+		reporter.Failed(err)
+
+		return errors.Wrap(err, "error loading default config")
 	}
 
-	gcpClient, err := gcpClientIface.NewClient(projectID, options)
-	exit.OnErrorWithMessage(err, "Failed to initialize a GCP Client")
+	reporter.Succeeded("")
 
 	k8sConfig, err := restConfigProducer.ForCluster()
 	exit.OnErrorWithMessage(err, "Failed to initialize a Kubernetes config")
@@ -121,36 +129,37 @@ func RunOnGCP(restConfigProducer restconfig.Producer, gwInstanceType string, ded
 	dynamicClient, err := dynamic.NewForConfig(k8sConfig)
 	exit.OnErrorWithMessage(err, "Failed to create dynamic client")
 
-	gcpCloudInfo := gcp.CloudInfo{
-		ProjectID: projectID,
-		InfraID:   infraID,
-		Region:    region,
-		Client:    gcpClient,
-	}
-	gcpCloud := gcp.NewCloud(gcpCloudInfo)
 	msDeployer := ocp.NewK8sMachinesetDeployer(restMapper, dynamicClient)
 	// TODO: Ideally we should be able to specify the image for GWNode, but it was seen that
 	// with certain images, the instance is not coming up. Needs to be investigated further.
-	gwDeployer := gcp.NewOcpGatewayDeployer(gcpCloudInfo, msDeployer, gwInstanceType, "", dedicatedGWNodes, k8sClientSet)
+	gwDeployer := gcp.NewOcpGatewayDeployer(*gcpCloudInfo, msDeployer, gwInstanceType, "", dedicatedGWNodes, k8sClientSet)
 
 	exit.OnErrorWithMessage(err, "Failed to initialize a GatewayDeployer config")
 
-	return function(gcpCloud, gwDeployer, reporter)
+	return function(gcp.NewCloud(*gcpCloudInfo), gwDeployer, reporter)
 }
 
-func initializeFlagsFromOCPMetadata(metadataFile string) error {
-	fileInfo, err := os.Stat(metadataFile)
+func (args *Args) getFlagName(flag string) string {
+	if args.cloudName == "" {
+		return flag
+	}
+
+	return fmt.Sprintf("%v-%v", args.cloudName, flag)
+}
+
+func (args *Args) initializeFlagsFromOCPMetadata() error {
+	fileInfo, err := os.Stat(args.OcpMetadataFile)
 	if err != nil {
-		return errors.Wrapf(err, "failed to stat file %q", metadataFile)
+		return errors.Wrapf(err, "failed to stat file %q", args.OcpMetadataFile)
 	}
 
 	if fileInfo.IsDir() {
-		metadataFile = filepath.Join(metadataFile, "metadata.json")
+		args.OcpMetadataFile = filepath.Join(args.OcpMetadataFile, "metadata.json")
 	}
 
-	data, err := os.ReadFile(metadataFile)
+	data, err := os.ReadFile(args.OcpMetadataFile)
 	if err != nil {
-		return errors.Wrapf(err, "error reading file %q", metadataFile)
+		return errors.Wrapf(err, "error reading file %q", args.OcpMetadataFile)
 	}
 
 	var metadata struct {
@@ -166,17 +175,17 @@ func initializeFlagsFromOCPMetadata(metadataFile string) error {
 		return errors.Wrap(err, "error unmarshalling data")
 	}
 
-	infraID = metadata.InfraID
-	region = metadata.GCP.Region
-	projectID = metadata.GCP.ProjectID
+	args.InfraID = metadata.InfraID
+	args.Region = metadata.GCP.Region
+	args.ProjectID = metadata.GCP.ProjectID
 
 	return nil
 }
 
-func getGCPCredentials() (*google.Credentials, error) {
-	authJSON, err := os.ReadFile(credentialsFile)
+func (args *Args) getGCPCredentials() (*google.Credentials, error) {
+	authJSON, err := os.ReadFile(args.CredentialsFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading file %q", credentialsFile)
+		return nil, errors.Wrapf(err, "error reading file %q", args.CredentialsFile)
 	}
 
 	creds, err := google.CredentialsFromJSON(context.TODO(), authJSON, dns.CloudPlatformScope)

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -34,7 +34,7 @@ func newAWSPrepareCommand() *cobra.Command {
 		Run:   prepareAws,
 	}
 
-	aws.AddAWSFlags(cmd)
+	aws.ClientArgs.AddAWSFlags(cmd)
 	cmd.Flags().StringVar(&awsGWInstanceType, "gateway-instance", "c5d.large", "Type of gateways instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of dedicated gateways to deploy (Set to `0` when using --load-balancer mode)")
@@ -64,7 +64,7 @@ func prepareAws(cmd *cobra.Command, args []string) {
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := aws.RunOnAWS(*parentRestConfigProducer, awsGWInstanceType,
+	err := aws.ClientArgs.RunOnAWS(*parentRestConfigProducer, awsGWInstanceType,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -34,7 +34,7 @@ func newGCPPrepareCommand() *cobra.Command {
 		Run:   prepareGCP,
 	}
 
-	gcp.AddGCPFlags(cmd)
+	gcp.ClientArgs.AddGCPFlags(cmd)
 	cmd.Flags().StringVar(&gcpGWInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
@@ -61,7 +61,7 @@ func prepareGCP(cmd *cobra.Command, args []string) {
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := gcp.RunOnGCP(*parentRestConfigProducer, gcpGWInstanceType, dedicatedGateway,
+	err := gcp.ClientArgs.RunOnGCP(*parentRestConfigProducer, gcpGWInstanceType, dedicatedGateway,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -1,14 +1,10 @@
 /*
 SPDX-License-Identifier: Apache-2.0
-
 Copyright Contributors to the Submariner project.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/subctl/cmd/cloud/vpcpeering/aws.go
+++ b/pkg/subctl/cmd/cloud/vpcpeering/aws.go
@@ -1,0 +1,106 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcpeering
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	cloudprepareaws "github.com/submariner-io/cloud-prepare/pkg/aws"
+	"github.com/submariner-io/submariner-operator/internal/exit"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/aws"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+)
+
+var targetArgs = aws.NewArgs("target")
+
+// NewCommand returns a new cobra.Command used to create a VPC Peering on a cloud infrastructure.
+func newAWSVPCPeeringCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "aws",
+		Short: "Create a VPC Peering on AWS cloud",
+		Long:  "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on AWS cloud for Submariner installation.",
+		Run:   vpcPeerAws,
+	}
+
+	aws.ClientArgs.AddAWSFlags(cmd)
+	targetArgs.AddAWSFlags(cmd)
+
+	return cmd
+}
+
+func vpcPeerAws(cmd *cobra.Command, args []string) {
+	targetArgs.ValidateFlags()
+
+	reporter := cloudutils.NewStatusReporter()
+
+	reporter.Started("Initializing AWS connectivity")
+
+	targetCloud, err := cloudprepareaws.NewCloudFromSettings(targetArgs.CredentialsFile,
+		targetArgs.Profile, targetArgs.InfraID, targetArgs.Region)
+	if err != nil {
+		reporter.Failed(err)
+		exit.OnErrorWithMessage(err, "Failed to initialize AWS connectivity")
+	}
+
+	reporter.Succeeded("")
+
+	err = aws.ClientArgs.RunOnAWS(*parentRestConfigProducer, "",
+		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			return errors.Wrap(err, cloud.CreateVpcPeering(targetCloud, reporter).Error())
+		})
+	if err != nil {
+		exit.OnErrorWithMessage(err, "Failed to create VPC Peering on AWS cloud")
+	}
+}
+
+// newCleanupAWSVPCPeeringCommand removes a VPC Peering between different AWS clusters.
+func newCleanupAWSVPCPeeringCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "aws",
+		Short: "Removes VPC Peering on AWS cloud",
+		Long:  "This command cleans an OpenShift installer-provisioned infrastructure (IPI) on AWS cloud for Submariner uninstallation.",
+		Run:   cleanupVpcPeerAws,
+	}
+
+	aws.ClientArgs.AddAWSFlags(cmd)
+	targetArgs.AddAWSFlags(cmd)
+
+	return cmd
+}
+
+// cleanupVpcPeerAws removes peering object and routes between two OCP clusters in AWS.
+func cleanupVpcPeerAws(cmd *cobra.Command, args []string) {
+	targetArgs.ValidateFlags()
+
+	reporter := cloudutils.NewStatusReporter()
+
+	reporter.Started("Initializing AWS connectivity")
+	reporter.Succeeded("")
+
+	var err error
+
+	err = aws.ClientArgs.RunOnAWS(*parentRestConfigProducer, "",
+		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			return errors.Wrap(err, cloud.CleanupAfterSubmariner(reporter).Error())
+		})
+	if err != nil {
+		exit.OnErrorWithMessage(err, "Failed to remove VPC Peering on AWS cloud")
+	}
+}

--- a/pkg/subctl/cmd/cloud/vpcpeering/gcp.go
+++ b/pkg/subctl/cmd/cloud/vpcpeering/gcp.go
@@ -1,0 +1,105 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcpeering
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	cloudpreparegcp "github.com/submariner-io/cloud-prepare/pkg/gcp"
+	"github.com/submariner-io/submariner-operator/internal/exit"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/gcp"
+	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
+)
+
+// NewCommand returns a new cobra.Command used to create a VPC Peering on a cloud infrastructure.
+func newGCPVPCPeeringCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gcp",
+		Short: "Create a VPC Peering on GCP cloud",
+		Long:  "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on GCP cloud for Submariner installation.",
+		Run:   vpcPeerGcp,
+	}
+
+	gcp.ClientArgs.AddGCPFlags(cmd)
+	targetArgs.AddAWSFlags(cmd)
+
+	return cmd
+}
+
+func vpcPeerGcp(cmd *cobra.Command, args []string) {
+	targetArgs.ValidateFlags()
+
+	reporter := cloudutils.NewStatusReporter()
+
+	reporter.Started("Initializing GCP connectivity")
+
+	cloudInfo, err := cloudpreparegcp.NewCloudInfoFromSettings(targetArgs.CredentialsFile,
+		targetArgs.Profile, targetArgs.InfraID, targetArgs.Region)
+	if err != nil {
+		reporter.Failed(err)
+		exit.OnErrorWithMessage(err, "Failed to initialize GCP connectivity")
+	}
+
+	reporter.Succeeded("")
+
+	err = gcp.ClientArgs.RunOnGCP(*parentRestConfigProducer, "", false,
+		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			return errors.Wrap(err, cloud.CreateVpcPeering(cloudpreparegcp.NewCloud(*cloudInfo), reporter).Error())
+		})
+	if err != nil {
+		exit.OnErrorWithMessage(err, "Failed to create VPC Peering on GCP cloud")
+	}
+}
+
+// newCleanupAWSVPCPeeringCommand removes a VPC Peering between different AWS clusters.
+func newCleanupGCPVPCPeeringCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gcp",
+		Short: "Removes VPC Peering on GCP cloud",
+		Long:  "This command cleans an OpenShift installer-provisioned infrastructure (IPI) on GCP cloud for Submariner uninstallation.",
+		Run:   cleanupVpcPeerGcp,
+	}
+
+	gcp.ClientArgs.AddGCPFlags(cmd)
+	targetArgs.AddAWSFlags(cmd)
+
+	return cmd
+}
+
+// cleanupVpcPeerGcp removes peering object and routes between two OCP clusters in AWS.
+func cleanupVpcPeerGcp(cmd *cobra.Command, args []string) {
+	targetArgs.ValidateFlags()
+
+	reporter := cloudutils.NewStatusReporter()
+
+	reporter.Started("Initializing GCP connectivity")
+
+	reporter.Succeeded("")
+
+	var err error
+
+	err = gcp.ClientArgs.RunOnGCP(*parentRestConfigProducer, "", false,
+		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
+			return errors.Wrap(err, cloud.CleanupAfterSubmariner(reporter).Error())
+		})
+	if err != nil {
+		exit.OnErrorWithMessage(err, "Failed to create VPC Peering on GCP cloud")
+	}
+}

--- a/pkg/subctl/cmd/cloud/vpcpeering/generic.go
+++ b/pkg/subctl/cmd/cloud/vpcpeering/generic.go
@@ -1,0 +1,51 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcpeering
+
+import "github.com/spf13/cobra"
+
+func newGenericVPCPeeringCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generic",
+		Short: "Create a VPC peering between generic clusters for Submariner",
+		Long:  "This command labels the required number of gateway nodes for Submariner VPC Peering.",
+		Run:   vpcPeerGenericCluster,
+	}
+
+	return cmd
+}
+
+func vpcPeerGenericCluster(cmd *cobra.Command, args []string) {
+	// Nothing to peer here
+}
+
+func newCleanupGenericVPCPeeringCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generic",
+		Short: "Removes VPC peering between generic clusters for Submariner",
+		Long:  "This command create a vpc peering between two OCP cloud agnostic clusters",
+		Run:   cleanupVpcPeerGenericCluster,
+	}
+
+	return cmd
+}
+
+func cleanupVpcPeerGenericCluster(cmd *cobra.Command, args []string) {
+	// Nothing to clean up here
+}

--- a/pkg/subctl/cmd/cloud/vpcpeering/vpcpeering.go
+++ b/pkg/subctl/cmd/cloud/vpcpeering/vpcpeering.go
@@ -1,0 +1,76 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcpeering
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
+)
+
+var parentRestConfigProducer *restconfig.Producer
+
+// NewCommand returns a new cobra.Command used to prepare a cloud infrastructure.
+func NewCommand(restConfigProducer *restconfig.Producer) *cobra.Command {
+	parentRestConfigProducer = restConfigProducer
+
+	cmd := &cobra.Command{
+		Use:   "vpc-peering",
+		Short: "Manage VPC Peering between clusters",
+		Long:  `This command creates a VPC Peering between different clusters of the same cloud provider.`,
+	}
+
+	cmd.AddCommand(newCreateCommand(restConfigProducer))
+	cmd.AddCommand(newCleanupCommand(restConfigProducer))
+
+	return cmd
+}
+
+func newCreateCommand(restConfigProducer *restconfig.Producer) *cobra.Command {
+	parentRestConfigProducer = restConfigProducer
+
+	// Create VPC-Peering
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a VPC Peering between clusters",
+		Long:  `This command creates a VPC Peering between different clusters of the same cloud provider.`,
+	}
+
+	cmd.AddCommand(newAWSVPCPeeringCommand())
+	cmd.AddCommand(newGCPVPCPeeringCommand())
+	cmd.AddCommand(newGenericVPCPeeringCommand())
+
+	return cmd
+}
+
+func newCleanupCommand(restConfigProducer *restconfig.Producer) *cobra.Command {
+	parentRestConfigProducer = restConfigProducer
+
+	// Clean up VPC-Peering
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Remove a VPC Peering between clusters",
+		Long:  `This command removes a VPC Peering between different clusters of the same cloud provider.`,
+	}
+
+	cmd.AddCommand(newCleanupAWSVPCPeeringCommand())
+	cmd.AddCommand(newCleanupGCPVPCPeeringCommand())
+	cmd.AddCommand(newCleanupGenericVPCPeeringCommand())
+
+	return cmd
+}


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

Related to: 
* https://github.com/submariner-io/enhancements/issues/64

Depends on https://github.com/submariner-io/cloud-prepare/pull/190

Adding the `subctl cloud vpc-peering <cloud> [flags]` command for setting a VPC Peering between two clusters.

The vpc-peering command must be executed after the `cloud prepare` command to make sure all the pre-requisites are met.

As it requires a _target_ cloud to also be able to connect to it to perform all the necessary actions, the flag names will be the same but prefixed with _target_ i.e. `--target-region`. The same flags have been added so that different profiles or credentials file can be used.

Some usage examples:

* With metadata-file
```
$ subctl cloud vpc-peering aws --metadata-file=source-aws-cloud.json --target-metadata-file=target-aws-cloud.json
```
* With all other flags
```
$ subctl cloud vpc-peering aws --region=eu-west-1 --infra-id=source-infra --target=region=eu-west-2 --target-infra-id=target-infra
```
