### PR TITLE
Wrap parameter/return lists as expected by gofumpt

### DIFF
--- a/controllers/helpers/helpers.go
+++ b/controllers/helpers/helpers.go
@@ -39,7 +39,8 @@ import (
 )
 
 func ReconcileDaemonSet(owner metav1.Object, daemonSet *appsv1.DaemonSet, reqLogger logr.Logger,
-	client controllerClient.Client, scheme *runtime.Scheme) (*appsv1.DaemonSet, error) {
+	client controllerClient.Client, scheme *runtime.Scheme,
+) (*appsv1.DaemonSet, error) {
 	var err error
 
 	// Set the owner and controller.
@@ -98,7 +99,8 @@ func ReconcileDaemonSet(owner metav1.Object, daemonSet *appsv1.DaemonSet, reqLog
 }
 
 func ReconcileDeployment(owner metav1.Object, deployment *appsv1.Deployment, reqLogger logr.Logger,
-	client controllerClient.Client, scheme *runtime.Scheme) (*appsv1.Deployment, error) {
+	client controllerClient.Client, scheme *runtime.Scheme,
+) (*appsv1.Deployment, error) {
 	var err error
 
 	// Set the owner and controller
@@ -143,7 +145,8 @@ func ReconcileDeployment(owner metav1.Object, deployment *appsv1.Deployment, req
 }
 
 func ReconcileConfigMap(owner metav1.Object, configMap *corev1.ConfigMap, reqLogger logr.Logger,
-	client controllerClient.Client, scheme *runtime.Scheme) (*corev1.ConfigMap, error) {
+	client controllerClient.Client, scheme *runtime.Scheme,
+) (*corev1.ConfigMap, error) {
 	var err error
 
 	// Set the owner and controller
@@ -188,7 +191,8 @@ func ReconcileConfigMap(owner metav1.Object, configMap *corev1.ConfigMap, reqLog
 }
 
 func ReconcileService(owner metav1.Object, service *corev1.Service, reqLogger logr.Logger,
-	client controllerClient.Client, scheme *runtime.Scheme) (*corev1.Service, error) {
+	client controllerClient.Client, scheme *runtime.Scheme,
+) (*corev1.Service, error) {
 	var err error
 
 	// Set the owner and controller

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -36,7 +36,8 @@ import (
 
 func Setup(namespace string, owner metav1.Object, labels map[string]string, port int32,
 	client controllerClient.Client, config *rest.Config, scheme *runtime.Scheme,
-	reqLogger logr.Logger) error {
+	reqLogger logr.Logger,
+) error {
 	app, ok := labels["app"]
 	if !ok {
 		return fmt.Errorf("no app label in the provided labels, %v", labels)

--- a/controllers/servicediscovery/cleanup.go
+++ b/controllers/servicediscovery/cleanup.go
@@ -104,7 +104,8 @@ func (r *Reconciler) removeFinalizer(ctx context.Context, instance *operatorv1al
 }
 
 func (r *Reconciler) removeLighthouseConfigFromCustomDNSConfigMap(ctx context.Context,
-	config *operatorv1alpha1.CoreDNSCustomConfig) error {
+	config *operatorv1alpha1.CoreDNSCustomConfig,
+) error {
 	configMap := newCoreDNSCustomConfigMap(config)
 
 	log.Info("Removing lighthouse config from custom DNS ConfigMap", "Name", configMap.Name, "Namespace", configMap.Namespace)

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -191,7 +191,8 @@ func (r *Reconciler) getServiceDiscovery(ctx context.Context, key types.Namespac
 }
 
 func (r *Reconciler) addFinalizer(ctx context.Context,
-	instance *submarinerv1alpha1.ServiceDiscovery) (*submarinerv1alpha1.ServiceDiscovery, error) {
+	instance *submarinerv1alpha1.ServiceDiscovery,
+) (*submarinerv1alpha1.ServiceDiscovery, error) {
 	added, err := finalizer.Add(ctx, resource.ForControllerClient(r.config.Client, instance.Namespace,
 		&submarinerv1alpha1.ServiceDiscovery{}), instance, constants.CleanupFinalizer)
 	if err != nil {
@@ -433,7 +434,8 @@ func getCustomCoreDNSNamespace(config *submarinerv1alpha1.CoreDNSCustomConfig) s
 }
 
 func (r *Reconciler) updateDNSCustomConfigMap(ctx context.Context, cr *submarinerv1alpha1.ServiceDiscovery,
-	reqLogger logr.Logger) error {
+	reqLogger logr.Logger,
+) error {
 	var configFunc func(context.Context, *corev1.ConfigMap) (*corev1.ConfigMap, error)
 
 	customCoreDNSName := cr.Spec.CoreDNSCustomConfig.ConfigMapName
@@ -487,7 +489,8 @@ func (r *Reconciler) updateDNSCustomConfigMap(ctx context.Context, cr *submarine
 }
 
 func (r *Reconciler) configureDNSConfigMap(ctx context.Context, cr *submarinerv1alpha1.ServiceDiscovery, configMapNamespace,
-	configMapName string) error {
+	configMapName string,
+) error {
 	lighthouseDNSService := &corev1.Service{}
 
 	err := r.config.Client.Get(ctx, types.NamespacedName{Name: lighthouseCoreDNSName, Namespace: cr.Namespace}, lighthouseDNSService)
@@ -503,7 +506,8 @@ func (r *Reconciler) configureDNSConfigMap(ctx context.Context, cr *submarinerv1
 }
 
 func (r *Reconciler) updateLighthouseConfigInConfigMap(ctx context.Context, cr *submarinerv1alpha1.ServiceDiscovery,
-	configMapNamespace, configMapName, clusterIP string) error {
+	configMapNamespace, configMapName, clusterIP string,
+) error {
 	// nolint:wrapcheck // No need to wrap errors here
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		configMap, err := r.config.KubeClient.CoreV1().ConfigMaps(configMapNamespace).Get(ctx, configMapName, metav1.GetOptions{})
@@ -586,7 +590,8 @@ func (r *Reconciler) configureOpenshiftClusterDNSOperator(ctx context.Context, i
 }
 
 func (r *Reconciler) updateLighthouseConfigInOpenshiftDNSOperator(ctx context.Context, instance *submarinerv1alpha1.ServiceDiscovery,
-	clusterIP string) error {
+	clusterIP string,
+) error {
 	// nolint:wrapcheck // No need to wrap errors here
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		dnsOperator := &operatorv1.DNS{}
@@ -631,7 +636,8 @@ func (r *Reconciler) updateLighthouseConfigInOpenshiftDNSOperator(ctx context.Co
 }
 
 func getUpdatedForwardServers(instance *submarinerv1alpha1.ServiceDiscovery, dnsOperator *operatorv1.DNS,
-	clusterIP string) []operatorv1.Server {
+	clusterIP string,
+) []operatorv1.Server {
 	updatedForwardServers := make([]operatorv1.Server, 0)
 	changed := false
 	containsLighthouse := false
@@ -744,7 +750,8 @@ func (r *Reconciler) ensureLighthouseCoreDNSDeployment(instance *submarinerv1alp
 }
 
 func (r *Reconciler) ensureLighthouseCoreDNSService(ctx context.Context, instance *submarinerv1alpha1.ServiceDiscovery,
-	reqLogger logr.Logger) error {
+	reqLogger logr.Logger,
+) error {
 	lighthouseCoreDNSService := &corev1.Service{}
 
 	err := r.config.Client.Get(ctx, types.NamespacedName{Name: lighthouseCoreDNSName, Namespace: instance.Namespace},

--- a/controllers/submariner/daemonsets.go
+++ b/controllers/submariner/daemonsets.go
@@ -30,7 +30,8 @@ import (
 )
 
 func updateDaemonSetStatus(ctx context.Context, clnt client.Reader, daemonSet *appsv1.DaemonSet, status *v1alpha1.DaemonSetStatus,
-	namespace string) error {
+	namespace string,
+) error {
 	if daemonSet != nil {
 		if status == nil {
 			status = &v1alpha1.DaemonSetStatus{}
@@ -54,7 +55,8 @@ func updateDaemonSetStatus(ctx context.Context, clnt client.Reader, daemonSet *a
 }
 
 func checkDaemonSetContainers(ctx context.Context, clnt client.Reader, daemonSet *appsv1.DaemonSet,
-	namespace string) (bool, *[]corev1.ContainerState, error) {
+	namespace string,
+) (bool, *[]corev1.ContainerState, error) {
 	containerStatuses, err := retrieveDaemonSetContainerStatuses(ctx, clnt, daemonSet, namespace)
 	if err != nil {
 		return false, nil, err
@@ -84,7 +86,8 @@ func checkDaemonSetContainers(ctx context.Context, clnt client.Reader, daemonSet
 }
 
 func retrieveDaemonSetContainerStatuses(ctx context.Context, clnt client.Reader, daemonSet *appsv1.DaemonSet,
-	namespace string) (*[]corev1.ContainerStatus, error) {
+	namespace string,
+) (*[]corev1.ContainerStatus, error) {
 	pods, err := findPodsBySelector(ctx, clnt, namespace, daemonSet.Spec.Selector)
 	if err != nil {
 		return nil, err
@@ -99,7 +102,8 @@ func retrieveDaemonSetContainerStatuses(ctx context.Context, clnt client.Reader,
 }
 
 func findPodsBySelector(ctx context.Context, clnt client.Reader, namespace string,
-	labelSelector *metav1.LabelSelector) ([]corev1.Pod, error) {
+	labelSelector *metav1.LabelSelector,
+) ([]corev1.Pod, error) {
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating label selector")

--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -245,7 +245,8 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 
 // nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileGatewayDaemonSet(
-	instance *v1alpha1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet, error) {
+	instance *v1alpha1.Submariner, reqLogger logr.Logger,
+) (*appsv1.DaemonSet, error) {
 	daemonSet, err := helpers.ReconcileDaemonSet(instance, newGatewayDaemonSet(instance, names.GatewayComponent),
 		reqLogger, r.config.Client, r.config.Scheme)
 	if err != nil {
@@ -289,7 +290,8 @@ func buildGatewayStatusAndUpdateMetrics(gateways []submarinerv1.Gateway) []subma
 }
 
 func (r *Reconciler) retrieveGateways(ctx context.Context, owner metav1.Object,
-	namespace string) ([]submarinerv1.Gateway, error) {
+	namespace string,
+) ([]submarinerv1.Gateway, error) {
 	foundGateways := &submarinerv1.GatewayList{}
 
 	err := r.config.Client.List(ctx, foundGateways, client.InNamespace(namespace))

--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -32,7 +32,8 @@ import (
 
 // nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileGlobalnetDaemonSet(instance *v1alpha1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet,
-	error) {
+	error,
+) {
 	daemonSet, err := helpers.ReconcileDaemonSet(instance, newGlobalnetDaemonSet(instance, names.GlobalnetComponent), reqLogger,
 		r.config.Client, r.config.Scheme)
 	if err != nil {

--- a/controllers/submariner/loadbalancer_resources.go
+++ b/controllers/submariner/loadbalancer_resources.go
@@ -40,7 +40,8 @@ const (
 
 // nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileLoadBalancer(
-	instance *v1alpha1.Submariner, reqLogger logr.Logger) (*corev1.Service, error) {
+	instance *v1alpha1.Submariner, reqLogger logr.Logger,
+) (*corev1.Service, error) {
 	return helpers.ReconcileService(instance, newLoadBalancerService(instance), reqLogger, r.config.Client, r.config.Scheme)
 }
 

--- a/controllers/submariner/np_syncer_resources.go
+++ b/controllers/submariner/np_syncer_resources.go
@@ -35,7 +35,8 @@ import (
 
 // nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileNetworkPluginSyncerDeployment(instance *v1alpha1.Submariner,
-	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger) error {
+	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger,
+) error {
 	// Only OVNKubernetes needs networkplugin-syncer so far
 	if needsNetworkPluginSyncer(instance) {
 		_, err := helpers.ReconcileDeployment(instance, newNetworkPluginSyncerDeployment(instance,

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -34,7 +34,8 @@ import (
 
 // nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileRouteagentDaemonSet(instance *v1alpha1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet,
-	error) {
+	error,
+) {
 	return helpers.ReconcileDaemonSet(instance, newRouteAgentDaemonSet(instance, names.RouteAgentComponent), reqLogger, r.config.Client,
 		r.config.Scheme)
 }

--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -32,7 +32,8 @@ import (
 )
 
 func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner *v1alpha1.Submariner, reqLogger logr.Logger,
-	isEnabled bool) error {
+	isEnabled bool,
+) error {
 	// nolint:wrapcheck // No need to wrap errors here
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if isEnabled {

--- a/controllers/uninstall/uninstall.go
+++ b/controllers/uninstall/uninstall.go
@@ -325,7 +325,8 @@ func convertPodSpecContainersToUninstall(podSpec *corev1.PodSpec) {
 }
 
 func findPodsBySelector(ctx context.Context, clnt client.Reader, namespace string,
-	labelSelector *metav1.LabelSelector) ([]corev1.Pod, error) {
+	labelSelector *metav1.LabelSelector,
+) ([]corev1.Pod, error) {
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating label selector")

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/klog/v2 v2.8.0
+	k8s.io/klog/v2 v2.8.0 // indirect
 	k8s.io/utils v0.0.0-20210305010621-2afb4311ab10
 	sigs.k8s.io/controller-runtime v0.8.3
 	sigs.k8s.io/controller-tools v0.4.1

--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -258,7 +258,8 @@ func nodeAffinity(scheduling schedulingType) *v1.Affinity {
 }
 
 func addNodeSelectorTerm(nodeSelTerms []v1.NodeSelectorTerm, label string,
-	op v1.NodeSelectorOperator, values []string) []v1.NodeSelectorTerm {
+	op v1.NodeSelectorOperator, values []string,
+) []v1.NodeSelectorTerm {
 	return append(nodeSelTerms, v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
 		{
 			Key:      label,

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -193,7 +193,8 @@ func CreateOrUpdateBrokerAdminRole(clientset kubernetes.Interface, inNamespace s
 
 // nolint:wrapcheck // No need to wrap here
 func CreateNewBrokerRoleBinding(kubeClient kubernetes.Interface, serviceAccount, roleName, inNamespace string) (
-	brokerRoleBinding *rbacv1.RoleBinding, err error) {
+	brokerRoleBinding *rbacv1.RoleBinding, err error,
+) {
 	return kubeClient.RbacV1().RoleBindings(inNamespace).Create(
 		context.TODO(), NewBrokerRoleBinding(serviceAccount, roleName, inNamespace), metav1.CreateOptions{})
 }

--- a/pkg/broker/file.go
+++ b/pkg/broker/file.go
@@ -38,7 +38,8 @@ import (
 const InfoFileName = "broker-info.subm"
 
 func WriteInfoToFile(restConfig *rest.Config, brokerNamespace, ipsecFile string, components stringset.Interface,
-	customDomains []string, status reporter.Interface) error {
+	customDomains []string, status reporter.Interface,
+) error {
 	status.Start("Saving broker info to file %q", InfoFileName)
 	defer status.End()
 

--- a/pkg/broker/globalcidr_cm.go
+++ b/pkg/broker/globalcidr_cm.go
@@ -46,7 +46,8 @@ type ClusterInfo struct {
 }
 
 func CreateGlobalnetConfigMap(kubeClient kubernetes.Interface, globalnetEnabled bool, defaultGlobalCidrRange string,
-	defaultGlobalClusterSize uint, namespace string) error {
+	defaultGlobalClusterSize uint, namespace string,
+) error {
 	gnConfigMap, err := NewGlobalnetConfigMap(globalnetEnabled, defaultGlobalCidrRange, defaultGlobalClusterSize, namespace)
 	if err != nil {
 		return errors.Wrap(err, "error creating config map")
@@ -61,7 +62,8 @@ func CreateGlobalnetConfigMap(kubeClient kubernetes.Interface, globalnetEnabled 
 }
 
 func NewGlobalnetConfigMap(globalnetEnabled bool, defaultGlobalCidrRange string,
-	defaultGlobalClusterSize uint, namespace string) (*v1.ConfigMap, error) {
+	defaultGlobalClusterSize uint, namespace string,
+) (*v1.ConfigMap, error) {
 	labels := map[string]string{
 		"component": "submariner-globalnet",
 	}
@@ -99,7 +101,8 @@ func NewGlobalnetConfigMap(globalnetEnabled bool, defaultGlobalCidrRange string,
 }
 
 func UpdateGlobalnetConfigMap(k8sClientset kubernetes.Interface, namespace string,
-	configMap *v1.ConfigMap, newCluster ClusterInfo) error {
+	configMap *v1.ConfigMap, newCluster ClusterInfo,
+) error {
 	var clusterInfo []ClusterInfo
 
 	err := json.Unmarshal([]byte(configMap.Data[ClusterInfoKey]), &clusterInfo)

--- a/pkg/crd/updater.go
+++ b/pkg/crd/updater.go
@@ -94,21 +94,24 @@ func (u *updater) CreateOrUpdateFromEmbedded(ctx context.Context, crdYaml string
 }
 
 func (c *controllerClientCreator) Create(ctx context.Context, crd *apiextensions.CustomResourceDefinition,
-	options metav1.CreateOptions) (*apiextensions.CustomResourceDefinition, error) {
+	options metav1.CreateOptions,
+) (*apiextensions.CustomResourceDefinition, error) {
 	// TODO skitt handle options
 	err := c.client.Create(ctx, crd)
 	return crd, err
 }
 
 func (c *controllerClientCreator) Update(ctx context.Context, crd *apiextensions.CustomResourceDefinition,
-	options metav1.UpdateOptions) (*apiextensions.CustomResourceDefinition, error) {
+	options metav1.UpdateOptions,
+) (*apiextensions.CustomResourceDefinition, error) {
 	// TODO skitt handle options
 	err := c.client.Update(ctx, crd)
 	return crd, err
 }
 
 func (c *controllerClientCreator) Get(ctx context.Context, name string,
-	options metav1.GetOptions) (*apiextensions.CustomResourceDefinition, error) {
+	options metav1.GetOptions,
+) (*apiextensions.CustomResourceDefinition, error) {
 	crd := &apiextensions.CustomResourceDefinition{}
 	// TODO skitt handle options
 	err := c.client.Get(ctx, client.ObjectKey{Name: name}, crd)

--- a/pkg/deploy/operator.go
+++ b/pkg/deploy/operator.go
@@ -28,7 +28,8 @@ import (
 )
 
 func Operator(status reporter.Interface, version, repository string, imageOverrideArr []string, debug bool,
-	clientProducer client.Producer) error {
+	clientProducer client.Producer,
+) error {
 	operatorImage, err := image.ForOperator(version, repository, imageOverrideArr)
 	if err != nil {
 		return errors.Wrap(err, "error overriding Operator Image")

--- a/pkg/deploy/servicediscovery.go
+++ b/pkg/deploy/servicediscovery.go
@@ -40,7 +40,8 @@ type ServiceDiscoveryOptions struct {
 }
 
 func ServiceDiscovery(clientProducer client.Producer, options *ServiceDiscoveryOptions, brokerInfo *broker.Info, brokerSecret *v1.Secret,
-	imageOverrides map[string]string, status reporter.Interface) error {
+	imageOverrides map[string]string, status reporter.Interface,
+) error {
 	serviceDiscoverySpec := populateServiceDiscoverySpec(options, brokerInfo, brokerSecret, imageOverrides)
 
 	err := servicediscoverycr.Ensure(clientProducer.ForOperator(), constants.OperatorNamespace, serviceDiscoverySpec)
@@ -52,7 +53,8 @@ func ServiceDiscovery(clientProducer client.Producer, options *ServiceDiscoveryO
 }
 
 func populateServiceDiscoverySpec(options *ServiceDiscoveryOptions, brokerInfo *broker.Info, brokerSecret *v1.Secret,
-	imageOverrides map[string]string) *submariner.ServiceDiscoverySpec {
+	imageOverrides map[string]string,
+) *submariner.ServiceDiscoverySpec {
 	brokerURL := removeSchemaPrefix(brokerInfo.BrokerURL)
 
 	serviceDiscoverySpec := submariner.ServiceDiscoverySpec{

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -55,7 +55,8 @@ type SubmarinerOptions struct {
 }
 
 func Submariner(clientProducer client.Producer, options *SubmarinerOptions, brokerInfo *broker.Info, brokerSecret *v1.Secret,
-	netconfig globalnet.Config, imageOverrides map[string]string, status reporter.Interface) error {
+	netconfig globalnet.Config, imageOverrides map[string]string, status reporter.Interface,
+) error {
 	pskSecret, err := secret.Ensure(clientProducer.ForKubernetes(), constants.OperatorNamespace, brokerInfo.IPSecPSK)
 	if err != nil {
 		return status.Error(err, "Error creating PSK secret for cluster")
@@ -72,7 +73,8 @@ func Submariner(clientProducer client.Producer, options *SubmarinerOptions, brok
 }
 
 func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info, brokerSecret *v1.Secret, pskSecret *v1.Secret,
-	netconfig globalnet.Config, imageOverrides map[string]string) *submariner.SubmarinerSpec {
+	netconfig globalnet.Config, imageOverrides map[string]string,
+) *submariner.SubmarinerSpec {
 	brokerURL := removeSchemaPrefix(brokerInfo.BrokerURL)
 
 	// For backwards compatibility, the connection information is populated through the secret and individual components

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -461,7 +461,8 @@ func ValidateExistingGlobalNetworks(kubeClient kubernetes.Interface, namespace s
 }
 
 func AllocateAndUpdateGlobalCIDRConfigMap(brokerAdminClientset kubernetes.Interface, brokerNamespace string,
-	netconfig *Config, status reporter.Interface) error {
+	netconfig *Config, status reporter.Interface,
+) error {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		status.Start("Retrieving Globalnet information from the Broker")
 		defer status.End()

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -64,7 +64,8 @@ func (cn *ClusterNetwork) IsComplete() bool {
 }
 
 func Discover(dynClient dynamic.Interface, clientSet kubernetes.Interface, operatorClient operatorclientset.Interface,
-	operatorNamespace string) (*ClusterNetwork, error) {
+	operatorNamespace string,
+) (*ClusterNetwork, error) {
 	discovery, err := networkPluginsDiscovery(dynClient, clientSet)
 	if err != nil {
 		return nil, err

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -39,7 +39,8 @@ import (
 )
 
 func ClusterToBroker(brokerInfo *broker.Info, options *Options, clientProducer client.Producer,
-	status reporter.Interface) error {
+	status reporter.Interface,
+) error {
 	err := checkRequirements(clientProducer.ForKubernetes(), options.IgnoreRequirements, status)
 	if err != nil {
 		return err

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -154,7 +154,8 @@ func getPodOwnerRef(ctx context.Context, client crclient.Client, ns string) (*me
 
 // findFinalOwnerRef tries to locate the final controller/owner based on the owner reference provided.
 func findFinalOwnerRef(ctx context.Context, client crclient.Client, ns string,
-	ownerRef *metav1.OwnerReference) (*metav1.OwnerReference, bool, error) {
+	ownerRef *metav1.OwnerReference,
+) (*metav1.OwnerReference, bool, error) {
 	if ownerRef == nil {
 		return nil, false, nil
 	}

--- a/pkg/subctl/cmd/cloud/aws/aws.go
+++ b/pkg/subctl/cmd/cloud/aws/aws.go
@@ -63,7 +63,8 @@ func AddAWSFlags(command *cobra.Command) {
 // RunOnAWS runs the given function on AWS, supplying it with a cloud instance connected to AWS and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to AWS.
 func RunOnAWS(restConfigProducer restconfig.Producer, gwInstanceType string, status reporter.Interface,
-	function func(api.Cloud, api.GatewayDeployer, reporter.Interface) error) error {
+	function func(api.Cloud, api.GatewayDeployer, reporter.Interface) error,
+) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
 		exit.OnErrorWithMessage(err, "Failed to read AWS information from OCP metadata file")

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -80,7 +80,8 @@ func AddGCPFlags(command *cobra.Command) {
 // RunOnGCP runs the given function on GCP, supplying it with a cloud instance connected to GCP and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to GCP.
 func RunOnGCP(restConfigProducer restconfig.Producer, gwInstanceType string, dedicatedGWNodes bool, status reporter.Interface,
-	function func(api.Cloud, api.GatewayDeployer, reporter.Interface) error) error {
+	function func(api.Cloud, api.GatewayDeployer, reporter.Interface) error,
+) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
 		exit.OnErrorWithMessage(err, "Failed to read GCP Cluster information from OCP metadata file")

--- a/pkg/subctl/cmd/cloud/generic/generic.go
+++ b/pkg/subctl/cmd/cloud/generic/generic.go
@@ -28,7 +28,8 @@ import (
 )
 
 func RunOnK8sCluster(restConfigProducer restconfig.Producer, status reporter.Interface,
-	function func(api.GatewayDeployer, reporter.Interface) error) error {
+	function func(api.GatewayDeployer, reporter.Interface) error,
+) error {
 	k8sConfig, err := restConfigProducer.ForCluster()
 	if err != nil {
 		return status.Error(err, "error initializing Kubernetes config")

--- a/pkg/subctl/cmd/cloud/rhos/rhos.go
+++ b/pkg/subctl/cmd/cloud/rhos/rhos.go
@@ -68,7 +68,8 @@ func AddRHOSFlags(command *cobra.Command) {
 // RunOnRHOS runs the given function on RHOS, supplying it with a cloud instance connected to RHOS and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to RHOS.
 func RunOnRHOS(restConfigProducer restconfig.Producer, gwInstanceType string, dedicatedGWNodes bool, status reporter.Interface,
-	function func(api.Cloud, api.GatewayDeployer, reporter.Interface) error) error {
+	function func(api.Cloud, api.GatewayDeployer, reporter.Interface) error,
+) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
 		region = os.Getenv("OS_REGION_NAME")

--- a/pkg/subctl/cmd/diagnose/firewall.go
+++ b/pkg/subctl/cmd/diagnose/firewall.go
@@ -69,7 +69,8 @@ func spawnClientPodOnNonGatewayNode(client kubernetes.Interface, namespace, podC
 }
 
 func spawnPod(client kubernetes.Interface, scheduling pods.Scheduling, podName, namespace,
-	podCommand string) (*pods.Scheduled, error) {
+	podCommand string,
+) (*pods.Scheduled, error) {
 	pod, err := pods.Schedule(&pods.Config{
 		Name:       podName,
 		ClientSet:  client,

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -429,7 +429,8 @@ func populatePSKSecret(subctlData *datafile.SubctlData) *v1.Secret {
 }
 
 func populateSubmarinerSpec(subctlData *datafile.SubctlData, brokerSecret, pskSecret *v1.Secret,
-	netconfig globalnet.Config) *submariner.SubmarinerSpec {
+	netconfig globalnet.Config,
+) *submariner.SubmarinerSpec {
 	brokerURL := subctlData.BrokerURL
 	if idx := strings.Index(brokerURL, "://"); idx >= 0 {
 		// Submariner doesn't work with a schema prefix

--- a/pkg/subctl/operator/lighthouse/ensure.go
+++ b/pkg/subctl/operator/lighthouse/ensure.go
@@ -27,7 +27,8 @@ import (
 )
 
 func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClient dynamic.Interface,
-	operatorNamespace string) (bool, error) {
+	operatorNamespace string,
+) (bool, error) {
 	if created, err := serviceaccount.Ensure(kubeClient, operatorNamespace); err != nil {
 		return created, err // nolint:wrapcheck // No need to wrap here
 	} else if created {

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
This is required by golangci-lint 1.45.2; it all involves formatting
wrapped lists of parameters or return types.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
