### PR TITLE
Remove incorrect CODEOWNERS entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,11 +3,6 @@
 *.md @anfredette @astoycos @Billy99 @dfarrell07 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
 /.github/workflows/ @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
 /scripts/ @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
-branch # @anfredette @astoycos @Billy99 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
 build/* @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
-codeowners # @anfredette @astoycos @Billy99 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
-Core # @anfredette @astoycos @Billy99 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
 Dockerfile.dapper @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
-Feature # @anfredette @astoycos @Billy99 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
 Makefile* @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
-Submariner # @anfredette @astoycos @Billy99 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis


### PR DESCRIPTION
The comments in CODEOWNERS.in result in incorrect CODEOWNERS entries;
this doesn't currently have any negative impact but should be fixed.

Depends on https://github.com/submariner-io/shipyard/pull/761
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
