### PR TITLE
Added internal service to gather collection

### DIFF
--- a/pkg/subctl/cmd/gather/gather.go
+++ b/pkg/subctl/cmd/gather/gather.go
@@ -222,6 +222,7 @@ func gatherDiscovery(dataType string, info Info) bool {
 		gatherEndpointSlices(&info, corev1.NamespaceAll)
 		gatherConfigMapLighthouseDNS(&info, cmd.SubmarinerNamespace)
 		gatherConfigMapCoreDNS(&info)
+		gatherLabeledServices(&info, internalSvcLabel)
 	default:
 		return false
 	}

--- a/pkg/subctl/cmd/gather/servicediscovery.go
+++ b/pkg/subctl/cmd/gather/servicediscovery.go
@@ -20,6 +20,7 @@ package gather
 
 import (
 	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -32,6 +33,7 @@ const (
 	lighthouseComponentsLabel = "component=submariner-lighthouse"
 	k8sCoreDNSPodLabel        = "k8s-app=kube-dns"
 	ocpCoreDNSPodLabel        = "dns.operator.openshift.io/daemonset-dns=default"
+	internalSvcLabel          = "submariner.io/exportedServiceRef"
 )
 
 func gatherServiceDiscoveryPodLogs(info *Info) {
@@ -108,6 +110,15 @@ func gatherConfigMapCoreDNS(info *Info) {
 
 		gatherConfigMaps(info, namespace, metav1.ListOptions{FieldSelector: fieldSelector})
 	}
+}
+
+// gatherLabeledServices gathers a service based on the label provided.
+func gatherLabeledServices(info *Info, label string) {
+	ResourcesToYAMLFile(info, schema.GroupVersionResource{
+		Group:    corev1.SchemeGroupVersion.Group,
+		Version:  corev1.SchemeGroupVersion.Version,
+		Resource: "services",
+	}, corev1.NamespaceAll, metav1.ListOptions{LabelSelector: label})
 }
 
 func gatherConfigMapLighthouseDNS(info *Info, namespace string) {


### PR DESCRIPTION
- this commit adds the collection of the internal service
  that is created by every exported service.
- the collection criteria is a service that is labeled with
  submariner.io/exportedServiceRef with a value of the service name.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

Associated with issue [#1700](https://github.com/submariner-io/submariner/issues/1700)