### PR TITLE
Backport: Modify default state of dedicated-gw for rhos and gcp

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -39,7 +39,7 @@ func newGCPPrepareCommand() *cobra.Command {
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
 	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
-		"Whether a dedicated gateway node has to be deployed (default true)")
+		"Whether a dedicated gateway node has to be deployed")
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -38,8 +38,8 @@ func newGCPPrepareCommand() *cobra.Command {
 	cmd.Flags().StringVar(&gcpGWInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
-	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", false,
-		"Whether a dedicated gateway node has to be deployed (default false)")
+	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
+		"Whether a dedicated gateway node has to be deployed (default true)")
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -39,8 +39,8 @@ func newRHOSPrepareCommand() *cobra.Command {
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
 	cmd.Flags().StringVar(&rhosGWInstanceType, "gateway-instance", "PnTAE.CPU_16_Memory_32768_Disk_80", "Type of gateway instance machine")
-	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", false,
-		"Whether a dedicated gateway node has to be deployed (default false)")
+	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
+		"Whether a dedicated gateway node has to be deployed")
 
 	return cmd
 }


### PR DESCRIPTION
Modify default state of dedicated-gw for rhos and gcp.
Currently the default value of dedicated-gw is set as false, but
this could potentially have issues during cluster scaling and/or
during upgrades. The recommended setting is to use dedicated gw
nodes. This PR modifies the default value accordingly.

