### PR TITLE
Automated backport of #2054: Bump markdown-link-check to the current tip

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
+        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
+        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
         with:
           config-file: ".markdownlinkcheck.json"
 


### PR DESCRIPTION
Backport of #2054 on release-0.12.

#2054: Bump markdown-link-check to the current tip

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.