### PR TITLE
Update pause image location used for uninstall

### DIFF
--- a/controllers/uninstall/uninstall.go
+++ b/controllers/uninstall/uninstall.go
@@ -318,8 +318,10 @@ func convertPodSpecContainersToUninstall(podSpec *corev1.PodSpec) {
 
 	podSpec.Containers = []corev1.Container{
 		{
-			Name:  "pause",
-			Image: "gcr.io/google_containers/pause",
+			Name: "pause",
+			// Note: K8s 1.25 is moving to a new image location, registry.k8s.io.
+			// See https://github.com/kubernetes/kubernetes/pull/109938.
+			Image: "k8s.gcr.io/pause",
 		},
 	}
 }


### PR DESCRIPTION
...to _k8s.gcr.io_ which is used by [K8s core](https://github.com/kubernetes/kubernetes/blob/c285e781331a3785a7f436042c65c5641ce8a9e9/cmd/kubelet/app/options/container_runtime.go#L30) so shouldn't cause an issue in an air-gapped deployment..

Fixes https://github.com/submariner-io/submariner-operator/issues/2001