### PR TITLE
[Backport] Open metrics port for globalnet by default

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -54,8 +54,14 @@ func prepareAws(cmd *cobra.Command, args []string) {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: vxlanPort, Protocol: "udp"},
-			{Port: metricsPort, Protocol: "tcp"},
 		},
+	}
+
+	for i := range metricsPort {
+		port := api.PortSpec{
+			Port: metricsPort[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// For load-balanced gateways we want these ports open internally to facilitate private-ip to pivate-ip gateways communications.

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -56,8 +56,14 @@ func prepareGCP(cmd *cobra.Command, args []string) {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: vxlanPort, Protocol: "udp"},
-			{Port: metricsPort, Protocol: "tcp"},
 		},
+	}
+
+	for i := range metricsPort {
+		port := api.PortSpec{
+			Port: metricsPort[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.

--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -57,8 +57,14 @@ func prepareRHOS(cmd *cobra.Command, args []string) {
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: vxlanPort, Protocol: "udp"},
-			{Port: metricsPort, Protocol: "tcp"},
 		},
+	}
+
+	for i := range metricsPort {
+		port := api.PortSpec{
+			Port: metricsPort[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.

--- a/pkg/subctl/cmd/uint16slice.go
+++ b/pkg/subctl/cmd/uint16slice.go
@@ -1,0 +1,56 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type Uint16Slice struct {
+	Value *[]uint16
+}
+
+func (s *Uint16Slice) Type() string {
+	return "Uint16Slice"
+}
+
+func (s *Uint16Slice) String() string {
+	return fmt.Sprintf("%v", *s.Value)
+}
+
+func (s *Uint16Slice) Set(value string) error {
+	values := strings.Split(value, ",")
+
+	*s.Value = make([]uint16, len(values))
+
+	for i, d := range values {
+		u, err := strconv.ParseUint(d, 10, 16)
+		if err != nil {
+			return errors.Wrap(err, "conversion to uint16 failed")
+		}
+
+		(*s.Value)[i] = uint16(u)
+	}
+
+	return nil
+}


### PR DESCRIPTION
1. allow metrics-port flag for cloud prepare cmd to accept
multiple values.
2. make globalnet metrics port to be default as well

Related to submariner-io/subctl#74

Signed-off-by: Maayan Friedman <maafried@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
