### PR TITLE
Sanitize generated ClusterIDs in join

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -262,7 +262,7 @@ func determineClusterID(status reporter.Interface) {
 		exit.OnError(status.Error(err, "Error determining cluster ID of the target cluster"))
 
 		if err = cluster.IsValidID(joinFlags.ClusterID); err != nil {
-			joinFlags.ClusterID = cluster.SanitizeClusterID(joinFlags.ClusterID)
+			joinFlags.ClusterID = cluster.SanitizeID(joinFlags.ClusterID)
 		}
 	}
 

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -260,6 +260,10 @@ func determineClusterID(status reporter.Interface) {
 	if joinFlags.ClusterID == "" {
 		joinFlags.ClusterID, err = restConfigProducer.GetClusterID()
 		exit.OnError(status.Error(err, "Error determining cluster ID of the target cluster"))
+
+		if err = cluster.IsValidID(joinFlags.ClusterID); err != nil {
+			joinFlags.ClusterID = cluster.SanitizeClusterID(joinFlags.ClusterID)
+		}
 	}
 
 	if joinFlags.ClusterID != "" {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-const replaceChar = "0"
+const rfc1123Compliant = "0"
 
 func IsValidID(clusterID string) error {
 	if errs := validation.IsDNS1123Label(clusterID); len(errs) > 0 {
@@ -36,22 +36,21 @@ func IsValidID(clusterID string) error {
 	return nil
 }
 
-func SanitizeClusterID(clusterID string) string {
-	var result string
-	inputLen := len(clusterID)
+func SanitizeID(clusterID string) string {
+	if clusterID == "" {
+		return ""
+	}
 
-	if inputLen > 0 {
-		regDNS1123 := regexp.MustCompile("[^a-z0-9-]+")
-		result = strings.ToLower(clusterID)
-		result = regDNS1123.ReplaceAllString(result, "-")
+	regDNS1123 := regexp.MustCompile("[^a-z0-9-]+")
+	result := regDNS1123.ReplaceAllString(strings.ToLower(clusterID), "-")
 
-		if result[0] == '-' {
-			result = replaceChar + result[1:]
-		}
+	if result[0] == '-' {
+		result = rfc1123Compliant + result[1:]
+	}
 
-		if result[inputLen-1:] == "-" {
-			result = result[:inputLen-1] + replaceChar
-		}
+	resultLen := len(result)
+	if result[resultLen-1] == '-' {
+		result = result[:resultLen-1] + rfc1123Compliant
 	}
 
 	return result

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -19,9 +19,14 @@ limitations under the License.
 package cluster
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+const replaceChar = "0"
 
 func IsValidID(clusterID string) error {
 	if errs := validation.IsDNS1123Label(clusterID); len(errs) > 0 {
@@ -29,4 +34,25 @@ func IsValidID(clusterID string) error {
 	}
 
 	return nil
+}
+
+func SanitizeClusterID(clusterID string) string {
+	var result string
+	inputLen := len(clusterID)
+
+	if inputLen > 0 {
+		regDNS1123 := regexp.MustCompile("[^a-z0-9-]+")
+		result = strings.ToLower(clusterID)
+		result = regDNS1123.ReplaceAllString(result, "-")
+
+		if result[0] == '-' {
+			result = replaceChar + result[1:]
+		}
+
+		if result[inputLen-1:] == "-" {
+			result = result[:inputLen-1] + replaceChar
+		}
+	}
+
+	return result
 }

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -27,6 +27,11 @@ import (
 )
 
 var _ = Describe("TestClusterIDs", func() {
+	Describe("IsValidID", testIsValidID)
+	Describe("SanitizeID", testSanitizeID)
+})
+
+func testIsValidID() {
 	When("the id only contains alphabetic characters", func() {
 		It("should be valid", func() {
 			Expect(cluster.IsValidID("abcdef")).To(Succeed())
@@ -56,14 +61,18 @@ var _ = Describe("TestClusterIDs", func() {
 		})
 	})
 
+	When("the id contains uppercase alphabetic characters", func() {
+		It("should not be valid", func() {
+			Expect(cluster.IsValidID("A1b2c3d4e5f6")).To(Not(Succeed()))
+			Expect(cluster.IsValidID("1A2b3c4d5e6f")).To(Not(Succeed()))
+			Expect(cluster.IsValidID("a1-B2-c3-D4")).To(Not(Succeed()))
+		})
+	})
+
 	When("the id contains non-alphanumeric characters other than dashes", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("abcdéfg")).To(Not(Succeed()))
 			Expect(cluster.IsValidID("abcde.g")).To(Not(Succeed()))
-		})
-		It("should convert invalid characters to dashes", func() {
-			Expect(cluster.SanitizeClusterID("abcdéfg")).To(Equal("abcd-fg"))
-			Expect(cluster.SanitizeClusterID("abcde.g")).To(Equal("abcde-g"))
 		})
 	})
 
@@ -71,10 +80,6 @@ var _ = Describe("TestClusterIDs", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("-abcdef")).To(Not(Succeed()))
 			Expect(cluster.IsValidID("abcdef-")).To(Not(Succeed()))
-		})
-		It("should replace dash with 0", func() {
-			Expect(cluster.SanitizeClusterID("-abcdef")).To(Equal("0abcdef"))
-			Expect(cluster.SanitizeClusterID("abcdef-")).To(Equal("abcdef0"))
 		})
 	})
 
@@ -90,11 +95,85 @@ var _ = Describe("TestClusterIDs", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("")).To(Not(Succeed()))
 		})
-		It("should return empty string", func() {
-			Expect(cluster.SanitizeClusterID("")).To(Equal(""))
+	})
+}
+
+func testSanitizeID() {
+	When("the id only contains alphabetic characters", func() {
+		It("should return same id", func() {
+			Expect(cluster.SanitizeID("abcdef")).To(Equal("abcdef"))
 		})
 	})
-})
+
+	When("the id only contains numeric characters", func() {
+		It("should return same id", func() {
+			Expect(cluster.IsValidID("012345")).To(Succeed())
+			Expect(cluster.SanitizeID("012345")).To(Equal("012345"))
+		})
+	})
+
+	When("the id only contains alphanumeric characters", func() {
+		It("should return same id", func() {
+			Expect(cluster.SanitizeID("a0b1c2d3ef")).To(Equal("a0b1c2d3ef"))
+			Expect(cluster.SanitizeID("0a1b2c3def")).To(Equal("0a1b2c3def"))
+			Expect(cluster.SanitizeID("a0b1c2d3e4f5")).To(Equal("a0b1c2d3e4f5"))
+			Expect(cluster.SanitizeID("0a1b2c3d4e5f6")).To(Equal("0a1b2c3d4e5f6"))
+		})
+	})
+
+	When("the id only contains alphanumeric characters and dashes", func() {
+		It("should return same id valid", func() {
+			Expect(cluster.SanitizeID("a0b-1c2d3ef")).To(Equal("a0b-1c2d3ef"))
+			Expect(cluster.SanitizeID("0a1b2c3-def")).To(Equal("0a1b2c3-def"))
+			Expect(cluster.SanitizeID("a0b1c2d3---e4f5")).To(Equal("a0b1c2d3---e4f5"))
+		})
+	})
+
+	When("the id contains uppercase alphabetic characters", func() {
+		It("should convert lowercase characters to uppercase", func() {
+			Expect(cluster.SanitizeID("A1b2c3d4e5f6")).To(Equal("a1b2c3d4e5f6"))
+			Expect(cluster.SanitizeID("1A2b3c4d5e6f")).To(Equal("1a2b3c4d5e6f"))
+			Expect(cluster.SanitizeID("a1-B2-c3-D4")).To(Equal("a1-b2-c3-d4"))
+		})
+	})
+
+	When("the id contains non-alphanumeric characters other than dashes", func() {
+		It("should convert invalid characters to dashes", func() {
+			Expect(cluster.SanitizeID("abcdéfg")).To(Equal("abcd-fg"))
+			Expect(cluster.SanitizeID("abcde.g")).To(Equal("abcde-g"))
+		})
+	})
+
+	When("the id starts or end with a dash", func() {
+		It("should replace dash with 0", func() {
+			Expect(cluster.SanitizeID("-abcdef")).To(Equal("0abcdef"))
+			Expect(cluster.SanitizeID("abcdef-")).To(Equal("abcdef0"))
+		})
+	})
+
+	When("the id starts or end with non alphanumeric character", func() {
+		It("should replace non alphanumeric character with 0", func() {
+			Expect(cluster.SanitizeID("éabcdef")).To(Equal("0abcdef"))
+			Expect(cluster.SanitizeID("abcdefé")).To(Equal("abcdef0"))
+		})
+	})
+
+	When("the id is longer than 63 characters", func() {
+		It("should return same id", func() {
+			testID := "0123456789012345678901234567890123456789012345678901234567890123"
+			Expect(cluster.SanitizeID(testID)).To(Equal(testID))
+
+			testID = "0123456789012345678901234567890123456789012345678901234567890123456789"
+			Expect(cluster.SanitizeID(testID)).To(Equal(testID))
+		})
+	})
+
+	When("the id is empty", func() {
+		It("should return empty string", func() {
+			Expect(cluster.SanitizeID("")).To(Equal(""))
+		})
+	})
+}
 
 func TestCluster(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/submariner-io/submariner-operator/internal/cluster"
 )
 
