### PR TITLE
Drop IKE port configuration

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -40,6 +40,9 @@ import (
 var (
 	joinFlags    join.Options
 	labelGateway bool
+
+	// Deprecated: will be removed in 0.14.
+	ignoredIkePort int
 )
 
 var joinCmd = &cobra.Command{
@@ -93,7 +96,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&joinFlags.Repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&joinFlags.ImageVersion, "version", "", "image version")
 	cmd.Flags().IntVar(&joinFlags.NATTPort, "nattport", 4500, "IPsec NATT port")
-	cmd.Flags().IntVar(&joinFlags.IKEPort, "ikeport", 500, "IPsec IKE port")
+	cmd.Flags().IntVar(&ignoredIkePort, "ikeport", 500, "IPsec IKE port")
+	_ = cmd.Flags().MarkDeprecated("ikeport", "the IKE port setting is ignored")
 	cmd.Flags().BoolVar(&joinFlags.NATTraversal, "natt", true, "enable NAT traversal for IPsec")
 
 	cmd.Flags().BoolVar(&joinFlags.PreferredServer, "preferred-server", false,

--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -224,10 +224,6 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 			Volumes:     volumes,
 		},
 	}
-	if cr.Spec.CeIPSecIKEPort != 0 {
-		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
-			corev1.EnvVar{Name: "CE_IPSEC_IKEPORT", Value: strconv.Itoa(cr.Spec.CeIPSecIKEPort)})
-	}
 
 	if cr.Spec.CeIPSecNATTPort != 0 {
 		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,

--- a/controllers/submariner/submariner_suite_test.go
+++ b/controllers/submariner/submariner_suite_test.go
@@ -166,7 +166,6 @@ func (t *testDriver) assertUninstallGatewayDaemonSet() *appsv1.DaemonSet {
 
 func (t *testDriver) assertGatewayDaemonSetEnv(submariner *operatorv1.Submariner, envMap map[string]string) {
 	Expect(envMap).To(HaveKeyWithValue("CE_IPSEC_PSK", submariner.Spec.CeIPSecPSK))
-	Expect(envMap).To(HaveKeyWithValue("CE_IPSEC_IKEPORT", strconv.Itoa(submariner.Spec.CeIPSecIKEPort)))
 	Expect(envMap).To(HaveKeyWithValue("CE_IPSEC_NATTPORT", strconv.Itoa(submariner.Spec.CeIPSecNATTPort)))
 	Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("RemoteNamespace"), submariner.Spec.BrokerK8sRemoteNamespace))
 	Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("ApiServer"), submariner.Spec.BrokerK8sApiServer))

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -42,7 +42,6 @@ type SubmarinerOptions struct {
 	LoadBalancerEnabled           bool
 	HealthCheckEnabled            bool
 	NATTPort                      int
-	IKEPort                       int
 	HealthCheckInterval           uint64
 	HealthCheckMaxPacketLossCount uint64
 	ClusterID                     string
@@ -82,7 +81,6 @@ func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info,
 		Repository:               getImageRepo(options.Repository),
 		Version:                  getImageVersion(options.ImageVersion),
 		CeIPSecNATTPort:          options.NATTPort,
-		CeIPSecIKEPort:           options.IKEPort,
 		CeIPSecDebug:             options.IPSecDebug,
 		CeIPSecForceUDPEncaps:    options.ForceUDPEncaps,
 		CeIPSecPreferredServer:   options.PreferredServer,

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -139,7 +139,6 @@ func submarinerOptionsFrom(joinOptions *Options) *deploy.SubmarinerOptions {
 		LoadBalancerEnabled:           joinOptions.LoadBalancerEnabled,
 		HealthCheckEnabled:            joinOptions.HealthCheckEnabled,
 		NATTPort:                      joinOptions.NATTPort,
-		IKEPort:                       joinOptions.IKEPort,
 		HealthCheckInterval:           joinOptions.HealthCheckInterval,
 		HealthCheckMaxPacketLossCount: joinOptions.HealthCheckMaxPacketLossCount,
 		ClusterID:                     joinOptions.ClusterID,

--- a/pkg/join/options.go
+++ b/pkg/join/options.go
@@ -30,7 +30,6 @@ type Options struct {
 	LoadBalancerEnabled           bool
 	HealthCheckEnabled            bool
 	NATTPort                      int
-	IKEPort                       int
 	GlobalnetClusterSize          uint
 	HealthCheckInterval           uint64
 	HealthCheckMaxPacketLossCount uint64

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -59,7 +59,6 @@ var (
 	repository                    string
 	imageVersion                  string
 	nattPort                      int
-	ikePort                       int
 	preferredServer               bool
 	forceUDPEncaps                bool
 	natTraversal                  bool
@@ -78,6 +77,9 @@ var (
 	healthCheckInterval           uint64
 	healthCheckMaxPacketLossCount uint64
 	corednsCustomConfigMap        string
+
+	// Deprecated: will be removed in 0.14.
+	ignoredIkePort int
 )
 
 func init() {
@@ -93,7 +95,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&imageVersion, "version", "", "image version")
 	cmd.Flags().IntVar(&nattPort, "nattport", 4500, "IPsec NATT port")
-	cmd.Flags().IntVar(&ikePort, "ikeport", 500, "IPsec IKE port")
+	cmd.Flags().IntVar(&ignoredIkePort, "ikeport", 500, "IPsec IKE port")
+	_ = cmd.Flags().MarkDeprecated("ikeport", "the IKE port setting is ignored")
 	cmd.Flags().BoolVar(&natTraversal, "natt", true, "enable NAT traversal for IPsec")
 
 	cmd.Flags().BoolVar(&preferredServer, "preferred-server", false,
@@ -446,7 +449,6 @@ func populateSubmarinerSpec(subctlData *datafile.SubctlData, brokerSecret, pskSe
 		Repository:               getImageRepo(),
 		Version:                  getImageVersion(),
 		CeIPSecNATTPort:          nattPort,
-		CeIPSecIKEPort:           ikePort,
 		CeIPSecDebug:             ipsecDebug,
 		CeIPSecForceUDPEncaps:    forceUDPEncaps,
 		CeIPSecPreferredServer:   preferredServer,

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -34,7 +34,6 @@ function create_subm_vars() {
     subm_debug=false
     subm_broker=k8s
     ce_ipsec_debug=false
-    ce_ipsec_ikeport=500
     ce_ipsec_nattport=4500
 
     subm_ns=submariner-operator
@@ -201,7 +200,6 @@ function verify_subm_cr() {
   validate_equals '.spec.brokerK8sCA' $SUBMARINER_BROKER_CA
   validate_equals '.spec.brokerK8sRemoteNamespace' $SUBMARINER_BROKER_NS
   validate_equals '.spec.ceIPSecDebug' $ce_ipsec_debug
-  validate_equals '.spec.ceIPSecIKEPort' $ce_ipsec_ikeport
   validate_equals '.spec.ceIPSecNATTPort' $ce_ipsec_nattport
   validate_equals '.spec.repository' $subm_gateway_image_repo
   validate_equals '.spec.version' $subm_gateway_image_tag
@@ -274,7 +272,6 @@ function verify_subm_gateway_pod() {
   validate_pod_container_env 'BROKER_K8S_REMOTENAMESPACE' $SUBMARINER_BROKER_NS
   validate_pod_container_env 'BROKER_K8S_CA' $SUBMARINER_BROKER_CA
   validate_pod_container_env 'CE_IPSEC_DEBUG' $ce_ipsec_debug
-  validate_pod_container_env 'CE_IPSEC_IKEPORT' $ce_ipsec_ikeport
   validate_pod_container_env 'CE_IPSEC_NATTPORT' $ce_ipsec_nattport
 
   validate_equals '.spec.serviceAccount' 'submariner-gateway'


### PR DESCRIPTION
Submariner no longer uses this configuration setting, drop it from the
operator (but keep it in the CRD to avoid breaking old clients setting
it).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
