### PR TITLE
Bump Lighthouse to get latest E2E functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/submariner-io/admiral v0.12.0
 	github.com/submariner-io/cloud-prepare v0.12.0
-	github.com/submariner-io/lighthouse v0.12.0
-	github.com/submariner-io/shipyard v0.12.0
+	github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3
+	github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd
 	github.com/submariner-io/submariner v0.12.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/uw-labs/lichen v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -1406,10 +1406,11 @@ github.com/submariner-io/admiral v0.12.0 h1:o7w53UpkZPSwcIuG6hIT0aTDQC6HrLgcnZBi
 github.com/submariner-io/admiral v0.12.0/go.mod h1:AX0lc3FjWxM3KwSx0kU0b3f1xFxkm5k533pTehHl6QA=
 github.com/submariner-io/cloud-prepare v0.12.0 h1:tuWi77qa1CvY2p25EPDVfyWppQWrrKIlKwl8qRMugZc=
 github.com/submariner-io/cloud-prepare v0.12.0/go.mod h1:FPh8Ras/2G7teKW1sVlSK7WX1QYXodqbXuf/YV0yGAw=
-github.com/submariner-io/lighthouse v0.12.0 h1:ZvrKIO1z0EPQtlVy3oSHzxPDqVbjJe/j9cOT1WoYo9s=
-github.com/submariner-io/lighthouse v0.12.0/go.mod h1:ggT3u0O2IlEI5rkXjMvd+7r/lxZNqyBowadTj2CE+l0=
-github.com/submariner-io/shipyard v0.12.0 h1:vdOFYnSx/5WqMXfebhWWEzdaTdoBNBIvg/URRfGaYRY=
+github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3 h1:CmEfFLlsqDyJBssJ7tPIRexKOownZrYdtv1aOR55HZA=
+github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3/go.mod h1:b+k87bSbqFOp+oAMclAdkRIpAdqa6WJjH9ic3pmhRrw=
 github.com/submariner-io/shipyard v0.12.0/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
+github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd h1:Ilgju1c00qDjrPy/Y5dSx0dsOd8Gqn1kgKrJtLhwGFM=
+github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/submariner-io/submariner v0.12.0 h1:1WZJjir9ZQ506+lQRpfD9v1gf2L5ykkYzBzaSC0uHIc=
 github.com/submariner-io/submariner v0.12.0/go.mod h1:XvzGtDXPl/2+/ToZShQm65eL3IhgkEgm6/hLkkXZ/Fw=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=


### PR DESCRIPTION
Since https://github.com/submariner-io/lighthouse/pull/741 fixed the
tests to work without `nginx`, we need to bump operator to consume them
and build a new `subctl` that has `verify` working again.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
