### PR TITLE
Network discovery APIs for Kindnet CNI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/submariner-io/admiral v0.14.0-m1
 	github.com/submariner-io/shipyard v0.14.0-m1
-	github.com/submariner-io/submariner v0.13.0-m2.0.20220608112640-7f4a6a79da0d
+	github.com/submariner-io/submariner v0.14.0-m1.0.20220926102553-d3362895ea5e
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/text v0.3.8-0.20220509174342-b4bca84b0361
 	k8s.io/api v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -759,8 +759,8 @@ github.com/submariner-io/admiral v0.14.0-m1 h1:4Nt9f+JWobDKR4J3Mm5jDe2+BvgEKAD71
 github.com/submariner-io/admiral v0.14.0-m1/go.mod h1:Cu0d7XJTg5YiwTXc5zeUxwnP3xdazB43OGMMfn9rAsQ=
 github.com/submariner-io/shipyard v0.14.0-m1 h1:w8onUPOIxcmjWtUZJ8+BlQOCA8Sz/w4KUwcKfGlordE=
 github.com/submariner-io/shipyard v0.14.0-m1/go.mod h1:W3Oufy60RlxZ6vEQK1obw/jM35a9kNZVj4ls5Pyi+K0=
-github.com/submariner-io/submariner v0.13.0-m2.0.20220608112640-7f4a6a79da0d h1:BhA0h3q2yur40r64VZe/g3AQ8PuhDMnPPYi4hh+H2/k=
-github.com/submariner-io/submariner v0.13.0-m2.0.20220608112640-7f4a6a79da0d/go.mod h1:xZYyT7oVFObCXQoChh0bmQlCd5tIalBOXbh1gnYLUh8=
+github.com/submariner-io/submariner v0.14.0-m1.0.20220926102553-d3362895ea5e h1:RV1BZ6T46fhZ2m8z5ztTRBoOJK7i18+RGQDcL+Dh4wY=
+github.com/submariner-io/submariner v0.14.0-m1.0.20220926102553-d3362895ea5e/go.mod h1:UKpHJMg4cQmEgHTlYLFtY6/KXvve9xkr46LKcZQswWA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/discovery/network/kindnet.go
+++ b/pkg/discovery/network/kindnet.go
@@ -1,0 +1,52 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"github.com/submariner-io/submariner/pkg/cni"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func discoverKindNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
+	kindNetPod, err := FindPod(client, "app=kindnet")
+
+	if err != nil || kindNetPod == nil {
+		return nil, err
+	}
+
+	clusterNetwork := &ClusterNetwork{
+		NetworkPlugin: cni.KindNet,
+	}
+
+	for i := range kindNetPod.Spec.Containers {
+		for _, envVar := range kindNetPod.Spec.Containers[i].Env {
+			if envVar.Name == "POD_SUBNET" {
+				clusterNetwork.PodCIDRs = []string{envVar.Value}
+				break
+			}
+		}
+	}
+
+	clusterIPRange, err := findClusterIPRange(client)
+	if err == nil && clusterIPRange != "" {
+		clusterNetwork.ServiceCIDRs = []string{clusterIPRange}
+	}
+
+	return clusterNetwork, nil
+}

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -110,6 +110,11 @@ func networkPluginsDiscovery(client controllerClient.Client) (*ClusterNetwork, e
 		return osClusterNet, err
 	}
 
+	kindNet, err := discoverKindNetwork(client)
+	if err != nil || kindNet != nil {
+		return kindNet, err
+	}
+
 	weaveClusterNet, err := discoverWeaveNetwork(client)
 	if err != nil || weaveClusterNet != nil {
 		return weaveClusterNet, err

--- a/pkg/discovery/network/network_suite_test.go
+++ b/pkg/discovery/network/network_suite_test.go
@@ -45,7 +45,7 @@ func fakePodWithNamespace(namespace, name, component string, command []string, e
 		ObjectMeta: v1meta.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    map[string]string{"component": component, "name": component},
+			Labels:    map[string]string{"component": component, "name": component, "app": component},
 		},
 
 		Spec: v1.PodSpec{


### PR DESCRIPTION
This PR includes support for discovering kindnet CNI and configures Submariner deployment accordingly.

Depends on: https://github.com/submariner-io/submariner/pull/2036
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
