### PR TITLE
Restore gateway pod privileges

### DIFF
--- a/config/rbac/submariner-gateway/role.yaml
+++ b/config/rbac/submariner-gateway/role.yaml
@@ -8,6 +8,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
       - services
       - services/finalizers
       - endpoints

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2232,6 +2232,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
       - services
       - services/finalizers
       - endpoints


### PR DESCRIPTION
The gateway is failing trying to update labels on its own pod:

```
main.go:416] Error updating pod label: Error patching own pod "submariner-gateway-jqc9v"...forbidden: User "system:serviceaccount:submariner-operator:submariner-gateway" cannot patch resource "pods"
```

PR https://github.com/submariner-io/submariner-operator/pull/2008 removed the "pods" privilege for the gateway role but it turns out it's needed.