### PR TITLE
Switch strings.Title to cases.Title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20210506034541-84642328b1f0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
+	golang.org/x/text v0.3.7
 	google.golang.org/api v0.77.0
 	k8s.io/api v0.23.5
 	k8s.io/apiextensions-apiserver v0.23.5

--- a/pkg/embeddedyamls/generators/yamls2go.go
+++ b/pkg/embeddedyamls/generators/yamls2go.go
@@ -25,6 +25,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var files = []string{
@@ -166,7 +169,7 @@ func panicOnErr(err error) {
 }
 
 func constName(filename string) string {
-	return strings.Title(strings.ReplaceAll(
+	return cases.Title(language.English).String(strings.ReplaceAll(
 		strings.ReplaceAll(
 			strings.ReplaceAll(filename,
 				"-", "_"),


### PR DESCRIPTION
The former is deprecated and flagged by golangci-lint 1.45.2 on
Go 1.18. See https://pkg.go.dev/strings#Title for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
