### PR TITLE
Remove unnecessary CodeQL SARIF upload

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -51,8 +51,3 @@ jobs:
       - name: Show CodeQL scan SARIF report
         if: always()
         run: cat ../results/go.sarif
-      - name: Upload CodeQL scan SARIF report
-        if: always()
-        uses: github/codeql-action/upload-sarif@7fee4ca032ac341c12486c4c06822c5221c76533
-        with:
-          sarif_file: ../results/go.sarif


### PR DESCRIPTION
It seems the github/codeql-action/analyze GHA takes care of uploading
the SARIF so we don't need to do it ourselves.

Trying to do so fails with:

  Error: Aborting upload: only one run of the codeql/analyze or
  codeql/upload-sarif actions is allowed per job per tool/category.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
