### PR TITLE
Use constants for Globalnet defaults

### DIFF
--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -69,10 +69,10 @@ func init() {
 func addDeployBrokerFlags() {
 	deployBroker.PersistentFlags().BoolVar(&deployflags.BrokerSpec.GlobalnetEnabled, "globalnet", false,
 		"enable support for Overlapping CIDRs in connecting clusters (default disabled)")
-	deployBroker.PersistentFlags().StringVar(&deployflags.BrokerSpec.GlobalnetCIDRRange, "globalnet-cidr-range", "242.0.0.0/8",
-		"GlobalCIDR supernet range for allocating GlobalCIDRs to each cluster")
-	deployBroker.PersistentFlags().UintVar(&deployflags.BrokerSpec.DefaultGlobalnetClusterSize, "globalnet-cluster-size", 65536,
-		"default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
+	deployBroker.PersistentFlags().StringVar(&deployflags.BrokerSpec.GlobalnetCIDRRange, "globalnet-cidr-range",
+		broker.DefaultGlobalnetCIDR, "GlobalCIDR supernet range for allocating GlobalCIDRs to each cluster")
+	deployBroker.PersistentFlags().UintVar(&deployflags.BrokerSpec.DefaultGlobalnetClusterSize, "globalnet-cluster-size",
+		broker.DefaultGlobalnetClusterSize, "default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
 
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
 		"import IPsec PSK from existing submariner broker file, like broker-info.subm")

--- a/pkg/broker/globalcidr_cm.go
+++ b/pkg/broker/globalcidr_cm.go
@@ -30,11 +30,13 @@ import (
 )
 
 const (
-	GlobalCIDRConfigMapName = "submariner-globalnet-info"
-	GlobalnetStatusKey      = "globalnetEnabled"
-	ClusterInfoKey          = "clusterinfo"
-	GlobalnetCidrRange      = "globalnetCidrRange"
-	GlobalnetClusterSize    = "globalnetClusterSize"
+	GlobalCIDRConfigMapName     = "submariner-globalnet-info"
+	GlobalnetStatusKey          = "globalnetEnabled"
+	ClusterInfoKey              = "clusterinfo"
+	GlobalnetCidrRange          = "globalnetCidrRange"
+	GlobalnetClusterSize        = "globalnetClusterSize"
+	DefaultGlobalnetCIDR        = "242.0.0.0/8"
+	DefaultGlobalnetClusterSize = 65536 // i.e., x.x.x.x/16 subnet mask
 )
 
 type ClusterInfo struct {


### PR DESCRIPTION
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
