### PR TITLE
Rename SD Reconciler Client field to ScopedClient

### DIFF
--- a/controllers/servicediscovery/cleanup.go
+++ b/controllers/servicediscovery/cleanup.go
@@ -79,7 +79,7 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 	}
 
 	uninstallInfo := &uninstall.Info{
-		Client:     r.Client,
+		Client:     r.ScopedClient,
 		Components: components,
 		StartTime:  instance.DeletionTimestamp.Time,
 		Log:        log,
@@ -99,7 +99,7 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 
 // nolint:wrapcheck // No need to wrap
 func (r *Reconciler) removeFinalizer(ctx context.Context, instance *operatorv1alpha1.ServiceDiscovery) error {
-	return finalizer.Remove(ctx, ctrlresource.ForControllerClient(r.Client, instance.Namespace, instance),
+	return finalizer.Remove(ctx, ctrlresource.ForControllerClient(r.ScopedClient, instance.Namespace, instance),
 		instance, constants.CleanupFinalizer)
 }
 

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -73,7 +73,9 @@ const (
 
 // Reconciler reconciles a ServiceDiscovery object.
 type Reconciler struct {
-	Client controllerClient.Client
+	// This client is scoped to the operator namespace intended to only be used for resources created and maintained by this
+	// controller. Also it's a split client that reads objects from the cache and writes to the apiserver.
+	ScopedClient controllerClient.Client
 	// This client can be used to access any other resource not in the operator namespace.
 	GeneralClient controllerClient.Client
 	Scheme        *runtime.Scheme
@@ -106,7 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			controllerClient.InNamespace(request.NamespacedName.Namespace),
 			controllerClient.MatchingLabels{"app": names.ServiceDiscoveryComponent},
 		}
-		err := r.Client.DeleteAllOf(ctx, deployment, opts...)
+		err := r.ScopedClient.DeleteAllOf(ctx, deployment, opts...)
 
 		return reconcile.Result{}, errors.Wrap(err, "error deleting resource")
 	}
@@ -132,7 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	lighthouseDNSConfigMap := newLighthouseDNSConfigMap(instance)
 	if _, err = helpers.ReconcileConfigMap(instance, lighthouseDNSConfigMap, reqLogger,
-		r.Client, r.Scheme); err != nil {
+		r.ScopedClient, r.Scheme); err != nil {
 		log.Error(err, "Error creating the lighthouseCoreDNS configMap")
 		return reconcile.Result{}, errors.Wrap(err, "error reconciling ConfigMap")
 	}
@@ -168,7 +170,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *Reconciler) getServiceDiscovery(ctx context.Context, key types.NamespacedName) (*submarinerv1alpha1.ServiceDiscovery, error) {
 	instance := &submarinerv1alpha1.ServiceDiscovery{}
 
-	err := r.Client.Get(ctx, key, instance)
+	err := r.ScopedClient.Get(ctx, key, instance)
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving ServiceDiscovery resource")
 	}
@@ -179,7 +181,7 @@ func (r *Reconciler) getServiceDiscovery(ctx context.Context, key types.Namespac
 func (r *Reconciler) addFinalizer(ctx context.Context,
 	instance *submarinerv1alpha1.ServiceDiscovery,
 ) (*submarinerv1alpha1.ServiceDiscovery, error) {
-	added, err := finalizer.Add(ctx, resource.ForControllerClient(r.Client, instance.Namespace,
+	added, err := finalizer.Add(ctx, resource.ForControllerClient(r.ScopedClient, instance.Namespace,
 		&submarinerv1alpha1.ServiceDiscovery{}), instance, constants.CleanupFinalizer)
 	if err != nil {
 		return nil, err // nolint:wrapcheck // No need to wrap
@@ -426,7 +428,7 @@ func (r *Reconciler) updateDNSCustomConfigMap(ctx context.Context, cr *submarine
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.GeneralClient, configMap, func() error {
 		lighthouseDNSService := &corev1.Service{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: cr.Namespace},
+		err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: cr.Namespace},
 			lighthouseDNSService)
 		lighthouseClusterIP := lighthouseDNSService.Spec.ClusterIP
 		if err != nil || lighthouseClusterIP == "" {
@@ -462,7 +464,7 @@ func (r *Reconciler) configureDNSConfigMap(ctx context.Context, cr *submarinerv1
 ) error {
 	lighthouseDNSService := &corev1.Service{}
 
-	err := r.Client.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: cr.Namespace},
+	err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: cr.Namespace},
 		lighthouseDNSService)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving lighthouse DNS Service")
@@ -543,7 +545,7 @@ func findCoreDNSListeningPort(coreFile string) string {
 func (r *Reconciler) configureOpenshiftClusterDNSOperator(ctx context.Context, instance *submarinerv1alpha1.ServiceDiscovery) error {
 	lighthouseDNSService := &corev1.Service{}
 
-	err := r.Client.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: instance.Namespace},
+	err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: instance.Namespace},
 		lighthouseDNSService)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving lighthouse DNS Service")
@@ -562,7 +564,7 @@ func (r *Reconciler) updateLighthouseConfigInOpenshiftDNSOperator(ctx context.Co
 	// nolint:wrapcheck // No need to wrap errors here
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		dnsOperator := &operatorv1.DNS{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: defaultOpenShiftDNSController}, dnsOperator); err != nil {
+		if err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: defaultOpenShiftDNSController}, dnsOperator); err != nil {
 			// microshift uses the coredns image, but the DNS operator and CRDs are off
 			if meta.IsNoMatchError(err) {
 				err = r.configureDNSConfigMap(ctx, instance, microshiftDNSNamespace, microshiftDNSConfigMap)
@@ -585,7 +587,7 @@ func (r *Reconciler) updateLighthouseConfigInOpenshiftDNSOperator(ctx context.Co
 			Labels: dnsOperator.Labels,
 		}}
 
-		result, err := controllerutil.CreateOrUpdate(ctx, r.Client, toUpdate, func() error {
+		result, err := controllerutil.CreateOrUpdate(ctx, r.ScopedClient, toUpdate, func() error {
 			toUpdate.Spec = dnsOperator.Spec
 			for k, v := range dnsOperator.Labels {
 				toUpdate.Labels[k] = v
@@ -686,11 +688,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *Reconciler) ensureLightHouseAgent(instance *submarinerv1alpha1.ServiceDiscovery, reqLogger logr.Logger) error {
 	lightHouseAgent := newLighthouseAgent(instance, names.ServiceDiscoveryComponent)
 	if _, err := helpers.ReconcileDeployment(instance, lightHouseAgent, reqLogger,
-		r.Client, r.Scheme); err != nil {
+		r.ScopedClient, r.Scheme); err != nil {
 		return errors.Wrap(err, "error reconciling agent deployment")
 	}
 
-	err := metrics.Setup(instance.Namespace, instance, lightHouseAgent.GetLabels(), 8082, r.Client,
+	err := metrics.Setup(instance.Namespace, instance, lightHouseAgent.GetLabels(), 8082, r.ScopedClient,
 		r.RestConfig, r.Scheme, reqLogger)
 	if err != nil {
 		return errors.Wrap(err, "error setting up metrics")
@@ -702,12 +704,12 @@ func (r *Reconciler) ensureLightHouseAgent(instance *submarinerv1alpha1.ServiceD
 func (r *Reconciler) ensureLighthouseCoreDNSDeployment(instance *submarinerv1alpha1.ServiceDiscovery, reqLogger logr.Logger) error {
 	lighthouseCoreDNSDeployment := newLighthouseCoreDNSDeployment(instance)
 	if _, err := helpers.ReconcileDeployment(instance, lighthouseCoreDNSDeployment, reqLogger,
-		r.Client, r.Scheme); err != nil {
+		r.ScopedClient, r.Scheme); err != nil {
 		log.Error(err, "Error creating the lighthouseCoreDNS deployment")
 		return errors.Wrap(err, "error reconciling coredns deployment")
 	}
 
-	err := metrics.Setup(instance.Namespace, instance, lighthouseCoreDNSDeployment.GetLabels(), 9153, r.Client, r.RestConfig,
+	err := metrics.Setup(instance.Namespace, instance, lighthouseCoreDNSDeployment.GetLabels(), 9153, r.ScopedClient, r.RestConfig,
 		r.Scheme, reqLogger)
 	if err != nil {
 		return errors.Wrap(err, "error setting up coredns metrics")
@@ -721,12 +723,12 @@ func (r *Reconciler) ensureLighthouseCoreDNSService(ctx context.Context, instanc
 ) error {
 	lighthouseCoreDNSService := &corev1.Service{}
 
-	err := r.Client.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: instance.Namespace},
+	err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: instance.Namespace},
 		lighthouseCoreDNSService)
 	if apierrors.IsNotFound(err) {
 		lighthouseCoreDNSService = newLighthouseCoreDNSService(instance)
 		if _, err = helpers.ReconcileService(instance, lighthouseCoreDNSService, reqLogger,
-			r.Client, r.Scheme); err != nil {
+			r.ScopedClient, r.Scheme); err != nil {
 			log.Error(err, "Error creating the lighthouseCoreDNS service")
 
 			return errors.Wrap(err, "error reconciling coredns Service")

--- a/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -95,7 +95,7 @@ func newTestDriver() *testDriver {
 		t.JustBeforeEach()
 
 		t.Controller = &servicediscovery.Reconciler{
-			Client:        t.Client,
+			ScopedClient:  t.Client,
 			GeneralClient: t.Client,
 			Scheme:        scheme.Scheme,
 		}

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func main() {
 	}
 
 	if err = (&servicediscovery.Reconciler{
-		Client:        mgr.GetClient(),
+		ScopedClient:  mgr.GetClient(),
 		GeneralClient: generalClient,
 		Scheme:        mgr.GetScheme(),
 		RestConfig:    mgr.GetConfig(),


### PR DESCRIPTION
Same as was done for the `Submariner` controller for extra clarity.
