### PR TITLE
Print message when no kube config provided

### DIFF
--- a/cmd/subctl/execute/execute.go
+++ b/cmd/subctl/execute/execute.go
@@ -30,10 +30,16 @@ import (
 )
 
 func OnMultiCluster(restConfigProducer restconfig.Producer, run func(*cluster.Info, reporter.Interface) bool) {
+	restConfigs := restConfigProducer.MustGetForClusters()
+	if len(restConfigs) == 0 {
+		fmt.Println("No kube config was provided. Please use the --kubeconfig flag or set the KUBECONFIG environment variable")
+		return
+	}
+
 	success := true
 	status := cli.NewReporter()
 
-	for _, config := range restConfigProducer.MustGetForClusters() {
+	for _, config := range restConfigs {
 		fmt.Printf("Cluster %q\n", config.ClusterName)
 
 		clientProducer, err := client.NewProducerFromRestConfig(config.Config)

--- a/pkg/subctl/cmd/execute.go
+++ b/pkg/subctl/cmd/execute.go
@@ -90,9 +90,15 @@ func (c *Cluster) GetGateways() ([]submarinerv1.Gateway, error) {
 }
 
 func ExecuteMultiCluster(restConfigProducer restconfig.Producer, run func(*Cluster) bool) {
+	restConfigs := restConfigProducer.MustGetForClusters()
+	if len(restConfigs) == 0 {
+		fmt.Println("No kube config was provided. Please use the --kubeconfig flag or set the KUBECONFIG environment variable")
+		return
+	}
+
 	success := true
 
-	for _, config := range restConfigProducer.MustGetForClusters() {
+	for _, config := range restConfigs {
 		fmt.Printf("Cluster %q\n", config.ClusterName)
 
 		cluster, errMsg := NewCluster(config.Config, config.ClusterName)


### PR DESCRIPTION
`ExecuteMultiCluster` silently returns if no kube configs were provided - print a message instead.

Fixes https://github.com/submariner-io/submariner-operator/issues/1944