### PR TITLE
Add E2E tests for component cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ endif
 
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
-override E2E_ARGS += $(CLUSTER_SETTINGS_FLAG)
+override E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) cluster1 cluster2
 export DEPLOY_ARGS
-override UNIT_TEST_ARGS += cmd internal/cli internal/env internal/log
+override UNIT_TEST_ARGS += test internal/env
 override VALIDATE_ARGS += --skip-dirs pkg/client
 
 # Process extra flags from the `using=a,b,c` optional flag

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -251,7 +251,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            "submariner-lighthouse-agent",
+							Name:            name,
 							Image:           getImagePath(cr, names.ServiceDiscoveryImage, names.ServiceDiscoveryImage),
 							ImagePullPolicy: helpers.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.ServiceDiscoveryImage]),
 							Env: []corev1.EnvVar{

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -69,5 +69,7 @@ ${DAPPER_SOURCE}/bin/subctl benchmark throughput --intra-cluster ${KUBECONFIGS_D
 
 ${DAPPER_SOURCE}/bin/subctl benchmark throughput --verbose ${KUBECONFIGS_DIR}/kind-config-cluster1 ${KUBECONFIGS_DIR}/kind-config-cluster2
 
+${SCRIPTS_DIR}/e2e.sh "$@"
+
 print_clusters_message
 

--- a/test/e2e/cleanup/service_discovery.go
+++ b/test/e2e/cleanup/service_discovery.go
@@ -1,0 +1,168 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/controllers/uninstall"
+	operatorclient "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	operatorv1alpha1client "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned/typed/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Service Discovery cleanup", func() {
+	When("the ServiceDiscovery resource is deleted", testServiceDiscoveryCleanup)
+})
+
+func testServiceDiscoveryCleanup() {
+	var (
+		serviceDiscoveryInterface operatorv1alpha1client.ServiceDiscoveryInterface
+		submarinerInterface       operatorv1alpha1client.SubmarinerInterface
+		serviceDiscovery          *operatorv1alpha1.ServiceDiscovery
+		submariner                *operatorv1alpha1.Submariner
+		lhAgentAgentPodMonitor    *podMonitor
+		stopCh                    chan struct{}
+	)
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+
+		operatorClient, err := operatorclient.NewForConfig(framework.RestConfigs[framework.ClusterA])
+		Expect(err).To(Succeed())
+
+		serviceDiscoveryInterface = operatorClient.SubmarinerV1alpha1().ServiceDiscoveries(framework.TestContext.SubmarinerNamespace)
+		submarinerInterface = operatorClient.SubmarinerV1alpha1().Submariners(framework.TestContext.SubmarinerNamespace)
+
+		installed := false
+
+		submariner, err = submarinerInterface.Get(context.TODO(), submarinercr.SubmarinerName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			submariner = nil
+
+			serviceDiscovery, err = serviceDiscoveryInterface.Get(context.TODO(), names.ServiceDiscoveryCrName, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				Expect(err).To(Succeed())
+				installed = true
+			}
+		} else {
+			Expect(err).To(Succeed())
+			installed = submariner.Spec.ServiceDiscoveryEnabled
+		}
+
+		if !installed {
+			framework.Skipf("ServiceDiscovery is not installed, skipping the test...")
+			return
+		}
+
+		lhAgentAgentPodMonitor = startPodMonitor(names.AppendUninstall(names.ServiceDiscoveryComponent), stopCh)
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+
+		if submariner != nil {
+			Expect(util.Update(context.TODO(), resourceInterfaceForSubmariner(submarinerInterface), submariner,
+				func(existing runtime.Object) (runtime.Object, error) {
+					existing.(*operatorv1alpha1.Submariner).Spec.ServiceDiscoveryEnabled = true
+					return existing, nil
+				})).To(Succeed())
+		} else if serviceDiscovery != nil {
+			serviceDiscovery.ObjectMeta = metav1.ObjectMeta{
+				Name:        serviceDiscovery.Name,
+				Labels:      serviceDiscovery.Labels,
+				Annotations: serviceDiscovery.Annotations,
+			}
+
+			_, err := serviceDiscoveryInterface.Create(context.TODO(), serviceDiscovery, metav1.CreateOptions{})
+			if err != nil {
+				framework.Errorf("Error re-creating ServiceDiscovery: %v", err)
+			} else {
+				By("Re-created ServiceDiscovery resource")
+			}
+		}
+	})
+
+	It("should run an uninstall Deployment and cleanup coredns config", func() {
+		By(fmt.Sprintf("Deleting ServiceDiscovery resource in %q", framework.TestContext.ClusterIDs[framework.ClusterA]))
+
+		if submariner != nil {
+			Expect(util.Update(context.TODO(), resourceInterfaceForSubmariner(submarinerInterface), submariner,
+				func(existing runtime.Object) (runtime.Object, error) {
+					existing.(*operatorv1alpha1.Submariner).Spec.ServiceDiscoveryEnabled = false
+					return existing, nil
+				})).To(Succeed())
+		} else {
+			Expect(serviceDiscoveryInterface.Delete(context.TODO(), names.ServiceDiscoveryCrName, metav1.DeleteOptions{})).To(Succeed())
+		}
+
+		Eventually(func() bool {
+			_, err := serviceDiscoveryInterface.Get(context.TODO(), names.ServiceDiscoveryCrName, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, uninstall.ComponentReadyTimeout*2).Should(BeTrue(), "ServiceDiscovery resource not deleted")
+
+		By("ServiceDiscovery resource deleted")
+
+		lhAgentAgentPodMonitor.assertUninstallPodsCompleted()
+
+		_, err := framework.KubeClients[framework.ClusterA].AppsV1().Deployments(framework.TestContext.SubmarinerNamespace).Get(context.TODO(),
+			names.AppendUninstall(names.ServiceDiscoveryComponent), metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("Unexpected Deployment %q found",
+			names.AppendUninstall(names.ServiceDiscoveryComponent)))
+
+		Expect(getCorednsConfigMap().Data["Corefile"]).ToNot(ContainSubstring("lighthouse"))
+	})
+}
+
+func getCorednsConfigMap() *corev1.ConfigMap {
+	configMap, err := framework.KubeClients[framework.ClusterA].CoreV1().ConfigMaps("kube-system").Get(context.TODO(),
+		"coredns", metav1.GetOptions{})
+	Expect(err).To(Succeed())
+
+	return configMap
+}
+
+func resourceInterfaceForSubmariner(client operatorv1alpha1client.SubmarinerInterface) resource.Interface {
+	return &resource.InterfaceFuncs{
+		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.Get(ctx, name, options)
+		},
+		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
+			return client.Create(ctx, obj.(*operatorv1alpha1.Submariner), options)
+		},
+		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.Update(ctx, obj.(*operatorv1alpha1.Submariner), options)
+		},
+		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+			return client.Delete(ctx, name, options)
+		},
+	}
+}