-var _ = Describe("IsValidID", func() {
+var _ = Describe("TestClusterIDs", func() {
 	When("the id only contains alphabetic characters", func() {
 		It("should be valid", func() {
 			Expect(cluster.IsValidID("abcdef")).To(Succeed())
@@ -61,12 +61,20 @@ var _ = Describe("IsValidID", func() {
 			Expect(cluster.IsValidID("abcdéfg")).To(Not(Succeed()))
 			Expect(cluster.IsValidID("abcde.g")).To(Not(Succeed()))
 		})
+		It("should convert invalid characters to dashes", func() {
+			Expect(cluster.SanitizeClusterID("abcdéfg")).To(Equal("abcd-fg"))
+			Expect(cluster.SanitizeClusterID("abcde.g")).To(Equal("abcde-g"))
+		})
 	})
 
 	When("the id starts or end with a dash", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("-abcdef")).To(Not(Succeed()))
 			Expect(cluster.IsValidID("abcdef-")).To(Not(Succeed()))
+		})
+		It("should replace dash with 0", func() {
+			Expect(cluster.SanitizeClusterID("-abcdef")).To(Equal("0abcdef"))
+			Expect(cluster.SanitizeClusterID("abcdef-")).To(Equal("abcdef0"))
 		})
 	})
 
@@ -81,6 +89,9 @@ var _ = Describe("IsValidID", func() {
 	When("the id is empty", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("")).To(Not(Succeed()))
+		})
+		It("should return empty string", func() {
+			Expect(cluster.SanitizeClusterID("")).To(Equal(""))
 		})
 	})
 })

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -76,7 +76,7 @@ func testIsValidID() {
 		})
 	})
 
