### PR TITLE
Change uninstall to be reentrant

### DIFF
--- a/pkg/uninstall/all.go
+++ b/pkg/uninstall/all.go
@@ -41,11 +41,6 @@ import (
 )
 
 func All(clients client.Producer, clusterName, submarinerNamespace string, status reporter.Interface) error {
-	_, err := clients.ForKubernetes().CoreV1().Namespaces().Get(context.TODO(), submarinerNamespace, metav1.GetOptions{})
-	if err != nil {
-		return status.Error(err, "Error retrieving the Submariner namespace %q", submarinerNamespace)
-	}
-
 	found, brokerNS, err := ensureSubmarinerDeleted(clients, clusterName, submarinerNamespace, status)
 	if err != nil {
 		return err
@@ -67,7 +62,7 @@ func All(clients client.Producer, clusterName, submarinerNamespace string, statu
 	defer status.End()
 
 	err = clients.ForKubernetes().CoreV1().Namespaces().Delete(context.TODO(), submarinerNamespace, metav1.DeleteOptions{})
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return status.Error(err, "Error deleting the namespace")
 	}
 


### PR DESCRIPTION
This will be better UX and make sure that users can still uninstall even
if for some reason a previous uninstall didn't finish successfully.

Resolves: #1903

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
