### PR TITLE
Make `ForCluster` return cluster config and name

### DIFF
--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -49,13 +49,13 @@ var deployBroker = &cobra.Command{
 		config, err := restConfigProducer.ForCluster()
 		exit.OnError(status.Error(err, "Error creating REST config"))
 
-		clientProducer, err := client.NewProducerFromRestConfig(config)
+		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
 		exit.OnError(status.Error(err, "Error creating client producer"))
 
 		err = deploy.Broker(&deployflags, clientProducer, status)
 		exit.OnError(err)
 
-		err = broker.WriteInfoToFile(config, deployflags.BrokerNamespace, ipsecSubmFile,
+		err = broker.WriteInfoToFile(config.Config, deployflags.BrokerNamespace, ipsecSubmFile,
 			stringset.New(deployflags.BrokerSpec.Components...), deployflags.BrokerSpec.DefaultCustomDomains, status)
 		exit.OnError(err)
 	},

--- a/cmd/subctl/export.go
+++ b/cmd/subctl/export.go
@@ -58,7 +58,7 @@ var (
 				exit.OnErrorWithMessage(err, "Error getting service Namespace")
 			}
 
-			clientProducer, err := client.NewProducerFromRestConfig(config)
+			clientProducer, err := client.NewProducerFromRestConfig(config.Config)
 			exit.OnError(status.Error(err, "Error creating client producer"))
 
 			err = service.Export(clientProducer, serviceNamespace, args[0], status)

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -63,7 +63,7 @@ var joinCmd = &cobra.Command{
 		clientConfig, err := restConfigProducer.ForCluster()
 		exit.OnError(status.Error(err, "Error creating the REST config"))
 
-		clientProducer, err := client.NewProducerFromRestConfig(clientConfig)
+		clientProducer, err := client.NewProducerFromRestConfig(clientConfig.Config)
 		exit.OnError(status.Error(err, "Error creating the client producer"))
 
 		networkDetails := getNetworkDetails(clientProducer, status)

--- a/cmd/subctl/uninstall.go
+++ b/cmd/subctl/uninstall.go
@@ -43,20 +43,17 @@ var uninstallCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		status := cli.NewReporter()
 
-		clusterName, err := restConfigProducer.GetClusterID()
-		exit.OnError(status.Error(err, "Error getting cluster name"))
-
 		config, err := restConfigProducer.ForCluster()
 		exit.OnError(status.Error(err, "Error creating REST config"))
 
-		clientProducer, err := client.NewProducerFromRestConfig(config)
+		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
 		exit.OnError(status.Error(err, "Error creating client producer"))
 
 		if !uninstallOptions.noPrompt {
 			result := false
 			prompt := &survey.Confirm{
 				Message: fmt.Sprintf("This will completely uninstall Submariner from the cluster %q. Are you sure you want to continue?",
-					clusterName),
+					config.ClusterName),
 			}
 
 			_ = survey.AskOne(prompt, &result)
@@ -66,7 +63,7 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		exit.OnError(uninstall.All(clientProducer, clusterName, uninstallOptions.namespace, status))
+		exit.OnError(uninstall.All(clientProducer, config.ClusterName, uninstallOptions.namespace, status))
 	},
 }
 

--- a/pkg/subctl/cmd/cloud/aws/aws.go
+++ b/pkg/subctl/cmd/cloud/aws/aws.go
@@ -87,12 +87,12 @@ func RunOnAWS(restConfigProducer restconfig.Producer, gwInstanceType string, sta
 		return status.Error(err, "error initializing Kubernetes config")
 	}
 
