### PR TITLE
Add a GHA to test subctl

### DIFF
--- a/.github/workflows/subctl-unit.yml
+++ b/.github/workflows/subctl-unit.yml
@@ -1,0 +1,37 @@
+---
+name: Consuming Projects
+
+on:
+  pull_request:
+
+jobs:
+  unit-testing:
+    name: Check subctl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the submariner-operator repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          path: submariner-operator
+
+      - name: Check out the subctl repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          repository: submariner-io/subctl
+          path: subctl
+
+      - name: Check out the shipyard repository
+        # This is required so that we can run a build involving multiple
+        # repositories (using LOCAL_BUILD=1)
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          repository: submariner-io/shipyard
+          path: shipyard
+
+      - name: Update the subctl build to use the current submariner-operator
+        run: |
+          cd subctl
+          go mod edit -replace=github.com/submariner-io/submariner-operator=../submariner-operator
+
+      - name: Run Go subctl unit tests
+        run: make -C subctl LOCAL_BUILD=1 unit


### PR DESCRIPTION
This ensures we know whether changes made to the operator are going to
break subctl, before merging them.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
