### PR TITLE
Remove subctl docs, fixing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,6 @@ Please refer the Quickstart Guides on Submariner's website:
 * [Google Kubernetes Engine](https://submariner.io/getting-started/quickstart/managed-kubernetes/gke/).
 * [Rancher](https://submariner.io/getting-started/quickstart/managed-kubernetes/rancher/).
 
-## Subctl Releases
-
-### Latest Stable Release
-
-This release has the latest stable binaries: [latest release](https://github.com/submariner-io/submariner-operator/releases/latest).
-
-### Latest Merged Release
-
-This release is constantly updated with the latest code, and might be unstable: [devel
-release](https://github.com/submariner-io/submariner-operator/releases/tag/subctl-devel).
-
 ## Building and Testing
 
 See the [Building and Testing docs on Submariner's website](https://submariner.io/development/building-testing/).


### PR DESCRIPTION
The subctl tool has moved to its own repo. Remove docs about where it's
released, as one has moved and the other will move.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
