### PR TITLE
Additional role privileges for submariner-diagnose

### DIFF
--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -19,6 +19,7 @@ rules:
     resources:
       - configmaps
       - namespaces
+      - services
     verbs:
       - get
       - list
@@ -31,9 +32,23 @@ rules:
       - get
       - list
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - submariner.io
     resources:
       - '*'
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - multicluster.x-k8s.io
+    resources:
+      - "*"
     verbs:
       - get
       - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2843,6 +2843,7 @@ rules:
     resources:
       - configmaps
       - namespaces
+      - services
     verbs:
       - get
       - list
@@ -2855,9 +2856,23 @@ rules:
       - get
       - list
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - submariner.io
     resources:
       - '*'
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - multicluster.x-k8s.io
+    resources:
+      - "*"
     verbs:
       - get
       - list


### PR DESCRIPTION
`subctl diagnose` retrieves `Services` for `globalnet` checks and and `EndpointSlices` and `ServiceImports` for service discovery so add get/list privileges for these resources in the `submariner-diagnose` role.
