### PR TITLE
Refactor pkg/subctl/cmd/execute.go

### DIFF
--- a/cmd/subctl/execute/execute.go
+++ b/cmd/subctl/execute/execute.go
@@ -1,0 +1,64 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package execute
+
+import (
+	"fmt"
+	"github.com/submariner-io/submariner-operator/internal/cli"
+	"github.com/submariner-io/submariner-operator/pkg/reporter"
+	"os"
+
+	"github.com/submariner-io/submariner-operator/internal/exit"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
+	"github.com/submariner-io/submariner-operator/pkg/client"
+	"github.com/submariner-io/submariner-operator/pkg/cluster"
+)
+
+func OnMultiCluster(restConfigProducer restconfig.Producer, run func(*cluster.Info, reporter.Interface) bool) {
+	success := true
+
+	status := cli.NewReporter()
+	for _, config := range restConfigProducer.MustGetForClusters() {
+		status.Start("Cluster %q", config.ClusterName)
+
+		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
+		if err != nil {
+			exit.OnErrorWithMessage(err, "Error creating the client producer")
+		}
+
+		newCluster, errMsg := cluster.New(config.ClusterName, clientProducer)
+		if newCluster == nil {
+			success = false
+
+			status.Failure(errMsg.Error())
+			fmt.Println()
+
+			continue
+		}
+
+		success = run(newCluster, status) && success
+		status.End()
+
+		fmt.Println()
+	}
+
+	if !success {
+		os.Exit(1)
+	}
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,0 +1,79 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/internal/constants"
+	"github.com/submariner-io/submariner-operator/pkg/client"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Info struct {
+	Name            string
+	ClientProducer  client.Producer
+	Submariner      *v1alpha1.Submariner
+}
+
+func New(clusterName string, clientProducer client.Producer) (*Info, error) {
+	cluster := &Info{
+		Name:           clusterName,
+		ClientProducer: clientProducer,
+	}
+
+	var err error
+
+	cluster.Submariner, err = cluster.GetSubmariner()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error retrieving Submariner")
+	}
+
+	return cluster, nil
+}
+
+func (c *Info) GetSubmariner() (*v1alpha1.Submariner, error) {
+	submariner, err := c.ClientProducer.ForOperator().SubmarinerV1alpha1().Submariners(constants.SubmarinerNamespace).
+		Get(context.TODO(), constants.SubmarinerName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.New( "Submariner not found")
+		}
+		return nil, err
+	}
+	return submariner, nil
+}
+
+func (c *Info) GetGateways() ([]submarinerv1.Gateway, error) {
+	gateways, err := c.ClientProducer.ForSubmariner().SubmarinerV1().
+		Gateways(constants.OperatorNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.New("No gateways found")
+		}
+
+		return nil, err
+	}
+
+	return gateways.Items, nil
+}


### PR DESCRIPTION
1. Rename executeMultiCluster -> OnMultiCluster
2. Move it to cmd/subctl/execute
3. Move cluster related code to pkg/cluster/cluster.go

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
