### PR TITLE
Remove KubeClient in service discovery controller

### DIFF
--- a/controllers/servicediscovery/cleanup.go
+++ b/controllers/servicediscovery/cleanup.go
@@ -110,7 +110,7 @@ func (r *Reconciler) removeLighthouseConfigFromCustomDNSConfigMap(ctx context.Co
 
 	log.Info("Removing lighthouse config from custom DNS ConfigMap", "Name", configMap.Name, "Namespace", configMap.Namespace)
 
-	err := util.Update(ctx, resource.ForConfigMap(r.KubeClient, configMap.Namespace), configMap,
+	err := util.Update(ctx, resource.ForControllerClient(r.GeneralClient, configMap.Namespace, configMap), configMap,
 		func(existing runtime.Object) (runtime.Object, error) {
 			delete(existing.(*corev1.ConfigMap).Data, "lighthouse.server")
 			return existing, nil

--- a/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -94,8 +94,7 @@ func testReconciliation() {
 	When("the coredns ConfigMap exists", func() {
 		Context("and the lighthouse config isn't present", func() {
 			BeforeEach(func() {
-				t.InitClientObjs = append(t.InitClientObjs, newDNSService(clusterIP))
-				t.createConfigMap(newCoreDNSConfigMap(coreDNSCorefileData("")))
+				t.InitClientObjs = append(t.InitClientObjs, newDNSService(clusterIP), newCoreDNSConfigMap(coreDNSCorefileData("")))
 			})
 
 			It("should add it", func() {
@@ -109,8 +108,7 @@ func testReconciliation() {
 			updatedClusterIP := "10.10.10.11"
 
 			BeforeEach(func() {
-				t.InitClientObjs = append(t.InitClientObjs, newDNSService(updatedClusterIP))
-				t.createConfigMap(newCoreDNSConfigMap(coreDNSCorefileData(clusterIP)))
+				t.InitClientObjs = append(t.InitClientObjs, newDNSService(updatedClusterIP), newCoreDNSConfigMap(coreDNSCorefileData(clusterIP)))
 			})
 
 			It("should update the lighthouse config", func() {
@@ -122,7 +120,7 @@ func testReconciliation() {
 
 		Context("and the lighthouse DNS service doesn't exist", func() {
 			BeforeEach(func() {
-				t.createConfigMap(newCoreDNSConfigMap(coreDNSCorefileData("")))
+				t.InitClientObjs = append(t.InitClientObjs, newCoreDNSConfigMap(coreDNSCorefileData("")))
 			})
 
 			It("should create the service and add the lighthouse config", func() {
@@ -147,7 +145,7 @@ func testReconciliation() {
 
 		Context("and the custom coredns ConfigMap already exists", func() {
 			BeforeEach(func() {
-				t.createConfigMap(&corev1.ConfigMap{
+				t.InitClientObjs = append(t.InitClientObjs, newDNSService(clusterIP), &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
 						Namespace: t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace,
@@ -156,8 +154,6 @@ func testReconciliation() {
 						"lighthouse.server": strings.ReplaceAll(coreDNSConfigFormat, "$IP", "1.2.3.4"),
 					},
 				})
-
-				t.InitClientObjs = append(t.InitClientObjs, newDNSService(clusterIP))
 			})
 
 			It("should update it", func() {
@@ -223,7 +219,7 @@ func testCoreDNSCleanup() {
 
 	When("the coredns ConfigMap exists", func() {
 		BeforeEach(func() {
-			t.createConfigMap(newCoreDNSConfigMap(coreDNSCorefileData(clusterIP)))
+			t.InitClientObjs = append(t.InitClientObjs, newCoreDNSConfigMap(coreDNSCorefileData(clusterIP)))
 		})
 
 		It("should remove the lighthouse config section", func() {
@@ -255,7 +251,7 @@ func testCoreDNSCleanup() {
 
 		Context("and the custom coredns ConfigMap exists", func() {
 			BeforeEach(func() {
-				t.createConfigMap(&corev1.ConfigMap{
+				t.InitClientObjs = append(t.InitClientObjs, &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
 						Namespace: t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.58.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.58.0
 	github.com/prometheus/client_golang v1.13.0
-	github.com/submariner-io/admiral v0.14.0-m0
+	github.com/submariner-io/admiral v0.14.0-m0.0.20220826191654-859c17d6b3c9
 	github.com/submariner-io/shipyard v0.14.0-m0
 	github.com/submariner-io/submariner v0.13.0-m2.0.20220608112640-7f4a6a79da0d
 	github.com/uw-labs/lichen v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -832,8 +832,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/submariner-io/admiral v0.14.0-m0 h1:dnpYY1eFTYAtoTFtKR0qAKy3HNS1Y1tcWI/TNo6QYV4=
-github.com/submariner-io/admiral v0.14.0-m0/go.mod h1:RABKMTZXXkqsOVq1M3QzVM7iCGMY2ZDbRzbTaQWAczE=
+github.com/submariner-io/admiral v0.14.0-m0.0.20220826191654-859c17d6b3c9 h1:F5oa5ikzCQVH68HrHPoXozz66gc+lVwSplH3H8Ed21Q=
+github.com/submariner-io/admiral v0.14.0-m0.0.20220826191654-859c17d6b3c9/go.mod h1:RABKMTZXXkqsOVq1M3QzVM7iCGMY2ZDbRzbTaQWAczE=
 github.com/submariner-io/shipyard v0.14.0-m0 h1:223Y6aOJmNUXDE4IWvamUHF4AOAa/nvjNwQaxprL4AQ=
 github.com/submariner-io/shipyard v0.14.0-m0/go.mod h1:e4Unlk/40Jmzj/aaPWeGcNNv37y0DfpmnanoJbPogLY=
 github.com/submariner-io/submariner v0.13.0-m2.0.20220608112640-7f4a6a79da0d h1:BhA0h3q2yur40r64VZe/g3AQ8PuhDMnPPYi4hh+H2/k=

--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -193,10 +192,10 @@ func main() {
 	}
 
 	if err = (&servicediscovery.Reconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		RestConfig: mgr.GetConfig(),
-		KubeClient: kubernetes.NewForConfigOrDie(mgr.GetConfig()),
+		Client:        mgr.GetClient(),
+		GeneralClient: generalClient,
+		Scheme:        mgr.GetScheme(),
+		RestConfig:    mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "ServiceDiscovery")
 		os.Exit(1)


### PR DESCRIPTION
It's used to access ConfigMaps but we can use the controller Client instead.