### PR TITLE
[Backport] Change default namespace for diagnose

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/submariner-operator/internal/constants"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -72,7 +73,7 @@ func ScheduleAndAwaitCompletion(config *Config) (string, error) {
 	}
 
 	if config.Namespace == "" {
-		config.Namespace = "default"
+		config.Namespace = constants.OperatorNamespace
 	}
 
 	np := &Scheduled{Config: config}
@@ -95,7 +96,7 @@ func Schedule(config *Config) (*Scheduled, error) {
 	}
 
 	if config.Namespace == "" {
-		config.Namespace = "default"
+		config.Namespace = constants.OperatorNamespace
 	}
 
 	np := &Scheduled{Config: config}

--- a/pkg/subctl/cmd/diagnose/diagnose.go
+++ b/pkg/subctl/cmd/diagnose/diagnose.go
@@ -20,6 +20,7 @@ package diagnose
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
 )
@@ -47,6 +48,6 @@ func addVerboseFlag(command *cobra.Command) {
 }
 
 func addNamespaceFlag(command *cobra.Command) {
-	command.Flags().StringVar(&podNamespace, "namespace", "default",
+	command.Flags().StringVar(&podNamespace, "namespace", constants.OperatorNamespace,
 		"namespace in which validation pods should be deployed")
 }

--- a/pkg/subctl/cmd/diagnose/firewall.go
+++ b/pkg/subctl/cmd/diagnose/firewall.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/cli"
+	"github.com/submariner-io/submariner-operator/internal/constants"
 	"github.com/submariner-io/submariner-operator/internal/pods"
 	"github.com/submariner-io/submariner-operator/internal/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd"
@@ -121,7 +122,7 @@ func getActiveGatewayNodeName(cluster *cmd.Cluster, hostname string, status *cli
 		// On some platforms, the nodeName does not match with the hostname.
 		// Submariner Endpoint stores the hostname info in the endpoint and not the nodeName. So, we spawn a
 		// tiny pod to read the hostname and return the corresponding node.
-		sPod, err := spawnSnifferPodOnNode(cluster.KubeClient, node.Name, "default", "hostname")
+		sPod, err := spawnSnifferPodOnNode(cluster.KubeClient, node.Name, constants.OperatorNamespace, "hostname")
 		if err != nil {
 			status.EndWithFailure("Error spawning the sniffer pod on the node %q: %v", node.Name, err)
 			return ""


### PR DESCRIPTION
diagnose subcommands, kube-proxy-mode and firewall, spawn pods in
"default" ns if it is not provided by the user. For k8s 1.23 and above,
ns without PodSecurity labels throws warnings for the user. It is not
correct to manipulate a ns without the user's consent. Hence change the
"default" ns to "submariner-operator" which is already created with
these labels.

Backport of https://github.com/submariner-io/subctl/pull/126

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
