### PR TITLE
Add standard reporter.Interface implementations

### DIFF
--- a/pkg/reporter/klog.go
+++ b/pkg/reporter/klog.go
@@ -1,0 +1,50 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import "k8s.io/klog/v2"
+
+type klogType struct{}
+
+func Klog() Interface {
+	return &klogType{}
+}
+
+func (k klogType) Start(message string, args ...interface{}) {
+	klog.Infof(message, args...)
+}
+
+func (k klogType) End() {
+}
+
+func (k klogType) Success(message string, args ...interface{}) {
+	klog.Infof(message, args...)
+}
+
+func (k klogType) Failure(message string, args ...interface{}) {
+	klog.Errorf(message, args...)
+}
+
+func (k klogType) Warning(message string, args ...interface{}) {
+	klog.Warningf(message, args...)
+}
+
+func (k klogType) Error(err error, message string, args ...interface{}) error {
+	return HandleError(k, err, message, args...)
+}

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -18,6 +18,12 @@ limitations under the License.
 
 package reporter
 
+import (
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
 // Interface for reporting on the progress of an operation.
 type Interface interface {
 	// Start reports that an operation or sequence of operations is starting.
@@ -37,4 +43,24 @@ type Interface interface {
 
 	// Error wraps err with the supplied message, reports it as a failure, ends the current operation, and returns the error.
 	Error(err error, message string, args ...interface{}) error
+}
+
+func HandleError(reporter Interface, err error, message string, args ...interface{}) error {
+	err = errors.Wrapf(err, message, args...)
+	if err == nil {
+		return nil
+	}
+
+	capitalizeFirst := func(str string) string {
+		for i, v := range str {
+			return string(unicode.ToUpper(v)) + str[i+1:]
+		}
+
+		return ""
+	}
+
+	reporter.Failure(capitalizeFirst(err.Error()))
+	reporter.End()
+
+	return err
 }

--- a/pkg/reporter/silent.go
+++ b/pkg/reporter/silent.go
@@ -1,0 +1,44 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+type silent struct{}
+
+func Silent() Interface {
+	return &silent{}
+}
+
+func (s silent) Start(_ string, _ ...interface{}) {
+}
+
+func (s silent) End() {
+}
+
+func (s silent) Success(_ string, _ ...interface{}) {
+}
+
+func (s silent) Failure(_ string, _ ...interface{}) {
+}
+
+func (s silent) Warning(_ string, _ ...interface{}) {
+}
+
+func (s silent) Error(err error, message string, args ...interface{}) error {
+	return HandleError(s, err, message, args...)
+}

--- a/pkg/reporter/stdout.go
+++ b/pkg/reporter/stdout.go
@@ -1,0 +1,50 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import "fmt"
+
+type stdout struct{}
+
+func Stdout() Interface {
+	return &stdout{}
+}
+
+func (s stdout) Start(message string, args ...interface{}) {
+	s.Success(message, args...)
+}
+
+func (s stdout) End() {
+}
+
+func (s stdout) Success(message string, args ...interface{}) {
+	fmt.Printf(message+"\n", args...)
+}
+
+func (s stdout) Failure(message string, args ...interface{}) {
+	fmt.Printf("ERROR: "+message+"\n", args...)
+}
+
+func (s stdout) Warning(message string, args ...interface{}) {
+	fmt.Printf("WARNING: "+message+"\n", args...)
+}
+
+func (s stdout) Error(err error, message string, args ...interface{}) error {
+	return HandleError(s, err, message, args...)
+}


### PR DESCRIPTION
One that outputs to klog, another to stdout, and another that doesn't output anything (ie silent).
