### PR TITLE
Added command to unexport services

### DIFF
--- a/pkg/subctl/cmd/root.go
+++ b/pkg/subctl/cmd/root.go
@@ -48,6 +48,7 @@ var (
 		Short: "An installer for Submariner",
 	}
 	restConfigProducer = restconfig.NewProducer()
+	namespace          string
 )
 
 const SubmMissingMessage = "Submariner is not installed"
@@ -62,6 +63,10 @@ func init() {
 
 func AddToRootCommand(cmd *cobra.Command) {
 	rootCmd.AddCommand(cmd)
+}
+
+func addNamespaceFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace to use")
 }
 
 const (

--- a/pkg/subctl/cmd/unexport.go
+++ b/pkg/subctl/cmd/unexport.go
@@ -25,7 +25,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	"github.com/submariner-io/submariner-operator/internal/exit"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mcsclient "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 )
@@ -34,7 +34,7 @@ var (
 	unexportCmd = &cobra.Command{
 		Use:   "unexport",
 		Short: "Stop a resource from being exported to other clusters",
-		Long:  "This command stops exporting a resource so it isn't accessible to other clusters any more",
+		Long:  "This command stops exporting a resource so that it's no longer accessible to other clusters",
 	}
 	unexportServiceCmd = &cobra.Command{
 		Use:   "service <serviceName>",
@@ -55,14 +55,14 @@ func init() {
 
 func unexportService(cmd *cobra.Command, args []string) {
 	err := validateUnexportArguments(args)
-	utils.ExitOnError("Insufficient arguments", err)
+	exit.OnErrorWithMessage(err, "Insufficient arguments")
 
 	clientConfig := restConfigProducer.ClientConfig()
 	restConfig, err := clientConfig.ClientConfig()
-	utils.ExitOnError("Error connecting to the target cluster", err)
+	exit.OnErrorWithMessage(err, "Error connecting to the target cluster")
 
 	client, err := mcsclient.NewForConfig(restConfig)
-	utils.ExitOnError("Error connecting to the target cluster", err)
+	exit.OnErrorWithMessage(err, "Error connecting to the target cluster")
 
 	if namespace == "" {
 		if namespace, _, err = clientConfig.Namespace(); err != nil {
@@ -72,7 +72,7 @@ func unexportService(cmd *cobra.Command, args []string) {
 
 	err = client.ServiceExports(namespace).Delete(context.TODO(), args[0], metav1.DeleteOptions{})
 
-	utils.ExitOnError("Failed to unexport Service", err)
+	exit.OnErrorWithMessage(err, "Failed to unexport Service")
 	fmt.Fprintln(os.Stdout, "Service unexported successfully")
 }
 

--- a/pkg/subctl/cmd/unexport.go
+++ b/pkg/subctl/cmd/unexport.go
@@ -1,0 +1,85 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mcsclient "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
+)
+
+var (
+	unexportCmd = &cobra.Command{
+		Use:   "unexport",
+		Short: "Stop a resource from being exported to other clusters",
+		Long:  "This command stops exporting a resource so it isn't accessible to other clusters any more",
+	}
+	unexportServiceCmd = &cobra.Command{
+		Use:   "service <serviceName>",
+		Short: "Stop a Service from being exported to other clusters",
+		Long: "This command removes the ServiceExport resource with the given name which in turn stops the Service " +
+			"of the same name from being exported to other clusters",
+		PreRunE: restConfigProducer.CheckVersionMismatch,
+		Run:     unexportService,
+	}
+)
+
+func init() {
+	restConfigProducer.AddKubeContextFlag(unexportCmd)
+	addNamespaceFlag(unexportServiceCmd)
+	unexportCmd.AddCommand(unexportServiceCmd)
+	rootCmd.AddCommand(unexportCmd)
+}
+
+func unexportService(cmd *cobra.Command, args []string) {
+	err := validateUnexportArguments(args)
+	utils.ExitOnError("Insufficient arguments", err)
+
+	clientConfig := restConfigProducer.ClientConfig()
+	restConfig, err := clientConfig.ClientConfig()
+	utils.ExitOnError("Error connecting to the target cluster", err)
+
+	client, err := mcsclient.NewForConfig(restConfig)
+	utils.ExitOnError("Error connecting to the target cluster", err)
+
+	if namespace == "" {
+		if namespace, _, err = clientConfig.Namespace(); err != nil {
+			namespace = "default"
+		}
+	}
+
+	err = client.ServiceExports(namespace).Delete(context.TODO(), args[0], metav1.DeleteOptions{})
+
+	utils.ExitOnError("Failed to unexport Service", err)
+	fmt.Fprintln(os.Stdout, "Service unexported successfully")
+}
+
+func validateUnexportArguments(args []string) error {
+	if len(args) == 0 || args[0] == "" {
+		return errors.New("name of the Service to be removed must be specified")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This should be more intuitive to users, instead of having them go delete
the `ServiceExport` CR.

Resolves: #1830

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
