### PR TITLE
Fix system tests after latest Shipyard changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ dockertogoarch = $(patsubst arm/v7,arm,$(1))
 
 PLATFORMS ?= linux/amd64,linux/arm64
 IMAGES = submariner-operator submariner-operator-index
-PRELOAD_IMAGES := submariner-operator submariner-gateway submariner-globalnet submariner-route-agent lighthouse-agent lighthouse-coredns
+PRELOAD_IMAGES := submariner-operator
 MULTIARCH_IMAGES := submariner-operator
 
 ifneq (,$(filter ovn,$(USING)))


### PR DESCRIPTION
Shipyard now overrides only specific images, adjust the tests and the
general behavior to only preload the operator image, and only look for
it to be actually deployed from source.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
