### PR TITLE
Print out brokers information on `subctl show all`

### DIFF
--- a/pkg/subctl/cmd/show/all.go
+++ b/pkg/subctl/cmd/show/all.go
@@ -41,14 +41,21 @@ func init() {
 func showAll(cluster *cmd.Cluster) bool {
 	status := cli.NewStatus()
 
+	success := showBrokers(cluster)
+
+	fmt.Println()
+
 	if cluster.Submariner == nil {
+		success = getVersions(cluster) && success
+
+		fmt.Println()
 		status.Start(cmd.SubmMissingMessage)
 		status.EndWith(cli.Warning)
 
-		return true
+		return success
 	}
 
-	success := showConnections(cluster)
+	success = showConnections(cluster) && success
 
 	fmt.Println()
 

--- a/pkg/subctl/cmd/show/brokers.go
+++ b/pkg/subctl/cmd/show/brokers.go
@@ -1,0 +1,71 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package show
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/submariner-io/submariner-operator/internal/cli"
+	"github.com/submariner-io/submariner-operator/pkg/client"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func showBrokers(cluster *cmd.Cluster) bool {
+	template := "%-25.24s%-25.24s%-40.39s\n"
+	status := cli.NewStatus()
+
+	status.Start("Detecting broker(s)")
+
+	clientProducer, err := client.NewProducerFromRestConfig(cluster.Config)
+	if err != nil {
+		status.EndWithFailure("Error creating client producer")
+		return false
+	}
+
+	brokerList, err := clientProducer.ForOperator().SubmarinerV1alpha1().Brokers(corev1.NamespaceAll).List(
+		context.TODO(), metav1.ListOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		status.EndWithFailure(err.Error())
+		return false
+	}
+
+	status.End()
+
+	brokers := brokerList.Items
+	if len(brokers) == 0 {
+		return true
+	}
+
+	fmt.Printf(template, "NAMESPACE", "NAME", "COMPONENTS")
+
+	for i := range brokers {
+		fmt.Printf(
+			template,
+			brokers[i].Namespace,
+			brokers[i].Name,
+			strings.Join(brokers[i].Spec.Components, ", "),
+		)
+	}
+
+	return true
+}

--- a/pkg/subctl/cmd/show/versions.go
+++ b/pkg/subctl/cmd/show/versions.go
@@ -70,6 +70,10 @@ func getSubmarinerVersion(submariner *v1alpha1.Submariner, versions []versionIma
 func getOperatorVersion(clientSet kubernetes.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
 	operatorConfig, err := clientSet.AppsV1().Deployments(cmd.OperatorNamespace).Get(context.TODO(), names.OperatorComponent, v1.GetOptions{})
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return versions, nil
+		}
+
 		return nil, errors.Wrap(err, "error retrieving Deployment")
 	}
 
@@ -105,7 +109,9 @@ func getVersions(cluster *cmd.Cluster) bool {
 	submarinerClient, err := submarinerclientset.NewForConfig(cluster.Config)
 	exit.OnErrorWithMessage(err, "Unable to get the Submariner client")
 
-	versions = getSubmarinerVersion(cluster.Submariner, versions)
+	if cluster.Submariner != nil {
+		versions = getSubmarinerVersion(cluster.Submariner, versions)
+	}
 
 	versions, err = getOperatorVersion(cluster.KubeClient, versions)
 	exit.OnErrorWithMessage(err, "Unable to get the Operator version")
@@ -113,8 +119,11 @@ func getVersions(cluster *cmd.Cluster) bool {
 	versions, err = getServiceDiscoveryVersions(submarinerClient, versions)
 	exit.OnErrorWithMessage(err, "Unable to get the Service-Discovery version")
 
-	printVersions(versions)
 	status.EndWith(cli.Success)
+
+	if len(versions) > 0 {
+		printVersions(versions)
+	}
 
 	return true
 }


### PR DESCRIPTION
Print out the info, even if clusters only have brokers.
Clusters that don't have brokers will just show informatory "Detecting
brokers" message and nothing further.

Resolves: #1894

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
