### PR TITLE
Warn user when generic plugin is detected in diagnose

### DIFF
--- a/pkg/subctl/cmd/diagnose/cni.go
+++ b/pkg/subctl/cmd/diagnose/cni.go
@@ -82,7 +82,12 @@ func checkCNIConfig(cluster *cmd.Cluster) bool {
 		return false
 	}
 
-	status.EndWithSuccess("The detected CNI network plugin (%q) is supported", cluster.Submariner.Status.NetworkPlugin)
+	if cluster.Submariner.Status.NetworkPlugin == constants.NetworkPluginGeneric {
+		status.EndWithWarning("Submariner could not detect the CNI network plugin and is using (%q) plugin."+
+			" It may or may not work.", cluster.Submariner.Status.NetworkPlugin)
+	} else {
+		status.EndWithSuccess("The detected CNI network plugin (%q) is supported", cluster.Submariner.Status.NetworkPlugin)
+	}
 
 	return checkCalicoIPPoolsIfCalicoCNI(cluster)
 }


### PR DESCRIPTION
Although "generic" network plugin works with many CNIs,
there is no guarantee that it will work with all.
So, instead of reporting success, this PR displays
appropriate warning.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
