### PR TITLE
Backport 0.12: Reduce verbosity of controller reconciliation

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -106,7 +106,7 @@ func NewReconciler(config *Config) *Reconciler {
 // +kubebuilder:rbac:groups=submariner.io,resources=servicediscoveries,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=submariner.io,resources=servicediscoveries/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger := log.V(2).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling ServiceDiscovery")
 
 	instance, err := r.getServiceDiscovery(ctx, request.NamespacedName)

--- a/controllers/submariner/cleanup.go
+++ b/controllers/submariner/cleanup.go
@@ -45,7 +45,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 	}
 
 	// This has the side effect of setting the CIDRs in the Submariner instance.
-	clusterNetwork, err := r.discoverNetwork(instance)
+	clusterNetwork, err := r.discoverNetwork(instance, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -123,7 +123,7 @@ func NewReconciler(config *Config) *Reconciler {
 // +kubebuilder:rbac:groups=submariner.io,resources=submariners/status,verbs=get;update;patch
 // nolint:gocyclo // Refactoring would yield functions with a lot of params which isn't ideal either.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger := log.V(2).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Submariner")
 
 	// Fetch the Submariner instance
@@ -157,7 +157,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	initialStatus := instance.Status.DeepCopy()
 
-	clusterNetwork, err := r.discoverNetwork(instance)
+	clusterNetwork, err := r.discoverNetwork(instance, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/submariner/submariner_networkdiscovery.go
+++ b/controllers/submariner/submariner_networkdiscovery.go
@@ -20,6 +20,7 @@ package submariner
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	submopv1a1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
@@ -51,14 +52,16 @@ func (r *Reconciler) getClusterNetwork(submariner *submopv1a1.Submariner) (*netw
 	return r.config.ClusterNetwork, errors.Wrap(err, "error discovering cluster network")
 }
 
-func (r *Reconciler) discoverNetwork(submariner *submopv1a1.Submariner) (*network.ClusterNetwork, error) {
+func (r *Reconciler) discoverNetwork(submariner *submopv1a1.Submariner, log logr.Logger) (*network.ClusterNetwork, error) {
 	clusterNetwork, err := r.getClusterNetwork(submariner)
 	submariner.Status.ClusterCIDR = getCIDR(
+		log,
 		"Cluster",
 		submariner.Spec.ClusterCIDR,
 		clusterNetwork.PodCIDRs)
 
 	submariner.Status.ServiceCIDR = getCIDR(
+		log,
 		"Service",
 		submariner.Spec.ServiceCIDR,
 		clusterNetwork.ServiceCIDRs)
@@ -71,7 +74,7 @@ func (r *Reconciler) discoverNetwork(submariner *submopv1a1.Submariner) (*networ
 	return clusterNetwork, err
 }
 
-func getCIDR(cidrType, currentCIDR string, detectedCIDRs []string) string {
+func getCIDR(log logr.Logger, cidrType, currentCIDR string, detectedCIDRs []string) string {
 	detected := getFirstCIDR(detectedCIDRs)
 
 	if currentCIDR == "" {


### PR DESCRIPTION
These messages are flooding the log and making it grow endlessly, while
hiding real issues, as the loop happens every few seconds.
Reducing the verbosity of info logs helps clear the log and keep it
tidy.

Resolves: #1914

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit d1b458a9e5fd4f9b1708d40bbe1ff4cbf69543e9)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
