### PR TITLE
Point to submariner@feature-multi-active-gw for updated Endpoint CRD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,4 +71,5 @@ replace (
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.9.0
 )
 
-replace github.com/submariner-io/submariner => github.com/astoycos/submariner v0.12.0-m1.0.20220428190843-8a2fdf4866e3
+// Point to github.com/submariner-io/submariner@feature-multi-active-gw
+replace github.com/submariner-io/submariner => github.com/submariner-io/submariner v0.12.0-m3.0.20220502154739-568f97ce9ad2

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astoycos/submariner v0.12.0-m1.0.20220428190843-8a2fdf4866e3 h1:8dka8toETVRUkqqOpvu16mRnyH5mmYGboaLqZOJEp80=
-github.com/astoycos/submariner v0.12.0-m1.0.20220428190843-8a2fdf4866e3/go.mod h1:/HyiypjmcgECc2O6os+mqArC1h88ARRmv6a2lirU+vg=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -1371,6 +1369,8 @@ github.com/submariner-io/shipyard v0.12.0-m3/go.mod h1:el/lH6ed/1BN1FvEXlptiib7q
 github.com/submariner-io/shipyard v0.12.0-m3.0.20220421170648-adf7571e55ed/go.mod h1:JpJa1JxmdFqDUl7c/vJJE5HmRXxjZXeCgwa+d8uyVOs=
 github.com/submariner-io/shipyard v0.12.0-m3.0.20220428150939-1bcd83a05172 h1:ldl7OyCfs2fa4g/l8Ek1KSxiXG6uT+FqTqZ/F8LNL+M=
 github.com/submariner-io/shipyard v0.12.0-m3.0.20220428150939-1bcd83a05172/go.mod h1:JpJa1JxmdFqDUl7c/vJJE5HmRXxjZXeCgwa+d8uyVOs=
+github.com/submariner-io/submariner v0.12.0-m3.0.20220502154739-568f97ce9ad2 h1:Vf4z3M0a57QlioW6xOtGzTkBphfeJb7Rm8rO8NqJXGA=
+github.com/submariner-io/submariner v0.12.0-m3.0.20220502154739-568f97ce9ad2/go.mod h1:XbMQj5IYSYF+Hf4qL4W/TrdkHH48q79ZKdZ4oI5QpaE=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=


### PR DESCRIPTION
Override "Point to github.com/astycos/submariner for updated Endpoint CRD"

This overides the temporarily patch which pointed to astoycos version:
 github.com/astycos/submariner@AS-multi-active-gw-cgeip-controller
This now points to:
 github.com/submariner-io/submariner@feature-multi-active-gw

The Submariner Endpoint CRD was updated to include the AllocatedIPs from the
ClusterGlobalEgressIPs. The Endpoint CRD struct is define in the Submariner
repo, so need to point to a version that contains the change.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
