### PR TITLE
Set default value of dedicated-gw to true for GCP and RHOS

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -39,7 +39,7 @@ func newGCPPrepareCommand() *cobra.Command {
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
 	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
-		"Whether a dedicated gateway node has to be deployed (default true)")
+		"Whether a dedicated gateway node has to be deployed")
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -38,8 +38,8 @@ func newGCPPrepareCommand() *cobra.Command {
 	cmd.Flags().StringVar(&gcpGWInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
-	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", false,
-		"Whether a dedicated gateway node has to be deployed (default false)")
+	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
+		"Whether a dedicated gateway node has to be deployed (default true)")
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -39,8 +39,8 @@ func newRHOSPrepareCommand() *cobra.Command {
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
 	cmd.Flags().StringVar(&rhosGWInstanceType, "gateway-instance", "PnTAE.CPU_16_Memory_32768_Disk_80", "Type of gateway instance machine")
-	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", false,
-		"Whether a dedicated gateway node has to be deployed (default false)")
+	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
+		"Whether a dedicated gateway node has to be deployed")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes: https://github.com/submariner-io/submariner-operator/issues/1915
Fixes: #1919 
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
