### PR TITLE
Backport: Label operator namespace as privileged, add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.3.0
-	github.com/submariner-io/admiral v0.12.1
+	github.com/submariner-io/admiral v0.12.2-0.20220628083409-00ac56522dfb
 	github.com/submariner-io/cloud-prepare v0.12.1
 	github.com/submariner-io/lighthouse v0.12.1
 	github.com/submariner-io/shipyard v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -1404,6 +1404,10 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.12.1 h1:sd+hFxoNgn93jZSylI1rWu76zxx6sKZlGnMNb/j1b7E=
 github.com/submariner-io/admiral v0.12.1/go.mod h1:ZUIuVyI4cJ+iBYTtUxh9knfl785cFUUA3ofcPCGJ/Z0=
+github.com/submariner-io/admiral v0.12.2-0.20220523072532-998de8f36076 h1:FFISBxJpOK6XBEu5Azee5YzN+IK+VY3MRzbbH51MNeA=
+github.com/submariner-io/admiral v0.12.2-0.20220523072532-998de8f36076/go.mod h1:ZUIuVyI4cJ+iBYTtUxh9knfl785cFUUA3ofcPCGJ/Z0=
+github.com/submariner-io/admiral v0.12.2-0.20220628083409-00ac56522dfb h1:ABv5gcVrcFLBcZB9em2859AzFn4SPgvc1XQB5fbS+xc=
+github.com/submariner-io/admiral v0.12.2-0.20220628083409-00ac56522dfb/go.mod h1:ZUIuVyI4cJ+iBYTtUxh9knfl785cFUUA3ofcPCGJ/Z0=
 github.com/submariner-io/cloud-prepare v0.12.1 h1:1gEldvs8yRlaWd0cGtxDkkc+XK85H8f4DUQZ63vdngY=
 github.com/submariner-io/cloud-prepare v0.12.1/go.mod h1:AohgpAgS97sAunDYut550zyn600sLAWbgDVuXMFJYgg=
 github.com/submariner-io/lighthouse v0.12.1 h1:aPGde1TZ26RxjUyy4doc5iZmrHRv4yS4bPvJ37fri2Q=

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -64,8 +64,10 @@ func Ensure(crdUpdater crd.Updater, kubeClient kubernetes.Interface, componentAr
 		}
 	}
 
+	brokerNamespaceLabels := map[string]string{}
+
 	// Create the namespace
-	_, err := namespace.Ensure(kubeClient, brokerNS)
+	_, err := namespace.Ensure(kubeClient, brokerNS, brokerNamespaceLabels)
 	if err != nil {
 		return err // nolint:wrapcheck // No need to wrap here
 	}

--- a/pkg/subctl/operator/submarinerop/ensure.go
+++ b/pkg/subctl/operator/submarinerop/ensure.go
@@ -38,7 +38,12 @@ func Ensure(status reporter.Interface, clientProducer client.Producer, operatorN
 		status.Success("Created operator CRDs")
 	}
 
-	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace); err != nil {
+	operatorNamespaceLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/audit": "privileged",
+		"pod-security.kubernetes.io/warn": "privileged",
+	}
+
+	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace, operatorNamespaceLabels); err != nil {
 		return err
 	} else if created {
 		status.Success("Created operator namespace: %s", operatorNamespace)

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -45,6 +45,11 @@ function verify_subm_operator() {
   # Verify SubM namespace (ignore SubM Broker ns)
   kubectl get ns $subm_ns
 
+  # Verify SubM operator namespace has required pod security labels
+  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/enforce\":\"privileged\"'
+  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/audit\":\"privileged\"'
+  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/warn\":\"privileged\"'
+
   # Verify SubM Operator CRD
   kubectl get crds submariners.submariner.io
   kubectl api-resources | grep submariners


### PR DESCRIPTION
This is backport of 311e7aa2e7e7bba142b35dec21816168952602b1, which was
first implemented on the devel branch of the new subctl repo.

This is required for OpenShift 4.11.

Also add the privileged label during upgrades.

It would be better if these were Go unit tests, but we don't have those
for subctl yet.

Relates-to: https://github.com/submariner-io/subctl/issues/27
Depends on https://github.com/submariner-io/admiral/pull/377

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
