### PR TITLE
Drop periodic bundle tests

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -26,30 +26,3 @@ jobs:
           title: Broken link detected by CI
           content-filepath: .github/ISSUE_TEMPLATE/broken-link.md
           labels: automated, broken link
-
-  test-bundle-periodic:
-    name: Operator Bundle Test
-    if: github.repository_owner == 'submariner-io'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup kernel, increase the inotify settings
-        run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
-
-      - name: Check out the repository
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-
-      - name: Fetch all git tags
-        run: git fetch origin +refs/tags/*:refs/tags/*
-
-      - name: Run E2E using the bundle deployment method
-        run: |
-          make e2e using=bundle,lighthouse REPO=localhost:5000 IMG=localhost:5000/submariner-operator:local && \
-          make scorecard
-
-      - name: Raise an Issue to report broken bundle
-        if: ${{ failure() }}
-        uses: peter-evans/create-issue-from-file@v2.3.2
-        with:
-          title: Broken bundle detected by CI
-          content-filepath: .github/ISSUE_TEMPLATE/broken-bundle.md
-          labels: automated, broken bundle


### PR DESCRIPTION
These are currently broken. They will be restored once bundle
construction is fixed (as part of the planned Operator SDK upgrade).

Relates-to: #1716
Relates-to: submariner-io/shipyard#717
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
