### PR TITLE
Remove references to lighthouse.submariner.io CRDs

### DIFF
--- a/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_role.yaml
@@ -60,16 +60,3 @@ rules:
   - servicediscoveries
   verbs:
   - '*'
-- apiGroups:
-  - lighthouse.submariner.io
-  resources:
-  - '*'
-  - serviceexports
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch

--- a/bundle/manifests/submariner-globalnet_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-globalnet_rbac.authorization.k8s.io_v1_role.yaml
@@ -60,16 +60,3 @@ rules:
   - servicediscoveries
   verbs:
   - '*'
-- apiGroups:
-  - lighthouse.submariner.io
-  resources:
-  - '*'
-  - serviceexports
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch

--- a/bundle/manifests/submariner-lighthouse-coredns_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/submariner-lighthouse-coredns_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -28,17 +28,6 @@ rules:
   - delete
   - deletecollection
 - apiGroups:
-  - lighthouse.submariner.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - delete
-- apiGroups:
   - submariner.io
   resources:
   - gateways

--- a/bundle/manifests/submariner-routeagent_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-routeagent_rbac.authorization.k8s.io_v1_role.yaml
@@ -60,16 +60,3 @@ rules:
   - servicediscoveries
   verbs:
   - '*'
-- apiGroups:
-  - lighthouse.submariner.io
-  resources:
-  - '*'
-  - serviceexports
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch

--- a/config/rbac/lighthouse-coredns/cluster_role.yaml
+++ b/config/rbac/lighthouse-coredns/cluster_role.yaml
@@ -29,17 +29,6 @@ rules:
       - delete
       - deletecollection
   - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - "*"
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - delete
-  - apiGroups:
       - submariner.io
     resources:
       - "gateways"

--- a/config/rbac/submariner-gateway/role.yaml
+++ b/config/rbac/submariner-gateway/role.yaml
@@ -61,16 +61,3 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch

--- a/config/rbac/submariner-globalnet/role.yaml
+++ b/config/rbac/submariner-globalnet/role.yaml
@@ -61,16 +61,3 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch

--- a/config/rbac/submariner-route-agent/role.yaml
+++ b/config/rbac/submariner-route-agent/role.yaml
@@ -61,16 +61,3 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2313,19 +2313,6 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
 `
 	Config_rbac_submariner_gateway_role_binding_yaml = `---
 kind: RoleBinding
@@ -2485,19 +2472,6 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
 `
 	Config_rbac_submariner_route_agent_role_binding_yaml = `---
 kind: RoleBinding
@@ -2654,19 +2628,6 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
 `
 	Config_rbac_submariner_globalnet_role_binding_yaml = `---
 kind: RoleBinding
@@ -2966,17 +2927,6 @@ rules:
       - update
       - delete
       - deletecollection
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - "*"
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - delete
   - apiGroups:
       - submariner.io
     resources:

--- a/pkg/lighthouse/crds.go
+++ b/pkg/lighthouse/crds.go
@@ -24,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/embeddedyamls"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -34,26 +32,8 @@ const (
 )
 
 // Ensure ensures that the required resources are deployed on the target system
-// The resources handled here are the lighthouse CRDs: MultiClusterService,
-// ServiceImport, ServiceExport and ServiceDiscovery
-// nolint:gocyclo // This really isn't complex and just trips the threshold.
+// The resources handled here are the lighthouse CRDs: ServiceImport, ServiceExport and ServiceDiscovery.
 func Ensure(crdUpdater crd.Updater, isBroker bool) (bool, error) {
-	// Delete obsolete CRDs if they are still present
-	err := crdUpdater.Delete(context.TODO(), "serviceimports.lighthouse.submariner.io", metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return false, errors.Wrap(err, "error deleting the obsolete ServiceImport CRD")
-	}
-
-	err = crdUpdater.Delete(context.TODO(), "serviceexports.lighthouse.submariner.io", metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return false, errors.Wrap(err, "error deleting the obsolete ServiceExport CRD")
-	}
-
-	err = crdUpdater.Delete(context.TODO(), "multiclusterservices.lighthouse.submariner.io", metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return false, errors.Wrap(err, "error deleting the obsolete MultiClusterServices CRD")
-	}
-
 	installedMCSSI, err := crdUpdater.CreateOrUpdateFromEmbedded(context.TODO(),
 		embeddedyamls.Deploy_mcsapi_crds_multicluster_x_k8s_io_serviceimports_yaml)
 	if err != nil {


### PR DESCRIPTION
These CRDs are long-gone; we no longer need the removal code, or the
permissions in the CoreDNS plugin roles.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
