### PR TITLE
Add execute wrapper func that checks Submariner installed

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -27,4 +27,5 @@ const (
 	SubmarinerName          = "submariner"
 	SubmarinerNamespace     = "submariner-operator"
 	TrueLabel               = "true"
+	SubmarinerNotInstalled  = "Submariner is not installed"
 )


### PR DESCRIPTION
Simplifies commands that should only run if Submariner is installed.
