### PR TITLE
Include delete clusterrole for globalnet sa

### DIFF
--- a/config/rbac/submariner-globalnet/cluster_role.yaml
+++ b/config/rbac/submariner-globalnet/cluster_role.yaml
@@ -42,15 +42,6 @@ rules:
     resources:
       - clusterglobalegressips
       - globalegressips
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - submariner.io
-    resources:
       - globalingressips
     verbs:
       - create


### PR DESCRIPTION
As part of uninstall operation, the globalnet-pod will
be deleting the clusterGlobalEgressIPs, globalEgressIPs
and globalIngressIPs created in the cluster. This PR
includes the necessary cluster role.

Related to: https://github.com/submariner-io/submariner/issues/1637
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
