### PR TITLE
Revert "Drop deprecated --colorcodes option"

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -38,8 +38,9 @@ import (
 )
 
 var (
-	joinFlags    join.Options
-	labelGateway bool
+	joinFlags         join.Options
+	labelGateway      bool
+	ignoredColorCodes string
 )
 
 var joinCmd = &cobra.Command{
@@ -92,6 +93,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&joinFlags.ClusterCIDR, "clustercidr", "", "cluster CIDR")
 	cmd.Flags().StringVar(&joinFlags.Repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&joinFlags.ImageVersion, "version", "", "image version")
+	cmd.Flags().StringVar(&ignoredColorCodes, "colorcodes", "", "color codes")
+	_ = cmd.Flags().MarkDeprecated("colorcodes", "--colorcodes has no effect and is deprecated")
 	cmd.Flags().IntVar(&joinFlags.NATTPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&joinFlags.IKEPort, "ikeport", 500, "IPsec IKE port")
 	cmd.Flags().BoolVar(&joinFlags.NATTraversal, "natt", true, "enable NAT traversal for IPsec")

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -62,6 +62,7 @@ var (
 	ikePort                       int
 	preferredServer               bool
 	forceUDPEncaps                bool
+	ignoredColorCodes             string
 	natTraversal                  bool
 	ignoreRequirements            bool
 	globalnetEnabled              bool
@@ -92,6 +93,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&clusterCIDR, "clustercidr", "", "cluster CIDR")
 	cmd.Flags().StringVar(&repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&imageVersion, "version", "", "image version")
+	cmd.Flags().StringVar(&ignoredColorCodes, "colorcodes", "", "color codes")
+	_ = cmd.Flags().MarkDeprecated("colorcodes", "--colorcodes has no effect and is deprecated")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
 	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
 	cmd.Flags().BoolVar(&natTraversal, "natt", true, "enable NAT traversal for IPsec")


### PR DESCRIPTION
--colorcodes is used in the upgrade tests, which means we can't remove
it in 0.13. The tests have been fixed, so this will be removable in
0.14.

This reverts commit be8c8e3164d6201ef7d7361c3027e5af0402b174.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
