### PR TITLE
Add globalnet image to list of images copied to local registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PATTERN := ^([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)$
 IS_SEMANTIC_VERSION = $(shell [[ $(or $(BUNDLE_VERSION),$(VERSION),'undefined') =~ $(PATTERN) ]] && echo true || echo false)
 
 IMAGES = submariner-operator submariner-operator-index
-PRELOAD_IMAGES := $(IMAGES) submariner-gateway submariner-route-agent lighthouse-agent lighthouse-coredns
+PRELOAD_IMAGES := $(IMAGES) submariner-gateway submariner-globalnet submariner-route-agent lighthouse-agent lighthouse-coredns
 undefine SKIP
 undefine FOCUS
 undefine E2E_TESTDIR


### PR DESCRIPTION
If you toggle between using `make deploy` and `make clusters`, you can get in a
state where the cluster won't come up because globalnet is not in the local
registry. Add `submariner-globalnet` to the set of images in the `PRELOAD_IMAGES`
list.

Error Example:

```
$ kubectl get pods -A
NAMESPACE             NAME                                             READY   STATUS             RESTARTS   AGE
:
submariner-operator   submariner-gateway-rsxwq                         1/1     Running            0          2m43s
submariner-operator   submariner-globalnet-5h9c6                       0/1     ImagePullBackOff   0          2m42s
submariner-operator   submariner-lighthouse-agent-75f96bbff6-h6jc4     1/1     Running            0          2m40s
submariner-operator   submariner-lighthouse-coredns-68766559c4-6pfx7   1/1     Running            0          2m40s
submariner-operator   submariner-lighthouse-coredns-68766559c4-dfkzd   1/1     Running            0          2m39s
submariner-operator   submariner-operator-5bfdb87494-mldmw             1/1     Running            1          5m35s
submariner-operator   submariner-routeagent-6zcc4                      1/1     Running            0          2m42s
submariner-operator   submariner-routeagent-f8tsw                      1/1     Running            0          2m42s
submariner-operator   submariner-routeagent-pgbtj                      1/1     Running            0          2m42s

$ kubectl describe pod -n submariner-operator submariner-globalnet-5h9c6
:
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  3m14s                default-scheduler  Successfully assigned submariner-operator/submariner-globalnet-5h9c6 to cluster1-worker
  Normal   Pulling    91s (x4 over 3m13s)  kubelet            Pulling image "localhost:5000/submariner-globalnet:local"
  Warning  Failed     91s (x4 over 3m1s)   kubelet            Failed to pull image "localhost:5000/submariner-globalnet:local": rpc error: code = Unknown desc = failed to pull and unpack image "localhost:5000/submariner-globalnet:local": failed to resolve reference "localhost:5000/submariner-globalnet:local": failed to do request: Head "http://localhost:5000/v2/submariner-globalnet/manifests/local": dial tcp 127.0.0.1:5000: connect: connection refused
  Warning  Failed     91s (x4 over 3m1s)   kubelet            Error: ErrImagePull
  Warning  Failed     79s (x6 over 3m1s)   kubelet            Error: ImagePullBackOff
  Normal   BackOff    65s (x7 over 3m1s)   kubelet            Back-off pulling image "localhost:5000/submariner-globalnet:local"

$ docker images | grep globalnet
quay.io/submariner/submariner-globalnet                dev               4b2152883754   4 days ago      205MB
quay.io/submariner/submariner-globalnet                devel             4b2152883754   4 days ago      205MB
```

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
