### PR TITLE
Check the running operator version in e2e

### DIFF
--- a/scripts/test/e2e.sh
+++ b/scripts/test/e2e.sh
@@ -17,6 +17,18 @@ ${SCRIPTS_DIR}/e2e.sh "$@"
 # Reload KUBECONFIG in case deploy was triggered
 . "${SCRIPTS_DIR}/lib/kubecfg"
 
+# Check that we're testing the version we expect
+function check_operator_version() {
+    local opv
+    opv=$(kubectl --context="$cluster" logs -n submariner-operator -l name=submariner-operator --tail=-1 | awk '/Submariner operator version/ { print $NF }')
+    printf "Cluster %s is running operator version %s\n" "$cluster" "$opv"
+    if [ "$opv" != "$VERSION" ]; then
+        printf "Operator version mismatch: expected %s, got %s\n" "$VERSION" "$opv"
+        exit 1
+    fi
+}
+run_consecutive "$*" check_operator_version
+
 command -v subctl || curl -Ls https://get.submariner.io | VERSION=devel bash
 
 load_settings


### PR DESCRIPTION
Once the clusters have been deployed, check that we're actually
running the version of the operator we expect to test.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
