### PR TITLE
Remove `names.ImagePrefix/ImagePostfix`

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -24,13 +24,10 @@ import (
 	"strings"
 
 	apis "github.com/submariner-io/submariner-operator/api/v1alpha1"
-	"github.com/submariner-io/submariner-operator/pkg/names"
 	v1 "k8s.io/api/core/v1"
 )
 
 func GetImagePath(repo, version, image, component string, imageOverrides map[string]string) string {
-	var path string
-
 	if override, ok := imageOverrides[component]; ok {
 		return override
 	}
@@ -39,13 +36,13 @@ func GetImagePath(repo, version, image, component string, imageOverrides map[str
 		return relatedImage
 	}
 
+	path := image
+
 	// If the repository is "local" we don't append it on the front of the image,
 	// a local repository is used for development, testing and CI when we inject
 	// images in the cluster, for example submariner-gateway:local, or submariner-route-agent:local
-	if repo == "local" {
-		path = image
-	} else {
-		path = fmt.Sprintf("%s/%s%s%s", repo, names.ImagePrefix, image, names.ImagePostfix)
+	if repo != "local" {
+		path = fmt.Sprintf("%s/%s", repo, image)
 	}
 
 	path = fmt.Sprintf("%s:%s", path, version)

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -44,12 +44,6 @@ var (
 	OperatorImage            = "submariner-operator"
 )
 
-/* Deprecated: These values are used by downstream distributions to patch the image names by adding a prefix/suffix. */
-var (
-	ImagePrefix  = ""
-	ImagePostfix = ""
-)
-
 var ValidImageNames = []string{
 	NetworkPluginSyncerImage, RouteAgentImage, GatewayImage, GlobalnetImage,
 	ServiceDiscoveryImage, LighthouseCoreDNSImage, OperatorImage,


### PR DESCRIPTION
These have been deprecated for a long while now, removing them adds to
the maintainability of our code.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
