### PR TITLE
Refactor parts of pkg/broker to eliminate references from controller code

### DIFF
--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/client"
 	"github.com/submariner-io/submariner-operator/pkg/deploy"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 )
 
 var (
@@ -71,9 +72,9 @@ func addDeployBrokerFlags() {
 	deployBroker.PersistentFlags().BoolVar(&deployflags.BrokerSpec.GlobalnetEnabled, "globalnet", false,
 		"enable support for Overlapping CIDRs in connecting clusters (default disabled)")
 	deployBroker.PersistentFlags().StringVar(&deployflags.BrokerSpec.GlobalnetCIDRRange, "globalnet-cidr-range",
-		broker.DefaultGlobalnetCIDR, "GlobalCIDR supernet range for allocating GlobalCIDRs to each cluster")
+		globalnet.DefaultGlobalnetCIDR, "GlobalCIDR supernet range for allocating GlobalCIDRs to each cluster")
 	deployBroker.PersistentFlags().UintVar(&deployflags.BrokerSpec.DefaultGlobalnetClusterSize, "globalnet-cluster-size",
-		broker.DefaultGlobalnetClusterSize, "default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
+		globalnet.DefaultGlobalnetClusterSize, "default cluster size for GlobalCIDR allocated to each cluster (amount of global IPs)")
 
 	deployBroker.PersistentFlags().StringVar(&ipsecSubmFile, "ipsec-psk-from", "",
 		"import IPsec PSK from existing submariner broker file, like broker-info.subm")

--- a/controllers/submariner/broker_controller.go
+++ b/controllers/submariner/broker_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
-	"github.com/submariner-io/submariner-operator/pkg/broker"
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
@@ -99,7 +98,7 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{}, err // nolint:wrapcheck // Errors are already wrapped
 	}
 
-	err = broker.CreateGlobalnetConfigMap(kubeClient, instance.Spec.GlobalnetEnabled, instance.Spec.GlobalnetCIDRRange,
+	err = globalnet.CreateConfigMap(kubeClient, instance.Spec.GlobalnetEnabled, instance.Spec.GlobalnetCIDRRange,
 		instance.Spec.DefaultGlobalnetClusterSize, request.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err // nolint:wrapcheck // Errors are already wrapped

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -34,12 +34,12 @@ import (
 	submopv1a1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/controllers/constants"
 	resourceiface "github.com/submariner-io/submariner-operator/controllers/resource"
-	"github.com/submariner-io/submariner-operator/pkg/broker"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
 	"github.com/submariner-io/submariner-operator/pkg/images"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -82,8 +82,7 @@ type Reconciler struct {
 	config Config
 	log    logr.Logger
 
-	// We need to synchronize changes to the SA used to connect to the broker ("cluster-" + clusterID, see pkg/broker/rbac.go
-	// and broker.ClusterSAName()), of two kinds:
+	// We need to synchronize changes to the SA used to connect to the broker (see names.ForClusterSA), of two kinds:
 	// - changes to the token in the secret used by the SA;
 	// - changes to the SA itself.
 	// The secrets are communicated to the pods which need them by mounting them. This ensures that changes to the secret
@@ -369,7 +368,7 @@ func (r *Reconciler) setupSecretSyncer(instance *submopv1a1.Submariner, logger l
 						secret := from.(*corev1.Secret)
 						logger.V(level.TRACE).Info("Transforming secret", "secret", secret)
 						if saName, ok := secret.ObjectMeta.Annotations["kubernetes.io/service-account.name"]; ok &&
-							saName == broker.ClusterSAName(instance.Spec.ClusterID) {
+							saName == names.ForClusterSA(instance.Spec.ClusterID) {
 							transformedSecret := &corev1.Secret{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: instance.Spec.BrokerK8sSecret,

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -30,6 +30,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	"github.com/submariner-io/submariner-operator/pkg/namespace"
 	"github.com/submariner-io/submariner-operator/pkg/role"
 	v1 "k8s.io/api/core/v1"
@@ -109,7 +110,7 @@ func createBrokerClusterRoleAndDefaultSA(kubeClient kubernetes.Interface, inName
 
 // CreateSAForCluster creates a new SA, and binds it to the submariner cluster role.
 func CreateSAForCluster(kubeClient kubernetes.Interface, clusterID, inNamespace string) (*v1.Secret, error) {
-	saName := ClusterSAName(clusterID)
+	saName := names.ForClusterSA(clusterID)
 
 	_, err := CreateNewBrokerSA(kubeClient, saName, inNamespace)
 	if err != nil && !apierrors.IsAlreadyExists(err) {

--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -29,13 +29,8 @@ import (
 const (
 	submarinerBrokerClusterRole      = "submariner-k8s-broker-cluster"
 	submarinerBrokerAdminRole        = "submariner-k8s-broker-admin"
-	submarinerBrokerClusterSAFmt     = "cluster-%s"
 	submarinerBrokerClusterDefaultSA = "submariner-k8s-broker-client" // for backwards compatibility with documentation
 )
-
-func ClusterSAName(clusterID string) string {
-	return fmt.Sprintf(submarinerBrokerClusterSAFmt, clusterID)
-}
 
 func NewBrokerSA(submarinerBrokerSA string) *v1.ServiceAccount {
 	sa := &v1.ServiceAccount{

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -68,7 +68,7 @@ func Broker(options *BrokerOptions, clientProducer client.Producer, status repor
 		}
 	}
 
-	if err = broker.CreateGlobalnetConfigMap(clientProducer.ForKubernetes(), options.BrokerSpec.GlobalnetEnabled,
+	if err = globalnet.CreateConfigMap(clientProducer.ForKubernetes(), options.BrokerSpec.GlobalnetEnabled,
 		options.BrokerSpec.GlobalnetCIDRRange, options.BrokerSpec.DefaultGlobalnetClusterSize, options.BrokerNamespace); err != nil {
 		return status.Error(err, "error creating globalCIDR configmap on Broker")
 	}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -18,6 +18,8 @@ limitations under the License.
 
 package names
 
+import "fmt"
+
 /* Component names and other constants. */
 const (
 	NetworkPluginSyncerComponent = "submariner-networkplugin-syncer"
@@ -54,4 +56,8 @@ var ValidImageNames = []string{
 
 func AppendUninstall(name string) string {
 	return name + "-uninstall"
+}
+
+func ForClusterSA(clusterID string) string {
+	return fmt.Sprintf("cluster-%s", clusterID)
 }

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -175,7 +175,7 @@ var deployBroker = &cobra.Command{
 			utils.ExitOnError("Error validating existing globalCIDR configmap", err)
 		}
 
-		err = broker.CreateGlobalnetConfigMap(clientProducer.ForKubernetes(), globalnetEnable, globalnetCIDRRange,
+		err = globalnet.CreateConfigMap(clientProducer.ForKubernetes(), globalnetEnable, globalnetCIDRRange,
 			defaultGlobalnetClusterSize, brokerNamespace)
 		utils.ExitOnError("Error creating globalCIDR configmap on Broker", err)
 


### PR DESCRIPTION
See individual commits for details. This will enable _pkg/broker_ to eventually be removed once the `subctl` code is removed.
 