### PR TITLE
Clarify that crd.CreateOrUpdate handles embedded CRDs

### DIFF
--- a/pkg/crd/updater.go
+++ b/pkg/crd/updater.go
@@ -43,7 +43,7 @@ type baseUpdater interface {
 
 type Updater interface {
 	baseUpdater
-	CreateOrUpdate(context.Context, string) (bool, error)
+	CreateOrUpdateFromEmbedded(context.Context, string) (bool, error)
 }
 
 type updater struct {
@@ -73,7 +73,7 @@ func UpdaterFromControllerClient(controllerClient client.Client) Updater {
 	}}
 }
 
-func (u *updater) CreateOrUpdate(ctx context.Context, crdYaml string) (bool, error) {
+func (u *updater) CreateOrUpdateFromEmbedded(ctx context.Context, crdYaml string) (bool, error) {
 	crd := &apiextensions.CustomResourceDefinition{}
 
 	if err := embeddedyamls.GetObject(crdYaml, crd); err != nil {

--- a/pkg/crd/updater_test.go
+++ b/pkg/crd/updater_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Updater", func() {
 
 		When("the CRD doesn't exist", func() {
 			It("should create it", func() {
-				created, err := updater.CreateOrUpdate(context.TODO(), crdYAML)
+				created, err := updater.CreateOrUpdateFromEmbedded(context.TODO(), crdYAML)
 				Expect(created).To(BeTrue())
 				Expect(err).To(Succeed())
 				assertCRDExists(crd.Name)
@@ -91,7 +91,7 @@ var _ = Describe("Updater", func() {
 				Expect(err).To(Succeed())
 				assertCRDExists(crd.Name)
 
-				created, err := updater.CreateOrUpdate(context.TODO(), crdYAML)
+				created, err := updater.CreateOrUpdateFromEmbedded(context.TODO(), crdYAML)
 				Expect(created).To(BeFalse())
 				Expect(err).To(Succeed())
 

--- a/pkg/gateway/crds.go
+++ b/pkg/gateway/crds.go
@@ -30,37 +30,37 @@ import (
 // Ensure ensures that the required resources are deployed on the target system.
 // The resources handled here are the gateway CRDs: Cluster and Endpoint.
 func Ensure(crdUpdater crd.Updater) error {
-	_, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	_, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_submariner_crds_submariner_io_clusters_yaml)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error provisioning the Cluster CRD")
 	}
 
-	_, err = crdUpdater.CreateOrUpdate(context.TODO(),
+	_, err = crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_submariner_crds_submariner_io_endpoints_yaml)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error provisioning the Endpoint CRD")
 	}
 
-	_, err = crdUpdater.CreateOrUpdate(context.TODO(),
+	_, err = crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_submariner_crds_submariner_io_gateways_yaml)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error provisioning the Gateway CRD")
 	}
 
-	_, err = crdUpdater.CreateOrUpdate(context.TODO(),
+	_, err = crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_submariner_crds_submariner_io_clusterglobalegressips_yaml)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error provisioning the ClusterGlobalEgressIP CRD")
 	}
 
-	_, err = crdUpdater.CreateOrUpdate(context.TODO(),
+	_, err = crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_submariner_crds_submariner_io_globalegressips_yaml)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error provisioning the GlobalEgressIP CRD")
 	}
 
-	_, err = crdUpdater.CreateOrUpdate(context.TODO(),
+	_, err = crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_submariner_crds_submariner_io_globalingressips_yaml)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "error provisioning the GlobalIngressIP CRD")

--- a/pkg/lighthouse/crds.go
+++ b/pkg/lighthouse/crds.go
@@ -53,7 +53,7 @@ func Ensure(crdUpdater crd.Updater, isBroker bool) (bool, error) {
 		return false, errors.Wrap(err, "error deleting the obsolete MultiClusterServices CRD")
 	}
 
-	installedMCSSI, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	installedMCSSI, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_mcsapi_crds_multicluster_x_k8s_io_serviceimports_yaml)
 	if err != nil {
 		return installedMCSSI, errors.Wrap(err, "error creating the MCS ServiceImport CRD")
@@ -64,13 +64,13 @@ func Ensure(crdUpdater crd.Updater, isBroker bool) (bool, error) {
 		return installedMCSSI, nil
 	}
 
-	installedMCSSE, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	installedMCSSE, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_mcsapi_crds_multicluster_x_k8s_io_serviceexports_yaml)
 	if err != nil {
 		return installedMCSSI || installedMCSSE, errors.Wrap(err, "error creating the MCS ServiceExport CRD")
 	}
 
-	installedSD, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	installedSD, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_crds_submariner_io_servicediscoveries_yaml)
 	if err != nil {
 		return installedMCSSI || installedMCSSE || installedSD, errors.Wrap(err, "error creating the ServiceDiscovery CRD")

--- a/pkg/subctl/operator/submarinerop/crds/ensure.go
+++ b/pkg/subctl/operator/submarinerop/crds/ensure.go
@@ -31,19 +31,19 @@ func Ensure(crdUpdater crd.Updater) (bool, error) {
 	// Attempt to update or create the CRD definitions.
 	// TODO(majopela): In the future we may want to report when we have updated the existing
 	//                 CRD definition with new versions
-	submarinerCreated, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	submarinerCreated, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_crds_submariner_io_submariners_yaml)
 	if err != nil {
 		return false, errors.Wrap(err, "error provisioning Submariner CRD")
 	}
 
-	serviceDiscoveryCreated, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	serviceDiscoveryCreated, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_crds_submariner_io_servicediscoveries_yaml)
 	if err != nil {
 		return false, errors.Wrap(err, "error provisioning ServiceDiscovery CRD")
 	}
 
-	brokerCreated, err := crdUpdater.CreateOrUpdate(context.TODO(),
+	brokerCreated, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_crds_submariner_io_brokers_yaml)
 
 	return submarinerCreated || serviceDiscoveryCreated || brokerCreated, errors.Wrap(err, "error provisioning Broker CRD")


### PR DESCRIPTION
The other functions in the interface handle CRD objects;
CreateOrUpdate expects the name of an embedded CRD.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
