### PR TITLE
Extend network discovery logging

### DIFF
--- a/pkg/discovery/network/canal.go
+++ b/pkg/discovery/network/canal.go
@@ -21,6 +21,7 @@ package network
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
@@ -59,13 +60,14 @@ func discoverCanalFlannelNetwork(clientSet kubernetes.Interface) (*ClusterNetwor
 	}
 
 	// Try to detect the service CIDRs using the generic functions
-	clusterIPRange, err := findClusterIPRange(clientSet)
+	clusterIPRange, clusterIPSource, err := findClusterIPRange(clientSet)
 	if err != nil {
 		return nil, err
 	}
 
 	if clusterIPRange != "" {
 		clusterNetwork.ServiceCIDRs = []string{clusterIPRange}
+		clusterNetwork.InfoSrc += fmt.Sprintf(" clusterIPSource: %s", clusterIPSource)
 	}
 
 	return clusterNetwork, nil

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -37,6 +37,7 @@ type ClusterNetwork struct {
 	NetworkPlugin  string
 	GlobalCIDR     string
 	PluginSettings map[string]string
+	InfoSrc        string
 }
 
 func (cn *ClusterNetwork) Show() {
@@ -56,7 +57,8 @@ func (cn *ClusterNetwork) Log(logger logr.Logger) {
 	logger.Info("Discovered K8s network details",
 		"plugin", cn.NetworkPlugin,
 		"clusterCIDRs", cn.PodCIDRs,
-		"serviceCIDRs", cn.ServiceCIDRs)
+		"serviceCIDRs", cn.ServiceCIDRs,
+		"infoSrc", cn.InfoSrc)
 }
 
 func (cn *ClusterNetwork) IsComplete() bool {

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -104,5 +104,7 @@ func parseOS4Network(cr *unstructured.Unstructured) (*ClusterNetwork, error) {
 		result.NetworkPlugin = ocpNetworkType
 	}
 
+	result.InfoSrc += fmt.Sprintf("OCP NetworkType: %s", ocpNetworkType)
+
 	return result, nil
 }

--- a/pkg/discovery/network/weavenet.go
+++ b/pkg/discovery/network/weavenet.go
@@ -19,6 +19,8 @@ limitations under the License.
 package network
 
 import (
+	"fmt"
+
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"k8s.io/client-go/kubernetes"
 )
@@ -50,9 +52,10 @@ func discoverWeaveNetwork(clientSet kubernetes.Interface) (*ClusterNetwork, erro
 		return nil, nil
 	}
 
-	clusterIPRange, err := findClusterIPRange(clientSet)
+	clusterIPRange, clusterIPSource, err := findClusterIPRange(clientSet)
 	if err == nil && clusterIPRange != "" {
 		clusterNetwork.ServiceCIDRs = []string{clusterIPRange}
+		clusterNetwork.InfoSrc += fmt.Sprintf(" clusterIPSource: %s", clusterIPSource)
 	}
 
 	return clusterNetwork, nil


### PR DESCRIPTION
Currently, we only log the bottom line of network discovery (plugin and cidrs),
in some cases (e.g: generic plugin) it is not clear from this information
how exactly the data was retrieved.

With this PR we should be able to deduce the source of network discovery information
also for cases like generic plugin, this additional information should be useful in cases like #1730 and
submariner-io/submariner-operator#1852   

Depends on #1802