### PR TITLE
Automated backport of #1958: Fix valid ClusterId check

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -19,21 +19,13 @@ limitations under the License.
 package cluster
 
 import (
-	"fmt"
-	"regexp"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func IsValidID(clusterID string) error {
-	// Make sure the clusterid is a valid DNS-1123 string
-	if match, _ := regexp.MatchString("^[a-z0-9][a-z0-9-]*[a-z0-9]$", clusterID); !match {
-		return fmt.Errorf("cluster IDs must be valid DNS-1123 names, with only lowercase alphanumerics,\n"+
-			"or '-' (and the first and last characters must be alphanumerics).\n"+
-			"%s doesn't meet these requirements", clusterID)
-	}
-
-	if len(clusterID) > 63 {
-		return fmt.Errorf("the cluster ID %q has a length of %d characters which exceeds the maximum"+
-			" supported length of 63", clusterID, len(clusterID))
+	if errs := validation.IsDNS1123Label(clusterID); len(errs) > 0 {
+		return errors.Errorf("%s is not a valid ClusterID %v", clusterID, errs)
 	}
 
 	return nil

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -25,9 +25,9 @@ import (
 
 func IsValidID(clusterID string) error {
 	// Make sure the clusterid is a valid DNS-1123 string
-	if match, _ := regexp.MatchString("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", clusterID); !match {
+	if match, _ := regexp.MatchString("^[a-z0-9][a-z0-9-]*[a-z0-9]$", clusterID); !match {
 		return fmt.Errorf("cluster IDs must be valid DNS-1123 names, with only lowercase alphanumerics,\n"+
-			"'.' or '-' (and the first and last characters must be alphanumerics).\n"+
+			"or '-' (and the first and last characters must be alphanumerics).\n"+
 			"%s doesn't meet these requirements", clusterID)
 	}
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1,0 +1,91 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner-operator/internal/cluster"
+)
+
+var _ = Describe("IsValidID", func() {
+	When("the id only contains alphabetic characters", func() {
+		It("should be valid", func() {
+			Expect(cluster.IsValidID("abcdef")).To(Succeed())
+		})
+	})
+
+	When("the id only contains numeric characters", func() {
+		It("should be valid", func() {
+			Expect(cluster.IsValidID("012345")).To(Succeed())
+		})
+	})
+
+	When("the id only contains alphanumeric characters", func() {
+		It("should be valid", func() {
+			Expect(cluster.IsValidID("a0b1c2d3ef")).To(Succeed())
+			Expect(cluster.IsValidID("0a1b2c3def")).To(Succeed())
+			Expect(cluster.IsValidID("a0b1c2d3e4f5")).To(Succeed())
+			Expect(cluster.IsValidID("0a1b2c3d4e5f6")).To(Succeed())
+		})
+	})
+
+	When("the id only contains alphanumeric characters and dashes", func() {
+		It("should be valid", func() {
+			Expect(cluster.IsValidID("a0b-1c2d3ef")).To(Succeed())
+			Expect(cluster.IsValidID("0a1b2c3-def")).To(Succeed())
+			Expect(cluster.IsValidID("a0b1c2d3---e4f5")).To(Succeed())
+		})
+	})
+
+	When("the id contains non-alphanumeric characters other than dashes", func() {
+		It("should not be valid", func() {
+			Expect(cluster.IsValidID("abcdéfg")).To(Not(Succeed()))
+			Expect(cluster.IsValidID("abcde.g")).To(Not(Succeed()))
+		})
+	})
+
+	When("the id starts or end with a dash", func() {
+		It("should not be valid", func() {
+			Expect(cluster.IsValidID("-abcdef")).To(Not(Succeed()))
+			Expect(cluster.IsValidID("abcdef-")).To(Not(Succeed()))
+		})
+	})
+
+	When("the id is longer than 63 characters", func() {
+		It("should not be valid", func() {
+			Expect(cluster.IsValidID("012345678901234567890123456789012345678901234567890123456789012")).To(Succeed())
+			Expect(cluster.IsValidID("0123456789012345678901234567890123456789012345678901234567890123")).To(Not(Succeed()))
+			Expect(cluster.IsValidID("0123456789012345678901234567890123456789012345678901234567890123456789")).To(Not(Succeed()))
+		})
+	})
+
+	When("the id is empty", func() {
+		It("should not be valid", func() {
+			Expect(cluster.IsValidID("")).To(Not(Succeed()))
+		})
+	})
+})
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster suite")
+}


### PR DESCRIPTION
Backport of #1958 on release-0.12.

#1958: Fix valid ClusterId check

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.