### PR TITLE
Use unique name for all-K8s E2E job

### DIFF
--- a/.github/workflows/e2e-all-k8s.yml
+++ b/.github/workflows/e2e-all-k8s.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e:
-    name: E2E
+    name: E2E All K8s
     if: contains(github.event.pull_request.labels.*.name, 'e2e-all-k8s')
     timeout-minutes: 30
     runs-on: ubuntu-latest


### PR DESCRIPTION
The GitHub required job configuration seems to only filter based on the
names of jobs, not the names of workflows and jobs. This now causes the
E2E All K8s job to be required, which would require running way too many
jobs on each PR.

There seems to have been some change to cause this new behavior, as the
same GHA configuration didn't used to result in the all-K8s job being
required.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
