### PR TITLE
Restore route agent node update privilege

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -54,5 +54,6 @@ rules:
       - get
       - list
       - watch
+      - update
     resources:
       - nodes

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2520,6 +2520,7 @@ rules:
       - get
       - list
       - watch
+      - update
     resources:
       - nodes
 `


### PR DESCRIPTION
The route agent needs to update the `submariner.io/cniIfaceIp` annotation on nodes for globalnet. This caused E2E failures, eg https://github.com/submariner-io/lighthouse/runs/8154953193?check_suite_focus=true.

The privilege was recently removed by https://github.com/submariner-io/submariner-operator/pull/2008.
