### PR TITLE
Automated backport of #1961: Add JUnit report generation to "subctl verify"

### DIFF
--- a/cmd/subctl/benchmark.go
+++ b/cmd/subctl/benchmark.go
@@ -123,8 +123,7 @@ func setUpTestFramework(args []string, restConfigProducer restconfig.Producer) e
 	framework.TestContext.OperationTimeout = operationTimeout
 	framework.TestContext.ConnectionTimeout = connectionTimeout
 	framework.TestContext.ConnectionAttempts = connectionAttempts
-	framework.TestContext.ReportDir = reportDirectory
-	framework.TestContext.ReportPrefix = "subctl"
+	framework.TestContext.JunitReport = junitReport
 	framework.TestContext.SubmarinerNamespace = constants.SubmarinerNamespace
 
 	config.DefaultReporterConfig.Verbose = verboseConnectivityVerification

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -46,7 +46,7 @@ var (
 	operationTimeout                uint
 	connectionTimeout               uint
 	connectionAttempts              uint
-	reportDirectory                 string
+	junitReport                     string
 	submarinerNamespace             string
 	verifyOnly                      string
 	disruptiveTests                 bool
@@ -126,7 +126,7 @@ func addVerifyFlags(cmd *cobra.Command) {
 	cmd.Flags().UintVar(&operationTimeout, "operation-timeout", 240, "operation timeout for K8s API calls")
 	cmd.Flags().UintVar(&connectionTimeout, "connection-timeout", 60, "timeout in seconds per connection attempt")
 	cmd.Flags().UintVar(&connectionAttempts, "connection-attempts", 2, "maximum number of connection attempts")
-	cmd.Flags().StringVar(&reportDirectory, "report-dir", ".", "XML report directory")
+	cmd.Flags().StringVar(&junitReport, "junit-report", "", "XML report path and report name")
 	cmd.Flags().StringVar(&submarinerNamespace, "submariner-namespace", "submariner-operator", "namespace in which submariner is deployed")
 	cmd.Flags().StringVar(&verifyOnly, "only", strings.Join(getAllVerifyKeys(), ","), "comma separated verifications to be performed")
 	cmd.Flags().BoolVar(&disruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/submariner-io/admiral v0.12.0
 	github.com/submariner-io/cloud-prepare v0.12.0
 	github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3
-	github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd
+	github.com/submariner-io/shipyard v0.12.1-0.20220502152100-2be122e1acee
 	github.com/submariner-io/submariner v0.12.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/uw-labs/lichen v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -1409,8 +1409,9 @@ github.com/submariner-io/cloud-prepare v0.12.0/go.mod h1:FPh8Ras/2G7teKW1sVlSK7W
 github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3 h1:CmEfFLlsqDyJBssJ7tPIRexKOownZrYdtv1aOR55HZA=
 github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3/go.mod h1:b+k87bSbqFOp+oAMclAdkRIpAdqa6WJjH9ic3pmhRrw=
 github.com/submariner-io/shipyard v0.12.0/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
-github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd h1:Ilgju1c00qDjrPy/Y5dSx0dsOd8Gqn1kgKrJtLhwGFM=
 github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
+github.com/submariner-io/shipyard v0.12.1-0.20220502152100-2be122e1acee h1:F0qAjuovhfFbOob334uogt+PM2FIRHAwZ5n4HzW50U0=
+github.com/submariner-io/shipyard v0.12.1-0.20220502152100-2be122e1acee/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/submariner-io/submariner v0.12.0 h1:1WZJjir9ZQ506+lQRpfD9v1gf2L5ykkYzBzaSC0uHIc=
 github.com/submariner-io/submariner v0.12.0/go.mod h1:XvzGtDXPl/2+/ToZShQm65eL3IhgkEgm6/hLkkXZ/Fw=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -52,7 +52,7 @@ var (
 	operationTimeout                uint
 	connectionTimeout               uint
 	connectionAttempts              uint
-	reportDirectory                 string
+	junitReport                     string
 	submarinerNamespace             string
 	verifyOnly                      string
 	disruptiveTests                 bool
@@ -73,7 +73,7 @@ func addVerifyFlags(cmd *cobra.Command) {
 	cmd.Flags().UintVar(&operationTimeout, "operation-timeout", 240, "operation timeout for K8s API calls")
 	cmd.Flags().UintVar(&connectionTimeout, "connection-timeout", 60, "timeout in seconds per connection attempt")
 	cmd.Flags().UintVar(&connectionAttempts, "connection-attempts", 2, "maximum number of connection attempts")
-	cmd.Flags().StringVar(&reportDirectory, "report-dir", ".", "XML report directory")
+	cmd.Flags().StringVar(&junitReport, "junit-report", "", "XML report path and report name")
 	cmd.Flags().StringVar(&submarinerNamespace, "submariner-namespace", "submariner-operator", "namespace in which submariner is deployed")
 }
 
@@ -198,8 +198,7 @@ func configureTestingFramework(args []string) error {
 	framework.TestContext.OperationTimeout = operationTimeout
 	framework.TestContext.ConnectionTimeout = connectionTimeout
 	framework.TestContext.ConnectionAttempts = connectionAttempts
-	framework.TestContext.ReportDir = reportDirectory
-	framework.TestContext.ReportPrefix = "subctl"
+	framework.TestContext.JunitReport = junitReport
 	framework.TestContext.SubmarinerNamespace = submarinerNamespace
 
 	config.DefaultReporterConfig.Verbose = verboseConnectivityVerification


### PR DESCRIPTION
Backport of #1961 on release-0.12.

#1961: Add JUnit report generation to "subctl verify"

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.