### PR TITLE
Update Lighthouse for nginx E2E on OpenShift fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/submariner-io/admiral v0.12.0
 	github.com/submariner-io/cloud-prepare v0.12.0
-	github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3
+	github.com/submariner-io/lighthouse v0.12.1-0.20220505160326-4dcbf81d546c
 	github.com/submariner-io/shipyard v0.12.1-0.20220502152100-2be122e1acee
 	github.com/submariner-io/submariner v0.12.0
 	github.com/ulikunitz/xz v0.5.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1406,8 +1406,8 @@ github.com/submariner-io/admiral v0.12.0 h1:o7w53UpkZPSwcIuG6hIT0aTDQC6HrLgcnZBi
 github.com/submariner-io/admiral v0.12.0/go.mod h1:AX0lc3FjWxM3KwSx0kU0b3f1xFxkm5k533pTehHl6QA=
 github.com/submariner-io/cloud-prepare v0.12.0 h1:tuWi77qa1CvY2p25EPDVfyWppQWrrKIlKwl8qRMugZc=
 github.com/submariner-io/cloud-prepare v0.12.0/go.mod h1:FPh8Ras/2G7teKW1sVlSK7WX1QYXodqbXuf/YV0yGAw=
-github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3 h1:CmEfFLlsqDyJBssJ7tPIRexKOownZrYdtv1aOR55HZA=
-github.com/submariner-io/lighthouse v0.12.1-0.20220428190125-bdaa08eb86e3/go.mod h1:b+k87bSbqFOp+oAMclAdkRIpAdqa6WJjH9ic3pmhRrw=
+github.com/submariner-io/lighthouse v0.12.1-0.20220505160326-4dcbf81d546c h1:+QyzIYaSgHWtmfWLwF1pu4KpntJxT8sMcfWmjWT1054=
+github.com/submariner-io/lighthouse v0.12.1-0.20220505160326-4dcbf81d546c/go.mod h1:b+k87bSbqFOp+oAMclAdkRIpAdqa6WJjH9ic3pmhRrw=
 github.com/submariner-io/shipyard v0.12.0/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/submariner-io/shipyard v0.12.1-0.20220502152100-2be122e1acee h1:F0qAjuovhfFbOob334uogt+PM2FIRHAwZ5n4HzW50U0=


### PR DESCRIPTION
Goal is to pull in 4dcbf81d546c2bf161225c3af9c10bcdcbe06cd7.

Automated results of:

go get github.com/submariner-io/lighthouse@release-0.12
go mod tidy

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
