### PR TITLE
Add packagedoc-lint linting, fix errors

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -105,6 +105,15 @@ jobs:
       - name: Run markdownlint
         run: make markdownlint
 
+  packagedoc-lint:
+    name: Package Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Run packagedoc-lint
+        run: make packagedoc-lint
+
   yaml-lint:
     name: YAML
     runs-on: ubuntu-latest

--- a/api/submariner/v1alpha1/register.go
+++ b/api/submariner/v1alpha1/register.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 // NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the submariner v1alpha1 API group

--- a/api/submariner/v1alpha1/versions.go
+++ b/api/submariner/v1alpha1/versions.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1alpha1
 
 var (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import "github.com/submariner-io/submariner-operator/cmd/subctl"

--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package subctl
 
 import (

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package metrics
 
 import (

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package servicediscovery
 
 import (

--- a/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package servicediscovery_test
 
 import (

--- a/controllers/submariner/submariner_networkdiscovery.go
+++ b/controllers/submariner/submariner_networkdiscovery.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package submariner
 
 import (

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package exit
 
 import (

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package image
 
 import (

--- a/pkg/broker/globalcidr_cm.go
+++ b/pkg/broker/globalcidr_cm.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package broker
 
 import (

--- a/pkg/discovery/network/calico.go
+++ b/pkg/discovery/network/calico.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package network
 
 import (

--- a/pkg/discovery/network/calico_test.go
+++ b/pkg/discovery/network/calico_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package network_test
 
 import (

--- a/pkg/embeddedyamls/generate.go
+++ b/pkg/embeddedyamls/generate.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package embeddedyamls
 
 //go:generate go run generators/yamls2go.go ../../ .

--- a/pkg/images/image_parsing_test.go
+++ b/pkg/images/image_parsing_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package images_test
 
 import (

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package images
 
 import (

--- a/pkg/lighthouse/crds.go
+++ b/pkg/lighthouse/crds.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package names
 
 /* Component names and other constants. */

--- a/pkg/scc/update.go
+++ b/pkg/scc/update.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package scc
 
 import (

--- a/pkg/subctl/benchmark/latency.go
+++ b/pkg/subctl/benchmark/latency.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmark
 
 import (

--- a/pkg/subctl/benchmark/throughput.go
+++ b/pkg/subctl/benchmark/throughput.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmark
 
 import (

--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/pkg/subctl/cmd/diagnose/all.go
+++ b/pkg/subctl/cmd/diagnose/all.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/cni.go
+++ b/pkg/subctl/cmd/diagnose/cni.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/connections.go
+++ b/pkg/subctl/cmd/diagnose/connections.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/deployment.go
+++ b/pkg/subctl/cmd/diagnose/deployment.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/diagnose.go
+++ b/pkg/subctl/cmd/diagnose/diagnose.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/firewall_metrics.go
+++ b/pkg/subctl/cmd/diagnose/firewall_metrics.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/firewall_tunnel.go
+++ b/pkg/subctl/cmd/diagnose/firewall_tunnel.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/firewall_vxlan.go
+++ b/pkg/subctl/cmd/diagnose/firewall_vxlan.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/globalnet.go
+++ b/pkg/subctl/cmd/diagnose/globalnet.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/k8s_version.go
+++ b/pkg/subctl/cmd/diagnose/k8s_version.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/diagnose/kubeproxy.go
+++ b/pkg/subctl/cmd/diagnose/kubeproxy.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package diagnose
 
 import (

--- a/pkg/subctl/cmd/execute.go
+++ b/pkg/subctl/cmd/execute.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/pkg/subctl/cmd/gather/logs.go
+++ b/pkg/subctl/cmd/gather/logs.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gather
 
 import (

--- a/pkg/subctl/cmd/gather/operator.go
+++ b/pkg/subctl/cmd/gather/operator.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gather
 
 import (

--- a/pkg/subctl/cmd/gather/resource.go
+++ b/pkg/subctl/cmd/gather/resource.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gather
 
 import (

--- a/pkg/subctl/cmd/gather/types.go
+++ b/pkg/subctl/cmd/gather/types.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gather
 
 import (

--- a/pkg/subctl/cmd/resource.go
+++ b/pkg/subctl/cmd/resource.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/pkg/subctl/cmd/show/all.go
+++ b/pkg/subctl/cmd/show/all.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package show
 
 import (

--- a/pkg/subctl/cmd/show/connections.go
+++ b/pkg/subctl/cmd/show/connections.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package show
 
 import (

--- a/pkg/subctl/cmd/show/endpoints.go
+++ b/pkg/subctl/cmd/show/endpoints.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package show
 
 import (

--- a/pkg/subctl/cmd/show/gateways.go
+++ b/pkg/subctl/cmd/show/gateways.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package show
 
 import (

--- a/pkg/subctl/cmd/show/versions.go
+++ b/pkg/subctl/cmd/show/versions.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package show
 
 import (

--- a/pkg/subctl/datafile/backup.go
+++ b/pkg/subctl/datafile/backup.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datafile
 
 import (

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package version
 
 import (


### PR DESCRIPTION
The idea here is to make sure the license headers are detached from the
package declarations, as otherwise the headers are considered a part of
the package documentation and included with it.

Add per-PR job to maintain consistent standards across all repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>
(cherry picked from commit 01a78a5af01d0d01b3aa63d228f617367a5849f0)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
