### PR TITLE
Fix extraneous uninstall pods present after cleanup complete

### DIFF
--- a/controllers/servicediscovery/cleanup.go
+++ b/controllers/servicediscovery/cleanup.go
@@ -40,6 +40,10 @@ import (
 )
 
 func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.ServiceDiscovery) (reconcile.Result, error) {
+	if !finalizer.IsPresent(instance, constants.CleanupFinalizer) {
+		return reconcile.Result{}, nil
+	}
+
 	if !uninstall.IsSupportedForVersion(instance.Spec.Version) {
 		log.Info("Deleting ServiceDiscovery version does not support uninstall", "version", instance.Spec.Version)
 		return reconcile.Result{}, r.removeFinalizer(ctx, instance)
@@ -87,7 +91,7 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 	}
 
 	if requeue {
-		return reconcile.Result{RequeueAfter: time.Millisecond * 100}, nil
+		return reconcile.Result{RequeueAfter: time.Millisecond * 500}, nil
 	}
 
 	return reconcile.Result{}, r.removeFinalizer(ctx, instance)

--- a/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -314,6 +314,9 @@ func testDeploymentUninstall() {
 			t.AssertNoDeployment(names.AppendUninstall(names.ServiceDiscoveryComponent))
 
 			t.awaitNoFinalizer()
+
+			t.AssertReconcileSuccess()
+			t.AssertNoDeployment(names.AppendUninstall(names.ServiceDiscoveryComponent))
 		})
 	})
 

--- a/controllers/submariner/cleanup.go
+++ b/controllers/submariner/cleanup.go
@@ -35,6 +35,10 @@ import (
 )
 
 func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operatorv1alpha1.Submariner) (reconcile.Result, error) {
+	if !finalizer.IsPresent(instance, constants.CleanupFinalizer) {
+		return reconcile.Result{}, nil
+	}
+
 	if !uninstall.IsSupportedForVersion(instance.Spec.Version) {
 		log.Info("Deleting Submariner version does not support uninstall", "version", instance.Spec.Version)
 		return reconcile.Result{}, r.removeFinalizer(ctx, instance)
@@ -89,7 +93,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 	}
 
 	if requeue {
-		return reconcile.Result{RequeueAfter: time.Millisecond * 100}, nil
+		return reconcile.Result{RequeueAfter: time.Millisecond * 500}, nil
 	}
 
 	return reconcile.Result{}, r.removeFinalizer(ctx, instance)

--- a/controllers/submariner/submariner_controller_test.go
+++ b/controllers/submariner/submariner_controller_test.go
@@ -313,6 +313,9 @@ func testDeletion() {
 			t.AssertNoDeployment(names.AppendUninstall(names.NetworkPluginSyncerComponent))
 
 			t.awaitNoFinalizer()
+
+			t.AssertReconcileSuccess()
+			t.AssertNoDaemonSet(names.AppendUninstall(names.GatewayComponent))
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.3.0
-	github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6
+	github.com/submariner-io/admiral v0.12.0-m3.0.20220304150942-10c88bb61e69
 	github.com/submariner-io/cloud-prepare v0.12.0-m3.0.20220216201630-d2a9f9d88aae
 	github.com/submariner-io/lighthouse v0.12.0-m3.0.20220215144325-3a00dd24acab
 	github.com/submariner-io/shipyard v0.12.0-m3

--- a/go.sum
+++ b/go.sum
@@ -1408,6 +1408,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/submariner-io/admiral v0.12.0-m3/go.mod h1:UBcJ547DlOWcX13HtWBS83tmd+DcWDu9FDbmI0iDSU4=
 github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6 h1:RMgMytzHKdn4giyMDnu9oFmT40ea0NX75HcttQCoL/U=
 github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6/go.mod h1:hFPcxH0gAr559/qK7ri10Yh1wyeK6yzow1PIqtBk+30=
+github.com/submariner-io/admiral v0.12.0-m3.0.20220304150942-10c88bb61e69 h1:BmjnngDV0IwUJ4FXM7eWxbvjUCXTBMBxWgzL7bjLxGo=
+github.com/submariner-io/admiral v0.12.0-m3.0.20220304150942-10c88bb61e69/go.mod h1:hFPcxH0gAr559/qK7ri10Yh1wyeK6yzow1PIqtBk+30=
 github.com/submariner-io/cloud-prepare v0.12.0-m3.0.20220216201630-d2a9f9d88aae h1:90Y+wiXPt5T6agzcV0YhWUHGcXRhCmVM5L+y+noOhSw=
 github.com/submariner-io/cloud-prepare v0.12.0-m3.0.20220216201630-d2a9f9d88aae/go.mod h1:yhEfsTN1GbfhGfvZFJOddAh1LOHE4YrhkDNpF8yxKyo=
 github.com/submariner-io/lighthouse v0.12.0-m3.0.20220215144325-3a00dd24acab h1:YIFa6fPm/MSXPMdKRjwUJvemZDDQa1t++phYuaM7PBI=


### PR DESCRIPTION
After the finalizer is removed, it can take a little time before K8s deletes the object. In the mean time, the controller may get triggered again in which case it will observe the `DeletionTimeStamp` non-zero and re-create the uninstall daemon sets. To avoid this, elide running cleanup if the finalizer isn't present.

Also increased the requeue interval to 500 ms.

Depends on https://github.com/submariner-io/admiral/pull/327