### PR TITLE
[Backport] Support nat-discovery port validation in subctl diagnose

### DIFF
--- a/pkg/subctl/cmd/diagnose/firewall.go
+++ b/pkg/subctl/cmd/diagnose/firewall.go
@@ -20,15 +20,29 @@ package diagnose
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/cli"
 	"github.com/submariner-io/submariner-operator/internal/pods"
+	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type TargetPort int
+
+const (
+	TunnelPort TargetPort = iota
+	NatDiscoveryPort
 )
 
 var diagnoseFirewallConfigCmd = &cobra.Command{
@@ -65,6 +79,11 @@ func spawnSnifferPodOnNode(client kubernetes.Interface, nodeName, namespace, pod
 
 func spawnClientPodOnNonGatewayNode(client kubernetes.Interface, namespace, podCommand string) (*pods.Scheduled, error) {
 	scheduling := pods.Scheduling{ScheduleOn: pods.NonGatewayNode, Networking: pods.PodNetworking}
+	return spawnPod(client, scheduling, "validate-client", namespace, podCommand)
+}
+
+func spawnClientPodOnNonGWNodeWithHostNwk(client kubernetes.Interface, namespace, podCommand string) (*pods.Scheduled, error) {
+	scheduling := pods.Scheduling{ScheduleOn: pods.NonGatewayNode, Networking: pods.HostNetworking}
 	return spawnPod(client, scheduling, "validate-client", namespace, podCommand)
 }
 
@@ -160,4 +179,190 @@ func getAnyRemoteEndpointResource(cluster *cmd.Cluster, status *cli.Status) *sub
 	status.EndWithFailure("Could not find any remote Endpoint in cluster %q", cluster.Name)
 
 	return nil
+}
+
+func checkKubeconfigArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("two kubeconfigs must be specified")
+	}
+
+	same, err := cmd.CompareFiles(args[0], args[1])
+	if err != nil {
+		return errors.Wrap(err, "error comparing the kubeconfig files")
+	}
+
+	if same {
+		return fmt.Errorf("the specified kubeconfig files are the same")
+	}
+
+	return nil
+}
+
+func validateConnectivity(localCluster, remoteCluster *cmd.Cluster, targetPort TargetPort, status *cli.Status) bool {
+	localEndpoint := getLocalEndpointResource(localCluster, status)
+	if localEndpoint == nil {
+		return false
+	}
+
+	gwNodeName := getActiveGatewayNodeName(localCluster, localEndpoint.Spec.Hostname, status)
+	if gwNodeName == "" {
+		return false
+	}
+
+	destPort, err := getTargetPort(localCluster.Submariner, localEndpoint, targetPort)
+	if err != nil {
+		status.EndWithFailure(fmt.Sprintf("Could not determine the target port: %v", err))
+		return false
+	}
+
+	clientMessage := string(uuid.NewUUID())[0:8]
+	podCommand := fmt.Sprintf("timeout %d tcpdump -ln -Q in -A -s 100 -i any udp and dst port %d | grep '%s'",
+		validationTimeout, destPort, clientMessage)
+
+	sPod, err := spawnSnifferPodOnNode(localCluster.KubeClient, gwNodeName, podNamespace, podCommand)
+	if err != nil {
+		status.EndWithFailure("Error spawning the sniffer pod on the Gateway node: %v", err)
+		return false
+	}
+
+	defer sPod.Delete()
+
+	gatewayPodIP := getGatewayIP(remoteCluster, localCluster.Name, status)
+	if gatewayPodIP == "" {
+		status.EndWithFailure("Error retrieving the gateway IP of cluster %q", localCluster.Name)
+		return false
+	}
+
+	podCommand = fmt.Sprintf("for x in $(seq 1000); do echo %s; done | for i in $(seq 5);"+
+		" do timeout 2 nc -n -p %s -u %s %d; done", clientMessage, clientSourcePort, gatewayPodIP, destPort)
+
+	// Spawn the pod on the nonGateway node. If we spawn the pod on Gateway node, the tunnel process can
+	// sometimes drop the udp traffic from client pod until the tunnels are properly setup.
+	cPod, err := spawnClientPodOnNonGWNodeWithHostNwk(remoteCluster.KubeClient, podNamespace, podCommand)
+	if err != nil {
+		status.EndWithFailure("Error spawning the client pod on non-Gateway node of cluster %q: %v",
+			remoteCluster.Name, err)
+		return false
+	}
+
+	defer cPod.Delete()
+
+	if err = cPod.AwaitCompletion(); err != nil {
+		status.EndWithFailure("Error waiting for the client pod to finish its execution: %v", err)
+		return false
+	}
+
+	if err = sPod.AwaitCompletion(); err != nil {
+		status.EndWithFailure("Error waiting for the sniffer pod to finish its execution: %v", err)
+		return false
+	}
+
+	if verboseOutput {
+		status.QueueSuccessMessage("tcpdump output from sniffer pod on Gateway node")
+		status.QueueSuccessMessage(sPod.PodOutput)
+	}
+
+	if !strings.Contains(sPod.PodOutput, clientMessage) {
+		status.EndWithFailure("The tcpdump output from the sniffer pod does not include the message"+
+			" sent from client pod. Please check that your firewall configuration allows UDP/%d traffic"+
+			" on the %q node.", destPort, localEndpoint.Spec.Hostname)
+
+		return false
+	}
+
+	return true
+}
+
+func getTargetPort(submariner *v1alpha1.Submariner, endpoint *subv1.Endpoint, tgtport TargetPort) (int32, error) {
+	var targetPort int32
+	var err error
+
+	switch endpoint.Spec.Backend {
+	case "libreswan", "wireguard", "vxlan":
+		if tgtport == TunnelPort {
+			targetPort, err = endpoint.Spec.GetBackendPort(subv1.UDPPortConfig, int32(submariner.Spec.CeIPSecNATTPort))
+			if err != nil {
+				return 0, fmt.Errorf("error reading tunnel port: %w", err)
+			}
+		} else if tgtport == NatDiscoveryPort {
+			targetPort, err = endpoint.Spec.GetBackendPort(subv1.NATTDiscoveryPortConfig, 4490)
+			if err != nil {
+				return 0, fmt.Errorf("error reading nat-discovery port: %w", err)
+			}
+		}
+
+		return targetPort, nil
+	default:
+		return 0, fmt.Errorf("could not determine the target port for cable driver %q", endpoint.Spec.Backend)
+	}
+}
+
+func getGatewayIP(cluster *cmd.Cluster, localClusterID string, status *cli.Status) string {
+	gateways, err := cluster.GetGateways()
+	if err != nil {
+		status.EndWithFailure("Error retrieving gateways from cluster %q: %v", cluster.Name, err)
+		return ""
+	}
+
+	if len(gateways) == 0 {
+		status.EndWithFailure("There are no gateways detected on cluster %q", cluster.Name)
+		return ""
+	}
+
+	for i := range gateways {
+		gw := &gateways[i]
+		if gw.Status.HAStatus != subv1.HAStatusActive {
+			continue
+		}
+
+		for j := range gw.Status.Connections {
+			conn := &gw.Status.Connections[j]
+			if conn.Endpoint.ClusterID == localClusterID {
+				if conn.UsingIP != "" {
+					return conn.UsingIP
+				}
+
+				if conn.Endpoint.NATEnabled {
+					return conn.Endpoint.PublicIP
+				}
+
+				return conn.Endpoint.PrivateIP
+			}
+		}
+	}
+
+	status.EndWithFailure("The gateway on cluster %q does not have an active connection to cluster %q",
+		cluster.Name, localClusterID)
+
+	return ""
+}
+
+func newCluster(cfg *rest.Config) *cmd.Cluster {
+	cluster, errMsg := cmd.NewCluster(cfg, "")
+	if cluster == nil {
+		utils.ExitWithErrorMsg(errMsg)
+	}
+
+	if cluster.Submariner == nil {
+		utils.ExitWithErrorMsg(cmd.SubmMissingMessage)
+	}
+
+	cluster.Name = cluster.Submariner.Spec.ClusterID
+
+	return cluster
+}
+
+func getClusterDetails(args []string) (*cmd.Cluster, *cmd.Cluster) {
+	localProducer := restconfig.NewProducerFrom(args[0], "")
+	localCfg, err := localProducer.ForCluster()
+	utils.ExitOnError("The provided local kubeconfig is invalid", err)
+
+	remoteProducer := restconfig.NewProducerFrom(args[1], "")
+	remoteCfg, err := remoteProducer.ForCluster()
+	utils.ExitOnError("The provided remote kubeconfig is invalid", err)
+
+	localCluster := newCluster(localCfg)
+	remoteCluster := newCluster(remoteCfg)
+
+	return localCluster, remoteCluster
 }

