### PR TITLE
Backport 0.12: always end gather status

### DIFF
--- a/pkg/subctl/cmd/gather/gather.go
+++ b/pkg/subctl/cmd/gather/gather.go
@@ -163,10 +163,8 @@ func gatherDataByCluster(cluster *cmd.Cluster, directory string) {
 				if ok {
 					info.Status = cli.NewReporter()
 					info.Status.Start("Gathering %s %s", module, dataType)
-
-					if gatherFuncs[module](dataType, info) {
-						info.Status.End()
-					}
+					gatherFuncs[module](dataType, info)
+					info.Status.End()
 				}
 			}
 		}


### PR DESCRIPTION
Currently, info.Status.End() is only called if the module supports the
requested datatype. This means that for datatypes which aren't
supported, the spinner started by info.Status.Start() continues
running until the program exits.

Fixes: #1904
Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit c6429094583fe62a5e88329f1cbc7a6436d99d55)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
