### PR TITLE
Run the upgrade job on devel only

### DIFF
--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -4,6 +4,7 @@ name: Upgrade
 on:
   pull_request:
     types: [ready_for_review, opened, reopened, synchronize, converted_to_draft, labeled]
+    branches: [devel]
 
 jobs:
   upgrade-e2e:


### PR DESCRIPTION
Our upgrade test is mostly interesting for upgrades to the current
development version. On release branches, it works as long as we don't
have a release later from a later release branch; after that, it
becomes a downgrade test since we don't have a way of installing the
latest release from a given release branch.

This disables the upgrade job on all non-devel branches.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
