### PR TITLE
Fix golangci-lint v1.44.2 errors

### DIFF
--- a/pkg/subctl/cmd/diagnose/cni.go
+++ b/pkg/subctl/cmd/diagnose/cni.go
@@ -216,8 +216,7 @@ func getSpecBool(pool unstructured.Unstructured, key string) (bool, error) {
 	}
 
 	if !found {
-		message := fmt.Sprintf("%s status not found for IPPool %q", key, pool.GetName())
-		return false, fmt.Errorf(message)
+		return false, fmt.Errorf("%s status not found for IPPool %q", key, pool.GetName())
 	}
 
 	return isDisabled, nil

--- a/pkg/subctl/cmd/diagnose/firewall.go
+++ b/pkg/subctl/cmd/diagnose/firewall.go
@@ -108,9 +108,11 @@ func getActiveGatewayNodeName(cluster *cmd.Cluster, hostname string, status *cli
 			return ""
 		}
 
-		defer sPod.Delete()
+		err = sPod.AwaitCompletion()
 
-		if err = sPod.AwaitCompletion(); err != nil {
+		sPod.Delete()
+
+		if err != nil {
 			status.EndWithFailure("Error waiting for the sniffer pod to finish its execution on node %q: %v", node.Name, err)
 			return ""
 		}


### PR DESCRIPTION
- pkg/subctl/cmd/diagnose/cni.go:219:17: dynamicFmtString
- pkg/subctl/cmd/diagnose/firewall.go:111:3: deferInLoop

Related to https://github.com/submariner-io/shipyard/pull/734.
