### PR TITLE
Automated backport of #1973: Change default image type

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -38,7 +38,7 @@ func newRHOSPrepareCommand() *cobra.Command {
 	rhos.AddRHOSFlags(cmd)
 	cmd.Flags().IntVar(&gateways, "gateways", DefaultNumGateways,
 		"Number of gateways to deploy")
-	cmd.Flags().StringVar(&rhosGWInstanceType, "gateway-instance", "PnTAE.CPU_16_Memory_32768_Disk_80", "Type of gateway instance machine")
+	cmd.Flags().StringVar(&rhosGWInstanceType, "gateway-instance", "PnTAE.CPU_4_Memory_8192_Disk_50", "Type of gateway instance machine")
 	cmd.Flags().BoolVar(&dedicatedGateway, "dedicated-gateway", true,
 		"Whether a dedicated gateway node has to be deployed")
 


### PR DESCRIPTION
Backport of #1973 on release-0.12.

#1973: Change default image type

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.
Depends on https://github.com/submariner-io/submariner-operator/pull/1973