### PR TITLE
diagnose clusterrole: remove pods sections:

### DIFF
--- a/config/rbac/submariner-diagnose/cluster_role.yaml
+++ b/config/rbac/submariner-diagnose/cluster_role.yaml
@@ -14,11 +14,3 @@ rules:
     verbs:
       - get
       - list
-  - apiGroups:  # pods are created to run firewall diagnostics
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - get
-      - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2779,14 +2779,6 @@ rules:
     verbs:
       - get
       - list
-  - apiGroups:  # pods are created to run firewall diagnostics
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - get
-      - list
 `
 	Config_rbac_submariner_diagnose_cluster_role_binding_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
all pods operations are being done in submariner-operator namespace
and thus these permessions are no longer required on the cluster role
scope

Signed-off-by: Tomer Shefler <sheflertomer@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