-	When("the id starts or ends	 with a dash", func() {
+	When("the id starts or ends with a dash", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("-abcdef")).To(Not(Succeed()))
 			Expect(cluster.IsValidID("abcdef-")).To(Not(Succeed()))
@@ -159,7 +159,7 @@ func testSanitizeID() {
 	})
 
 	When("the id has consecutive non alphanumeric characters", func() {
-		It("should repalce all such characters with a single dash", func() {
+		It("should replace all such characters with a single dash", func() {
 			Expect(cluster.SanitizeID("a@#$b@#$c")).To(Equal("a-b-c"))
 			Expect(cluster.SanitizeID("a@#$%^&*()._1")).To(Equal("a-1"))
 			Expect(cluster.SanitizeID("@abc!@#123@")).To(Equal("0abc-1230"))

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -76,7 +76,7 @@ func testIsValidID() {
 		})
 	})
 
-	When("the id starts or end with a dash", func() {
+	When("the id starts or ends	 with a dash", func() {
 		It("should not be valid", func() {
 			Expect(cluster.IsValidID("-abcdef")).To(Not(Succeed()))
 			Expect(cluster.IsValidID("abcdef-")).To(Not(Succeed()))
@@ -101,36 +101,36 @@ func testIsValidID() {
 func testSanitizeID() {
 	When("the id only contains alphabetic characters", func() {
 		It("should return same id", func() {
-			Expect(cluster.SanitizeID("abcdef")).To(Equal("abcdef"))
+			expectSanitizeIDNoChange("abcdef")
 		})
 	})
 
 	When("the id only contains numeric characters", func() {
 		It("should return same id", func() {
 			Expect(cluster.IsValidID("012345")).To(Succeed())
-			Expect(cluster.SanitizeID("012345")).To(Equal("012345"))
+			expectSanitizeIDNoChange("012345")
 		})
 	})
 
 	When("the id only contains alphanumeric characters", func() {
 		It("should return same id", func() {
-			Expect(cluster.SanitizeID("a0b1c2d3ef")).To(Equal("a0b1c2d3ef"))
-			Expect(cluster.SanitizeID("0a1b2c3def")).To(Equal("0a1b2c3def"))
-			Expect(cluster.SanitizeID("a0b1c2d3e4f5")).To(Equal("a0b1c2d3e4f5"))
-			Expect(cluster.SanitizeID("0a1b2c3d4e5f6")).To(Equal("0a1b2c3d4e5f6"))
+			expectSanitizeIDNoChange("a0b1c2d3ef")
+			expectSanitizeIDNoChange("0a1b2c3def")
+			expectSanitizeIDNoChange("a0b1c2d3e4f5")
+			expectSanitizeIDNoChange("0a1b2c3d4e5f6")
 		})
 	})
 
 	When("the id only contains alphanumeric characters and dashes", func() {
 		It("should return same id valid", func() {
-			Expect(cluster.SanitizeID("a0b-1c2d3ef")).To(Equal("a0b-1c2d3ef"))
-			Expect(cluster.SanitizeID("0a1b2c3-def")).To(Equal("0a1b2c3-def"))
-			Expect(cluster.SanitizeID("a0b1c2d3---e4f5")).To(Equal("a0b1c2d3---e4f5"))
+			expectSanitizeIDNoChange("a0b-1c2d3ef")
+			expectSanitizeIDNoChange("0a1b2c3-def")
+			expectSanitizeIDNoChange("a0b1c2d3---e4f5")
 		})
 	})
 
 	When("the id contains uppercase alphabetic characters", func() {
-		It("should convert lowercase characters to uppercase", func() {
+		It("should convert the characters to lowercase", func() {
 			Expect(cluster.SanitizeID("A1b2c3d4e5f6")).To(Equal("a1b2c3d4e5f6"))
 			Expect(cluster.SanitizeID("1A2b3c4d5e6f")).To(Equal("1a2b3c4d5e6f"))
 			Expect(cluster.SanitizeID("a1-B2-c3-D4")).To(Equal("a1-b2-c3-d4"))
@@ -144,35 +144,55 @@ func testSanitizeID() {
 		})
 	})
 
-	When("the id starts or end with a dash", func() {
+	When("the id starts or ends with a dash", func() {
 		It("should replace dash with 0", func() {
 			Expect(cluster.SanitizeID("-abcdef")).To(Equal("0abcdef"))
 			Expect(cluster.SanitizeID("abcdef-")).To(Equal("abcdef0"))
 		})
 	})
 
-	When("the id starts or end with non alphanumeric character", func() {
+	When("the id starts or ends with non alphanumeric character", func() {
 		It("should replace non alphanumeric character with 0", func() {
 			Expect(cluster.SanitizeID("éabcdef")).To(Equal("0abcdef"))
 			Expect(cluster.SanitizeID("abcdefé")).To(Equal("abcdef0"))
 		})
 	})
 
+	When("the id has consecutive non alphanumeric characters", func() {
+		It("should repalce all such characters with a single dash", func() {
+			Expect(cluster.SanitizeID("a@#$b@#$c")).To(Equal("a-b-c"))
+			Expect(cluster.SanitizeID("a@#$%^&*()._1")).To(Equal("a-1"))
+			Expect(cluster.SanitizeID("@abc!@#123@")).To(Equal("0abc-1230"))
+		})
+	})
+
+	When("the id has no alphanumeric characters", func() {
+		It("should return 0", func() {
+			Expect(cluster.SanitizeID(".@#$_")).To(Equal("0"))
+			Expect(cluster.SanitizeID("@")).To(Equal("0"))
+			Expect(cluster.SanitizeID(".@")).To(Equal("0"))
+		})
+	})
+
 	When("the id is longer than 63 characters", func() {
 		It("should return same id", func() {
 			testID := "0123456789012345678901234567890123456789012345678901234567890123"
-			Expect(cluster.SanitizeID(testID)).To(Equal(testID))
+			expectSanitizeIDNoChange(testID)
 
 			testID = "0123456789012345678901234567890123456789012345678901234567890123456789"
-			Expect(cluster.SanitizeID(testID)).To(Equal(testID))
+			expectSanitizeIDNoChange(testID)
 		})
 	})
 
 	When("the id is empty", func() {
 		It("should return empty string", func() {
-			Expect(cluster.SanitizeID("")).To(Equal(""))
+			expectSanitizeIDNoChange("")
 		})
 	})
+}
+
+func expectSanitizeIDNoChange(id string) {
+	Expect(cluster.SanitizeID(id)).To(Equal(id))
 }
 
 func TestCluster(t *testing.T) {


### PR DESCRIPTION
When generating clusterIDs from `kubeconfig`, sanitize them
to conform to DNS1123 Label specification instead of throwing
an error if they're invalid.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
