### PR TITLE
Change RHOS default image type in subctl

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -38,7 +38,7 @@ func newRHOSPrepareCommand() *cobra.Command {
 	rhos.AddRHOSFlags(cmd)
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
-	cmd.Flags().StringVar(&rhosGWInstanceType, "gateway-instance", "PnTAE.CPU_16_Memory_32768_Disk_80", "Type of gateway instance machine")
+	cmd.Flags().StringVar(&rhosGWInstanceType, "gateway-instance", "PnTAE.CPU_4_Memory_8192_Disk_50", "Type of gateway instance machine")
 	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
 		"Whether a dedicated gateway node has to be deployed")
 


### PR DESCRIPTION
Change the RHOS image type to a smaller one which is sufficient
for a submariner g/w node.

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
