### PR TITLE
Automated backport of #2066: gather: Use libreswan as default if none specified

### DIFF
--- a/pkg/subctl/cmd/gather/cni.go
+++ b/pkg/subctl/cmd/gather/cni.go
@@ -172,7 +172,7 @@ func gatherOVNResources(info *Info, networkPlugin string) {
 
 func gatherCableDriverResources(info *Info, cableDriver string) {
 	logPodInfo(info, "cable driver data", gatewayPodLabel, func(info *Info, pod *v1.Pod) {
-		if cableDriver == libreswan {
+		if cableDriver == libreswan || cableDriver == "" { // If none specified, use libreswan as default
 			logLibreswanCmds(info, pod)
 		}
 	})


### PR DESCRIPTION
Backport of #2066 on release-0.12.

#2066: gather: Use libreswan as default if none specified

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.