### PR TITLE
Make `getConfigMap` function public again.

### DIFF
--- a/pkg/discovery/globalnet/config_map.go
+++ b/pkg/discovery/globalnet/config_map.go
@@ -134,6 +134,6 @@ func updateConfigMap(k8sClientset kubernetes.Interface, namespace string, config
 }
 
 // nolint:wrapcheck // No need to wrap here
-func getConfigMap(kubeClient kubernetes.Interface, namespace string) (*v1.ConfigMap, error) {
+func GetConfigMap(kubeClient kubernetes.Interface, namespace string) (*v1.ConfigMap, error) {
 	return kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), globalCIDRConfigMapName, metav1.GetOptions{})
 }

--- a/pkg/discovery/globalnet/config_map.go
+++ b/pkg/discovery/globalnet/config_map.go
@@ -137,3 +137,8 @@ func updateConfigMap(k8sClientset kubernetes.Interface, namespace string, config
 func GetConfigMap(kubeClient kubernetes.Interface, namespace string) (*v1.ConfigMap, error) {
 	return kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), globalCIDRConfigMapName, metav1.GetOptions{})
 }
+
+// nolint:wrapcheck // No need to wrap here
+func DeleteConfigMap(kubeClient kubernetes.Interface, namespace string) error {
+	return kubeClient.CoreV1().ConfigMaps(namespace).Delete(context.TODO(), globalCIDRConfigMapName, metav1.DeleteOptions{})
+}

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -325,7 +325,7 @@ func ValidateGlobalnetConfiguration(globalnetInfo *Info, netconfig Config, statu
 }
 
 func GetGlobalNetworks(kubeClient kubernetes.Interface, brokerNamespace string) (*Info, *v1.ConfigMap, error) {
-	configMap, err := getConfigMap(kubeClient, brokerNamespace)
+	configMap, err := GetConfigMap(kubeClient, brokerNamespace)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error retrieving globalnet ConfigMap")
 	}


### PR DESCRIPTION
The function (GetGlobalnetConfigMap -> getConfigMap) was made
private in
https://github.com/submariner-io/submariner-operator/pull/2074/commits/83530c28a3a82c883b8c20e8e4c4e294729742aa#diff-6248f1e67444360455faa328c4ae105a2502bd60cd1db127b5398a7d2af23d7cR137.
This PR makes it publoc because it is used in submariner-addon.
https://github.com/stolostron/submariner-addon/blob/main/pkg/hub/submarineragent/controller.go#L720

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