--- a/test/e2e/cleanup/submariner.go
+++ b/test/e2e/cleanup/submariner.go
@@ -1,0 +1,330 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/watcher"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/controllers/uninstall"
+	operatorclient "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	operatorv1alpha1client "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned/typed/submariner/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
+	submarinerclientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("Submariner cleanup", func() {
+	When("the Submariner resource is deleted", testSubmarinerCleanup)
+})
+
+func testSubmarinerCleanup() {
+	var (
+		submarinerInterface           operatorv1alpha1client.SubmarinerInterface
+		submariner                    *operatorv1alpha1.Submariner
+		routeAgentPodMonitor          *podMonitor
+		gatewayPodMonitor             *podMonitor
+		globalnetPodMonitor           *podMonitor
+		networkPluginSyncerPodMonitor *podMonitor
+		brokerRestConfig              *rest.Config
+		stopCh                        chan struct{}
+	)
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+
+		framework.DetectGlobalnet()
+
+		operatorClient, err := operatorclient.NewForConfig(framework.RestConfigs[framework.ClusterA])
+		Expect(err).To(Succeed())
+
+		submarinerInterface = operatorClient.SubmarinerV1alpha1().Submariners(framework.TestContext.SubmarinerNamespace)
+
+		submariner, err = submarinerInterface.Get(context.TODO(), submarinercr.SubmarinerName, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+
+		brokerRestConfig = getBrokerRestConfig(submariner.Spec.BrokerK8sRemoteNamespace)
+		Expect(brokerRestConfig).ToNot(BeNil(), "No broker located")
+
+		routeAgentPodMonitor = startPodMonitor(names.AppendUninstall(names.RouteAgentComponent), stopCh)
+		gatewayPodMonitor = startPodMonitor(names.AppendUninstall(names.GatewayComponent), stopCh)
+
+		if framework.TestContext.GlobalnetEnabled {
+			globalnetPodMonitor = startPodMonitor(names.AppendUninstall(names.GlobalnetComponent), stopCh)
+		}
+
+		_, err = framework.KubeClients[framework.ClusterA].AppsV1().Deployments(framework.TestContext.SubmarinerNamespace).Get(context.TODO(),
+			names.NetworkPluginSyncerComponent, metav1.GetOptions{})
+		if err == nil {
+			networkPluginSyncerPodMonitor = startPodMonitor(names.AppendUninstall(names.NetworkPluginSyncerComponent), stopCh)
+		}
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+
+		if submariner != nil {
+			submariner.ObjectMeta = metav1.ObjectMeta{
+				Name:        submariner.Name,
+				Labels:      submariner.Labels,
+				Annotations: submariner.Annotations,
+			}
+
+			_, err := submarinerInterface.Create(context.TODO(), submariner, metav1.CreateOptions{})
+			if err != nil {
+				framework.Errorf("Error re-creating Submariner: %v", err)
+			} else {
+				By("Re-created Submariner resource")
+			}
+		}
+	})
+
+	It("should run DaemonSets/Deployments to uninstall components", func() {
+		By(fmt.Sprintf("Deleting Submariner resource in %q", framework.TestContext.ClusterIDs[framework.ClusterA]))
+
+		Expect(submarinerInterface.Delete(context.TODO(), submariner.Name, metav1.DeleteOptions{})).To(Succeed())
+
+		Eventually(func() bool {
+			_, err := submarinerInterface.Get(context.TODO(), submariner.Name, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, uninstall.ComponentReadyTimeout*2).Should(BeTrue(), "Submariner resource not deleted")
+
+		By("Submariner resource deleted")
+
+		routeAgentPodMonitor.assertUninstallPodsCompleted()
+		gatewayPodMonitor.assertUninstallPodsCompleted()
+		globalnetPodMonitor.assertUninstallPodsCompleted()
+		networkPluginSyncerPodMonitor.assertUninstallPodsCompleted()
+
+		_, err := framework.KubeClients[framework.ClusterA].AppsV1().DaemonSets(framework.TestContext.SubmarinerNamespace).Get(context.TODO(),
+			names.AppendUninstall(names.GatewayComponent), metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("Unexpected DaemonSet %q found",
+			names.AppendUninstall(names.GatewayComponent)))
+
+		_, err = framework.KubeClients[framework.ClusterA].AppsV1().DaemonSets(framework.TestContext.SubmarinerNamespace).Get(context.TODO(),
+			names.AppendUninstall(names.RouteAgentComponent), metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("Unexpected DaemonSet %q found",
+			names.AppendUninstall(names.RouteAgentComponent)))
+
+		_, err = framework.KubeClients[framework.ClusterA].AppsV1().DaemonSets(framework.TestContext.SubmarinerNamespace).Get(context.TODO(),
+			names.AppendUninstall(names.GlobalnetComponent), metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("Unexpected DaemonSet %q found",
+			names.AppendUninstall(names.GlobalnetComponent)))
+
+		_, err = framework.KubeClients[framework.ClusterA].AppsV1().Deployments(framework.TestContext.SubmarinerNamespace).Get(context.TODO(),
+			names.AppendUninstall(names.NetworkPluginSyncerComponent), metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("Unexpected Deployment %q found",
+			names.AppendUninstall(names.NetworkPluginSyncerComponent)))
+
+		assertNoClusterResources(brokerRestConfig, submariner.Spec.BrokerK8sRemoteNamespace)
+		assertNoEndpointResources(brokerRestConfig, submariner.Spec.BrokerK8sRemoteNamespace)
+		assertNoGlobalnetResources()
+	})
+}
+
+func assertNoGlobalnetResources() {
+	client, err := submarinerclientset.NewForConfig(framework.RestConfigs[framework.ClusterA])
+	Expect(err).To(Succeed())
+
+	list, err := client.SubmarinerV1().ClusterGlobalEgressIPs(metav1.NamespaceNone).List(context.TODO(), metav1.ListOptions{})
+	Expect(err).To(Succeed())
+	Expect(list.Items).To(BeEmpty())
+}
+
+func assertNoEndpointResources(brokerRestConfig *rest.Config, brokerNS string) {
+	clusterID := framework.TestContext.ClusterIDs[framework.ClusterA]
+
+	By(fmt.Sprintf("Verifying no Endpoint resources for %q", clusterID))
+
+	assertNoEndpoints := func(restConfig *rest.Config, namespace, msgFormat string) {
+		client, err := submarinerclientset.NewForConfig(restConfig)
+		Expect(err).To(Succeed())
+
+		endpoints, err := client.SubmarinerV1().Endpoints(namespace).List(context.TODO(), metav1.ListOptions{})
+		Expect(err).To(Succeed())
+
+		for i := range endpoints.Items {
+			Expect(endpoints.Items[i].Spec.ClusterID).ToNot(Equal(clusterID), fmt.Sprintf(msgFormat, endpoints.Items[i].Name))
+		}
+	}
+
+	assertNoEndpoints(brokerRestConfig, brokerNS, "Unexpected Endpoint %q found on the broker")
+	assertNoEndpoints(framework.RestConfigs[framework.ClusterA], framework.TestContext.SubmarinerNamespace,
+		"Unexpected local Endpoint %q found")
+}
+
+func assertNoClusterResources(brokerRestConfig *rest.Config, brokerNS string) {
+	clusterID := framework.TestContext.ClusterIDs[framework.ClusterA]
+
+	By(fmt.Sprintf("Verifying no Cluster resources for %q", clusterID))
+
+	assertNoCluster := func(restConfig *rest.Config, namespace, msgFormat string) {
+		client, err := submarinerclientset.NewForConfig(restConfig)
+		Expect(err).To(Succeed())
+
+		_, err = client.SubmarinerV1().Clusters(namespace).Get(context.TODO(), clusterID, metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), fmt.Sprintf(msgFormat, clusterID))
+	}
+
+	assertNoCluster(brokerRestConfig, brokerNS, "Unexpected Cluster %q found on the broker")
+	assertNoCluster(framework.RestConfigs[framework.ClusterA], framework.TestContext.SubmarinerNamespace,
+		"Unexpected local Cluster %q found")
+}
+
+type podInfo struct {
+	status  corev1.PodStatus
+	log     string
+	prevLog string
+}
+
+type podMonitor struct {
+	sync.Mutex
+	name string
+	pods map[string]*podInfo
+}
+
+func startPodMonitor(name string, stopCh <-chan struct{}) *podMonitor {
+	m := &podMonitor{
+		name: name,
+		pods: map[string]*podInfo{},
+	}
+
+	w, err := watcher.New(&watcher.Config{
+		RestConfig: framework.RestConfigs[framework.ClusterA],
+		ResourceConfigs: []watcher.ResourceConfig{
+			{
+				Name:         m.name,
+				ResourceType: &corev1.Pod{},
+				Handler: watcher.EventHandlerFuncs{
+					OnCreateFunc: m.processPod,
+					OnUpdateFunc: m.processPod,
+				},
+				SourceNamespace:     framework.TestContext.SubmarinerNamespace,
+				SourceLabelSelector: "app=" + name,
+			},
+		},
+	})
+	Expect(err).To(Succeed())
+
+	err = w.Start(stopCh)
+	Expect(err).To(Succeed())
+
+	return m
+}
+
+func (m *podMonitor) processPod(obj runtime.Object, _ int) bool {
+	defer GinkgoRecover()
+
+	pod := obj.(*corev1.Pod)
+
+	m.Lock()
+	defer m.Unlock()
+
+	info := m.pods[pod.Name]
+	if info == nil {
+		info = &podInfo{}
+		m.pods[pod.Name] = info
+	}
+
+	info.status = pod.Status
+
+	logOptions := corev1.PodLogOptions{
+		Container: m.name,
+	}
+
+	getPodLog(pod.Name, &logOptions, &info.log)
+
+	logOptions.Previous = true
+	getPodLog(pod.Name, &logOptions, &info.prevLog)
+
+	return false
+}
+
+func (m *podMonitor) assertUninstallPodsCompleted() {
+	if m == nil {
+		return
+	}
+
+	By(fmt.Sprintf("Verifying uninstall pods for component %q completed", m.name))
+
+	m.Lock()
+	defer m.Unlock()
+
+	Expect(len(m.pods)).ToNot(BeZero(), fmt.Sprintf("No uninstall pods were created for component %q", m.name))
+
+	for name, info := range m.pods {
+		if info.status.Phase == corev1.PodRunning {
+			continue
+		}
+
+		status, _ := json.MarshalIndent(info.status, "", "  ")
+
+		log := info.prevLog
+		if log == "" {
+			log = info.log
+		}
+
+		Fail(fmt.Sprintf("Pod %q did not complete\nSTATUS: %s\n\nLOG\n: %s\n", name, string(status), log))
+	}
+}
+
+func getPodLog(name string, options *corev1.PodLogOptions, writeTo *string) {
+	req := framework.KubeClients[framework.ClusterA].CoreV1().Pods(framework.TestContext.SubmarinerNamespace).GetLogs(name, options)
+
+	stream, err := req.Stream(context.TODO())
+	if err != nil {
+		return
+	}
+
+	defer stream.Close()
+
+	log := new(bytes.Buffer)
+
+	_, err = io.Copy(log, stream)
+	if err != nil {
+		return
+	}
+
+	*writeTo = log.String()
+}
+
+func getBrokerRestConfig(brokerNS string) *rest.Config {
+	for i := range framework.RestConfigs {
+		_, err := framework.KubeClients[i].CoreV1().Namespaces().Get(context.TODO(), brokerNS, metav1.GetOptions{})
+		if err == nil {
+			return framework.RestConfigs[i]
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,29 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/submariner-io/shipyard/test/e2e"
+	_ "github.com/submariner-io/submariner-operator/test/e2e/cleanup"
+)
+
+func TestE2E(t *testing.T) {
+	e2e.RunE2ETests(t)
+}


### PR DESCRIPTION
Delete the `Submariner` resource and verify the uninstall `Daemonset` pods successfully complete. If one doesn't, output its status and pod log. Also verify resources are deleted from the broker.

After the test completes, it re-creates the `Submariner` resource.

Added a similar test for `ServiceDiscovery`.

Depends on https://github.com/submariner-io/lighthouse/pull/691