### PR TITLE
Automated backport of #2192: Set DNSPolicy to ClusterFirstWithHostNet

### DIFF
--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -215,9 +215,9 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 			},
 			ServiceAccountName:            names.GatewayComponent,
 			HostNetwork:                   true,
+			DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
 			TerminationGracePeriodSeconds: pointer.Int64(1),
 			RestartPolicy:                 corev1.RestartPolicyAlways,
-			DNSPolicy:                     corev1.DNSClusterFirst,
 			// The gateway engine must be able to run on any flagged node, regardless of existing taints
 			Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 			Volumes:     volumes,

--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -103,6 +103,7 @@ func newGlobalnetDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonS
 					TerminationGracePeriodSeconds: pointer.Int64(2),
 					NodeSelector:                  map[string]string{"submariner.io/gateway": "true"},
 					HostNetwork:                   true,
+					DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
 					// The Globalnet Pod must be able to run on any flagged node, regardless of existing taints
 					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -120,6 +120,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 					},
 					ServiceAccountName: names.RouteAgentComponent,
 					HostNetwork:        true,
+					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 					// The route agent engine on all nodes, regardless of existing taints
 					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},


### PR DESCRIPTION
Backport of #2192 on release-0.13.

#2192: Set DNSPolicy to ClusterFirstWithHostNet

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.