### PR TITLE
Backport 0.12: Capture API warnings on `subctl gather`

### DIFF
--- a/pkg/subctl/cmd/gather/gather.go
+++ b/pkg/subctl/cmd/gather/gather.go
@@ -19,6 +19,7 @@ limitations under the License.
 package gather
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -37,6 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 var (
@@ -101,8 +103,13 @@ var gatherCmd = &cobra.Command{
 }
 
 func gatherData(cluster *cmd.Cluster) bool {
+	var warningsBuf bytes.Buffer
 	err := checkGatherArguments()
 	exit.OnErrorWithMessage(err, "Invalid arguments")
+
+	rest.SetDefaultWarningHandler(rest.NewWarningWriter(&warningsBuf, rest.WarningWriterOptions{
+		Deduplicate: true,
+	}))
 
 	if directory == "" {
 		directory = "submariner-" + time.Now().UTC().Format("20060102150405") // submariner-YYYYMMDDHHMMSS
@@ -118,6 +125,11 @@ func gatherData(cluster *cmd.Cluster) bool {
 	gatherDataByCluster(cluster, directory)
 
 	fmt.Printf("Files are stored under directory %q\n", directory)
+
+	warnings := warningsBuf.String()
+	if warnings != "" {
+		fmt.Printf("\nEncountered following Kubernetes warnings while running:\n%s", warnings)
+	}
 
 	return true
 }


### PR DESCRIPTION
This will make sure any warnings, such as deprecation, are properly
captured and reported so that they can be later handled.

Resolves: #1896

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 6c3a1c7f390135ff1aac0eca435a3e59dd3ee40e)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
