### PR TITLE
Use == instead of Strings.Compare()

### DIFF
--- a/cmd/subctl/benchmark.go
+++ b/cmd/subctl/benchmark.go
@@ -20,7 +20,6 @@ package subctl
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/onsi/ginkgo/config"
 	"github.com/spf13/cobra"
@@ -93,7 +92,7 @@ func checkBenchmarkArguments(args []string, intraCluster bool) error {
 	}
 
 	if len(args) == 2 {
-		if strings.Compare(args[0], args[1]) == 0 {
+		if args[0] == args[1] {
 			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> cannot be the same file")
 		}
 

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -156,7 +156,7 @@ func checkValidateArguments(args []string) error {
 	}
 
 	if len(args) == 2 {
-		if strings.Compare(args[0], args[1]) == 0 {
+		if args[0] == args[1] {
 			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> cannot be the same file")
 		}
 

--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -20,7 +20,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
@@ -80,7 +79,7 @@ func checkBenchmarkArguments(args []string, intraCluster bool) error {
 	}
 
 	if len(args) == 2 {
-		if strings.Compare(args[0], args[1]) == 0 {
+		if args[0] == args[1] {
 			return fmt.Errorf("kubeconfig file <kubeConfig1> and <kubeConfig2> cannot be the same file")
 		}
 


### PR DESCRIPTION
Fixes new gocritic errors in golangci-lint 1.46.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
