### PR TITLE
fix in diagnose cluster permissions: add getting deployments and namespaces

### DIFF
--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -18,6 +18,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - namespaces
     verbs:
       - get
       - list
@@ -25,6 +26,7 @@ rules:
       - apps
     resources:
       - daemonsets
+      - deployments
     verbs:
       - get
       - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2729,6 +2729,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - namespaces
     verbs:
       - get
       - list
@@ -2736,6 +2737,7 @@ rules:
       - apps
     resources:
       - daemonsets
+      - deployments
     verbs:
       - get
       - list


### PR DESCRIPTION
fixing: https://github.com/submariner-io/subctl/issues/129