### PR TITLE
Fix subctl show networks and versions output

### DIFF
--- a/pkg/subctl/cmd/show/networks.go
+++ b/pkg/subctl/cmd/show/networks.go
@@ -71,8 +71,8 @@ func showNetwork(cluster *cmd.Cluster) bool {
 		fmt.Println(msg)
 	}
 
-	clusterNetwork.Show()
 	status.EndWith(cli.Success)
+	clusterNetwork.Show()
 
 	return true
 }

--- a/pkg/subctl/cmd/show/versions.go
+++ b/pkg/subctl/cmd/show/versions.go
@@ -113,8 +113,8 @@ func getVersions(cluster *cmd.Cluster) bool {
 	versions, err = getServiceDiscoveryVersions(submarinerClient, versions)
 	exit.OnErrorWithMessage(err, "Unable to get the Service-Discovery version")
 
-	printVersions(versions)
 	status.EndWith(cli.Success)
+	printVersions(versions)
 
 	return true
 }


### PR DESCRIPTION
Signed-off-by: yboaron <yboaron@redhat.com>
(cherry picked from commit e644897b3dbc0fa00733ef324b512ca1b3acb250)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
