### PR TITLE
Add polaris validations GHA

### DIFF
--- a/.github/workflows/polaris.yml
+++ b/.github/workflows/polaris.yml
@@ -1,0 +1,53 @@
+---
+name: Polaris validations
+
+on:
+  pull_request:
+
+jobs:
+  default:
+    name: k8s
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: make subctl
+        run: |
+          make bin/subctl
+
+      - name: show subctl help
+        run: |
+          bin/subctl help
+          bin/subctl deploy-broker --help
+          bin/subctl join --help
+
+      - name: Deploy clusters
+        run: |
+          make clusters
+
+      - name: Deploy broker
+        run: |
+          bin/subctl deploy-broker --kubeconfig output/kubeconfigs/kind-config-cluster1 --broker-namespace newnamespace
+
+      - name: Label gateway nodes
+        run: |
+          kubectl --kubeconfig output/kubeconfigs/kind-config-cluster1 label node cluster1-worker submariner.io/gateway=true --overwrite
+          kubectl --kubeconfig output/kubeconfigs/kind-config-cluster2 label node cluster2-worker submariner.io/gateway=true --overwrite
+
+      - name: Join clusters
+        run: |
+          bin/subctl join --kubeconfig output/kubeconfigs/kind-config-cluster1 broker-info.subm --clusterid cluster1 --natt=false \
+            --servicecidr 100.1.0.0/16 --clustercidr 10.1.0.0/16
+          bin/subctl join --kubeconfig output/kubeconfigs/kind-config-cluster2 broker-info.subm --clusterid cluster2 --natt=false \
+            --servicecidr 100.2.0.0/16 --clustercidr 10.2.0.0/16
+
+      - name: Setup polaris
+        uses: fairwindsops/polaris/.github/actions/setup-polaris@master
+        with:
+          version: 5.0.0
+
+      - name: Run against cluster1 (has both Broker and Submariner)
+        run: |
+          polaris audit --kubeconfig output/kubeconfigs/kind-config-cluster1 --format pretty


### PR DESCRIPTION
[Polaris](https://polaris.docs.fairwinds.com/) is a k8s validation tool. It runs a variety of checks to ensure
that Kubernetes pods and controllers are configured using best
practices, helping you avoid problems in the future.

https://github.com/submariner-io/submariner-operator/pull/1860 is a result of red flag raised by Polaris.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