--- a/pkg/subctl/cmd/diagnose/firewall_natdiscovery.go
+++ b/pkg/subctl/cmd/diagnose/firewall_natdiscovery.go
@@ -26,17 +26,13 @@ import (
 	"github.com/submariner-io/submariner-operator/internal/cli"
 )
 
-const (
-	clientSourcePort = "9898"
-)
-
 func init() {
 	command := &cobra.Command{
-		Use:   "inter-cluster <localkubeconfig> <remotekubeconfig>",
-		Short: "Check firewall access to setup tunnels between the Gateway node",
-		Long:  "This command checks if the firewall configuration allows tunnels to be configured on the Gateway nodes.",
+		Use:   "nat-discovery <localkubeconfig> <remotekubeconfig>",
+		Short: "Check firewall access for nat-discovery to function properly",
+		Long:  "This command checks if the firewall configuration allows nat-discovery between the configured Gateway nodes.",
 		Args:  checkKubeconfigArgs,
-		Run:   validateTunnelConfig,
+		Run:   validateNatDiscoveryPort,
 	}
 
 	addDiagnoseFWConfigFlags(command)
@@ -44,21 +40,21 @@ func init() {
 	diagnoseFirewallConfigCmd.AddCommand(command)
 }
 
-func validateTunnelConfig(command *cobra.Command, args []string) {
+func validateNatDiscoveryPort(command *cobra.Command, args []string) {
 	localCluster, remoteCluster := getClusterDetails(args)
 
 	status := cli.NewStatus()
-	status.Start(fmt.Sprintf("Checking if tunnel port is opened on the gateway node of cluster %q", localCluster.Name))
+	status.Start(fmt.Sprintf("Checking if nat-discovery port is opened on the gateway node of cluster %q", localCluster.Name))
 
 	if isClusterSingleNode(remoteCluster, status) {
 		// Skip the check if it's a single node cluster
 		return
 	}
 
-	if !validateConnectivity(localCluster, remoteCluster, TunnelPort, status) {
-		status.EndWithFailure("Could not determine if tunnel port is allowed in the cluster %q", localCluster.Name)
+	if !validateConnectivity(localCluster, remoteCluster, NatDiscoveryPort, status) {
+		status.EndWithFailure("Could not determine if nat-discovery port is allowed in the cluster %q", localCluster.Name)
 		os.Exit(1)
 	}
 
-	status.EndWithSuccess("Tunnel port is allowed in the cluster %q", localCluster.Name)
+	status.EndWithSuccess("nat-discovery port is allowed in the cluster %q", localCluster.Name)
 }


### PR DESCRIPTION
Currently subctl diagnose ... command validates if metrics port
and tunnel port are allowed on the gateway port. Similar validation
should be done for Nat-discovery port as well. This PR handles that
and users can now use "subctl diagnose firewall nat-discovery ..."
for validating the nat-discovery port.

Since the subctl codebase is moved to its own repo, we cannot do
a clean cherry-pick. Hence, this PR re-implements the functionality
as per the existing code-base.

Related to: https://github.com/submariner-io/subctl/pull/81
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
