### PR TITLE
Extract plugin discovery function registration

### DIFF
--- a/pkg/discovery/network/calico.go
+++ b/pkg/discovery/network/calico.go
@@ -28,6 +28,10 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func init() {
+	registerNetworkPluginDiscoveryFunction(discoverCalicoNetwork)
+}
+
 // nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCalicoNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	cmList := &corev1.ConfigMapList{}

--- a/pkg/discovery/network/canal.go
+++ b/pkg/discovery/network/canal.go
@@ -30,6 +30,10 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func init() {
+	registerNetworkPluginDiscoveryFunction(discoverCanalFlannelNetwork)
+}
+
 // nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCanalFlannelNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	// TODO: this must be smarter, looking for the canal daemonset, with labels k8s-app=canal

--- a/pkg/discovery/network/kindnet.go
+++ b/pkg/discovery/network/kindnet.go
@@ -23,6 +23,10 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func init() {
+	registerNetworkPluginDiscoveryFunction(discoverKindNetwork)
+}
+
 func discoverKindNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	kindNetPod, err := FindPod(client, "app=kindnet")
 

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -32,6 +32,10 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func init() {
+	registerNetworkPluginDiscoveryFunction(discoverOpenShift4Network)
+}
+
 // nolint:nilnil // Intentional as the purpose is to discover.
 func discoverOpenShift4Network(client controllerClient.Client) (*ClusterNetwork, error) {
 	network := &unstructured.Unstructured{}

--- a/pkg/discovery/network/openshift4_test.go
+++ b/pkg/discovery/network/openshift4_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner/pkg/cni"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -61,7 +61,7 @@ func testOS4DiscoveryWith(json []byte) (*network.ClusterNetwork, error) {
 	err := obj.UnmarshalJSON(json)
 	Expect(err).NotTo(HaveOccurred())
 
-	return network.Discover(fake.NewClientBuilder().WithScheme(runtime.NewScheme()).WithObjects(obj).Build(), "")
+	return network.Discover(fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(obj).Build(), "")
 }
 
 func getNetworkJSON() []byte {

--- a/pkg/discovery/network/ovnkubernetes.go
+++ b/pkg/discovery/network/ovnkubernetes.go
@@ -37,6 +37,10 @@ const (
 	OvnSBDBDefaultPort = 6642
 )
 
+func init() {
+	registerNetworkPluginDiscoveryFunction(discoverOvnKubernetesNetwork)
+}
+
 func discoverOvnKubernetesNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	ovnDBPod, err := FindPod(client, "name=ovnkube-db")
 

--- a/pkg/discovery/network/weavenet.go
+++ b/pkg/discovery/network/weavenet.go
@@ -23,6 +23,10 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func init() {
+	registerNetworkPluginDiscoveryFunction(discoverWeaveNetwork)
+}
+
 func discoverWeaveNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	weaveNetPod, err := FindPod(client, "name=weave-net")
 


### PR DESCRIPTION
This means that the general network discovery code doesn't need to have a list of functions to call.

Depends on #2255
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