-	restMapper, err := util.BuildRestMapper(k8sConfig)
+	restMapper, err := util.BuildRestMapper(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating REST mapper")
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(k8sConfig)
+	dynamicClient, err := dynamic.NewForConfig(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating dynamic client")
 	}

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -119,19 +119,19 @@ func RunOnGCP(restConfigProducer restconfig.Producer, gwInstanceType string, ded
 		return status.Error(err, "error initializing Kubernetes config")
 	}
 
-	clientSet, err := kubernetes.NewForConfig(k8sConfig)
+	clientSet, err := kubernetes.NewForConfig(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating Kubernetes client")
 	}
 
 	k8sClientSet := k8s.NewInterface(clientSet)
 
-	restMapper, err := util.BuildRestMapper(k8sConfig)
+	restMapper, err := util.BuildRestMapper(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating REST mapper")
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(k8sConfig)
+	dynamicClient, err := dynamic.NewForConfig(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating dynamic client")
 	}

--- a/pkg/subctl/cmd/cloud/generic/generic.go
+++ b/pkg/subctl/cmd/cloud/generic/generic.go
@@ -35,7 +35,7 @@ func RunOnK8sCluster(restConfigProducer restconfig.Producer, status reporter.Int
 		return status.Error(err, "error initializing Kubernetes config")
 	}
 
-	clientSet, err := kubernetes.NewForConfig(k8sConfig)
+	clientSet, err := kubernetes.NewForConfig(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating Kubernetes client")
 	}

--- a/pkg/subctl/cmd/cloud/rhos/rhos.go
+++ b/pkg/subctl/cmd/cloud/rhos/rhos.go
@@ -104,19 +104,19 @@ func RunOnRHOS(restConfigProducer restconfig.Producer, gwInstanceType string, de
 		return status.Error(err, "error initializing Kubernetes config")
 	}
 
-	clientSet, err := kubernetes.NewForConfig(k8sConfig)
+	clientSet, err := kubernetes.NewForConfig(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating Kubernetes client")
 	}
 
 	k8sClientSet := k8s.NewInterface(clientSet)
 
-	restMapper, err := util.BuildRestMapper(k8sConfig)
+	restMapper, err := util.BuildRestMapper(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating REST mapper")
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(k8sConfig)
+	dynamicClient, err := dynamic.NewForConfig(k8sConfig.Config)
 	if err != nil {
 		return status.Error(err, "error creating dynamic client")
 	}

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -110,7 +110,7 @@ var deployBroker = &cobra.Command{
 		config, err := restConfigProducer.ForCluster()
 		utils.ExitOnError("The provided kubeconfig is invalid", err)
 
-		clientProducer, err := client.NewProducerFromRestConfig(config)
+		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
 		utils.ExitOnError("Error creating client producer", err)
 
 		status := cli.NewStatus()
@@ -151,7 +151,7 @@ var deployBroker = &cobra.Command{
 			}
 		}
 
-		subctlData, err := datafile.NewFromCluster(config, brokerNamespace, ipsecSubmFile)
+		subctlData, err := datafile.NewFromCluster(config.Config, brokerNamespace, ipsecSubmFile)
 		utils.ExitOnError("Error retrieving preparing the subm data file", err)
 
 		newFilename, err := datafile.BackupIfExists(brokerDetailsFilename)

--- a/pkg/subctl/cmd/diagnose/firewall_tunnel.go
+++ b/pkg/subctl/cmd/diagnose/firewall_tunnel.go
@@ -76,7 +76,7 @@ func validateTunnelConfig(command *cobra.Command, args []string) {
 	remoteCfg, err := remoteProducer.ForCluster()
 	utils.ExitOnError("The provided remote kubeconfig is invalid", err)
 
-	if !validateTunnelConfigAcrossClusters(localCfg, remoteCfg) {
+	if !validateTunnelConfigAcrossClusters(localCfg.Config, remoteCfg.Config) {
 		os.Exit(1)
 	}
 }

--- a/pkg/subctl/cmd/uninstall.go
+++ b/pkg/subctl/cmd/uninstall.go
@@ -40,20 +40,17 @@ var uninstallCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		status := cli.NewStatus()
 
-		clusterName, err := restConfigProducer.GetClusterID()
-		exit.OnError(status.Error(err, "Error getting cluster name"))
-
 		config, err := restConfigProducer.ForCluster()
 		exit.OnError(status.Error(err, "Error creating REST config"))
 
-		clientProducer, err := client.NewProducerFromRestConfig(config)
+		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
 		exit.OnError(status.Error(err, "Error creating client producer"))
 
 		if !noPrompt {
 			result := false
 			prompt := &survey.Confirm{
 				Message: fmt.Sprintf("This will completely uninstall Submariner from the cluster %q. Are you sure you want to continue?",
-					clusterName),
+					config.ClusterName),
 			}
 
 			_ = survey.AskOne(prompt, &result)
@@ -63,7 +60,7 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		exit.OnError(uninstall.All(clientProducer, clusterName, namespace, status))
+		exit.OnError(uninstall.All(clientProducer, config.ClusterName, namespace, status))
 	},
 }
 


### PR DESCRIPTION
This is needed:

1. because new [`cluster.NewInfo`](https://github.com/submariner-io/submariner-operator/blob/devel/pkg/cluster/info.go#L39) takes in a `clusterName`. For commands working on a single cluster and needing to create new cluster, `clusterName` is needed
2. uninstall cmd also needs a clustername
3. To make it consistent with [`ForClusters()`](https://github.com/submariner-io/submariner-operator/blob/devel/internal/restconfig/restconfig.go#L122)

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
4. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
5. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
6. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
7. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
