### PR TITLE
Build packages, not files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ $(EMBEDDED_YAMLS): pkg/embeddedyamls/generators/yamls2go.go deploy/crds/submarin
 bin/submariner-operator: $(VENDOR_MODULES) main.go $(EMBEDDED_YAMLS)
 	${SCRIPTS_DIR}/compile.sh \
 	--ldflags "-X=github.com/submariner-io/submariner-operator/pkg/version.Version=$(VERSION)" \
-	$@ main.go $(BUILD_ARGS)
+	$@ . $(BUILD_ARGS)
 
 bin/subctl: bin/subctl-$(VERSION)-$(GOOS)-$(GOARCH)$(GOEXE)
 	ln -sf $(<F) $@
@@ -198,7 +198,7 @@ bin/subctl-%: $(EMBEDDED_YAMLS) $(shell find pkg/subctl/ -name "*.go") $(VENDOR_
 	$(SCRIPTS_DIR)/compile.sh \
 		--ldflags "-X 'github.com/submariner-io/submariner-operator/pkg/version.Version=$(VERSION)' \
 			   -X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}'" \
-		--noupx $@ ./pkg/subctl/main.go $(BUILD_ARGS)
+		--noupx $@ ./pkg/subctl $(BUILD_ARGS)
 
 cmd/bin/subctl-%: $(shell find cmd/ -name "*.go") $(VENDOR_MODULES)
 	mkdir -p cmd/bin
@@ -211,7 +211,7 @@ cmd/bin/subctl-%: $(shell find cmd/ -name "*.go") $(VENDOR_MODULES)
 	$(SCRIPTS_DIR)/compile.sh \
 		--ldflags "-X 'github.com/submariner-io/submariner-operator/pkg/version.Version=$(VERSION)' \
 		       -X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}'" \
-        --noupx $@ cmd/main.go $(BUILD_ARGS)
+        --noupx $@ ./cmd $(BUILD_ARGS)
 
 ci: $(EMBEDDED_YAMLS) golangci-lint markdownlint unit build images
 


### PR DESCRIPTION
This specifies packages to build rather than main.go files, which
ensures that we record the correct module information in Go 1.18+.

Fixes: #2046
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
