### PR TITLE
Add discovery to properly identify flannel cni

### DIFF
--- a/pkg/discovery/network/flannel.go
+++ b/pkg/discovery/network/flannel.go
@@ -1,0 +1,105 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/cni"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// nolint:nilnil // Intentional as the purpose is to discover.
+func discoverFlannelNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
+	daemonsets := &appsv1.DaemonSetList{}
+
+	err := client.List(context.TODO(), daemonsets, controllerClient.InNamespace(metav1.NamespaceSystem))
+	if err != nil {
+		return nil, errors.WithMessage(err, "error listing the Daemonsets")
+	}
+
+	volumes := make([]corev1.Volume, 0)
+	// look for a daemonset matching "flannel"
+	for k := range daemonsets.Items {
+		if strings.Contains(daemonsets.Items[k].Name, "flannel") {
+			volumes = daemonsets.Items[k].Spec.Template.Spec.Volumes
+		}
+	}
+
+	if len(volumes) < 1 {
+		return nil, nil
+	}
+
+	var flannelConfigMap string
+	// look for the associated confimap to the flannel daemonset
+	for k := range volumes {
+		if strings.Contains(volumes[k].Name, "flannel") {
+			if volumes[k].ConfigMap.Name != "" {
+				flannelConfigMap = volumes[k].ConfigMap.Name
+			}
+		}
+	}
+
+	if flannelConfigMap == "" {
+		return nil, nil
+	}
+
+	// look for the configmap details using the configmap name discovered from the daemonset
+	cm := &corev1.ConfigMap{}
+
+	err = client.Get(context.TODO(), controllerClient.ObjectKey{
+		Namespace: metav1.NamespaceSystem,
+		Name:      flannelConfigMap,
+	}, cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, errors.WithMessage(err, "error listing the Daemonsets")
+	}
+
+	podCIDR := extractPodCIDRFromNetConfigJSON(cm)
+	if podCIDR == nil {
+		return nil, nil
+	}
+
+	clusterNetwork := &ClusterNetwork{
+		NetworkPlugin: cni.Flannel,
+		PodCIDRs:      []string{*podCIDR},
+	}
+
+	// Try to detect the service CIDRs using the generic functions
+	clusterIPRange, err := findClusterIPRange(client)
+	if err != nil {
+		return nil, err
+	}
+
+	if clusterIPRange != "" {
+		clusterNetwork.ServiceCIDRs = []string{clusterIPRange}
+	}
+
+	return clusterNetwork, nil
+}

--- a/pkg/discovery/network/flannel_test.go
+++ b/pkg/discovery/network/flannel_test.go
@@ -1,0 +1,115 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
+	"github.com/submariner-io/submariner/pkg/cni"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testFlannelPodCIDR = "10.0.0.0/8"
+)
+
+var _ = Describe("Flannel Network", func() {
+	When("the flannel DaemonSet and ConfigMap exist", func() {
+		It("should return a ClusterNetwork with the plugin name and CIDRs set correctly", func() {
+			clusterNet := testDiscoverFlannelWith(&flannelDaemonSet, &flannelCfgMap)
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Flannel))
+			Expect(clusterNet.PodCIDRs).To(Equal([]string{testFlannelPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDRFromService}))
+		})
+	})
+
+	When("the flannel DaemonSet does not exist", func() {
+		It("should return a ClusterNetwork with the generic plugin", func() {
+			clusterNet := testDiscoverFlannelWith()
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Generic))
+		})
+	})
+
+	When("the flannel ConfigMap does not exist", func() {
+		It("should return a ClusterNetwork with the generic plugin", func() {
+			clusterNet := testDiscoverFlannelWith(&flannelDaemonSet)
+			Expect(clusterNet).NotTo(BeNil())
+			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Generic))
+		})
+	})
+})
+
+func testDiscoverFlannelWith(objects ...controllerClient.Object) *network.ClusterNetwork {
+	client := newTestClient(objects...)
+	clusterNet, err := network.Discover(client, "")
+	Expect(err).NotTo(HaveOccurred())
+
+	return clusterNet
+}
+
+var flannelDaemonSet = appsv1.DaemonSet{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "kube-flannel-ds",
+		Namespace: metav1.NamespaceSystem,
+	},
+	Spec: appsv1.DaemonSetSpec{
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: corev1.PodSpec{
+				Volumes: volumes,
+			},
+		},
+	},
+}
+
+var volumes = []corev1.Volume{
+	{
+		Name: "flannel-cfg",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "kube-flannel-cfg"},
+			},
+		},
+	},
+}
+
+var flannelCfgMap = corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "kube-flannel-cfg",
+		Namespace: metav1.NamespaceSystem,
+	},
+	Data: map[string]string{
+		"net-conf.json": `{
+			"Network": "10.0.0.0/8",
+			"SubnetLen": 20,
+			"SubnetMin": "10.10.0.0",
+			"SubnetMax": "10.99.0.0",
+			"Backend": {
+				"Type": "udp",
+				"Port": 7890
+			}
+		}`,
+	},
+}

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -120,6 +120,11 @@ func networkPluginsDiscovery(client controllerClient.Client) (*ClusterNetwork, e
 		}
 	}
 
+	flanelNet, err := discoverFlannelNetwork(client)
+	if err != nil || flanelNet != nil {
+		return flanelNet, err
+	}
+
 	return nil, nil
 }
 

--- a/release-notes/20220216-flannel-cni.md
+++ b/release-notes/20220216-flannel-cni.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD041 -->
+The flannel CNI is now properly identified during join.


### PR DESCRIPTION
- this commit checks for a daemonset containing app=flannel
  and then extracts details from the associated configmap
  in the same fashion as the canal cni support.

Dependent on v0.12.0 with code freeze coming up

Fixes https://github.com/submariner-io/submariner-operator/issues/1731

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
