### PR TITLE
AIR_GAPPED support in operator

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -59,6 +59,7 @@ type SubmarinerSpec struct {
 	CeIPSecForceUDPEncaps    bool                 `json:"ceIPSecForceUDPEncaps,omitempty"`
 	Debug                    bool                 `json:"debug"`
 	NatEnabled               bool                 `json:"natEnabled"`
+	AirGappedDeployment      bool                 `json:"airGappedDeployment,omitempty"`
 	LoadBalancerEnabled      bool                 `json:"loadBalancerEnabled,omitempty"`
 	ServiceDiscoveryEnabled  bool                 `json:"serviceDiscoveryEnabled,omitempty"`
 	BrokerK8sInsecure        bool                 `json:"brokerK8sInsecure,omitempty"`
@@ -76,6 +77,7 @@ type SubmarinerStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	NatEnabled                bool                    `json:"natEnabled"`
+	AirGappedDeployment       bool                    `json:"airGappedDeployment"`
 	ColorCodes                string                  `json:"colorCodes,omitempty"`
 	ClusterID                 string                  `json:"clusterID"`
 	ServiceCIDR               string                  `json:"serviceCIDR,omitempty"`

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -35,6 +35,8 @@ spec:
           spec:
             description: SubmarinerSpec defines the desired state of Submariner.
             properties:
+              airGappedDeployment:
+                type: boolean
               broker:
                 type: string
               brokerK8sApiServer:
@@ -134,6 +136,8 @@ spec:
           status:
             description: SubmarinerStatus defines the observed state of Submariner.
             properties:
+              airGappedDeployment:
+                type: boolean
               clusterCIDR:
                 type: string
               clusterID:
@@ -848,6 +852,7 @@ spec:
               serviceCIDR:
                 type: string
             required:
+            - airGappedDeployment
             - clusterID
             - natEnabled
             type: object

--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -186,6 +186,7 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 						{Name: "SUBMARINER_COLORCODES", Value: cr.Spec.ColorCodes},
 						{Name: "SUBMARINER_DEBUG", Value: strconv.FormatBool(cr.Spec.Debug)},
 						{Name: "SUBMARINER_NATENABLED", Value: strconv.FormatBool(cr.Spec.NatEnabled)},
+						{Name: "AIR_GAPPED_DEPLOYMENT", Value: strconv.FormatBool(cr.Spec.AirGappedDeployment)},
 						{Name: "SUBMARINER_BROKER", Value: cr.Spec.Broker},
 						{Name: "SUBMARINER_CABLEDRIVER", Value: cr.Spec.CableDriver},
 						{Name: broker.EnvironmentVariable("ApiServer"), Value: cr.Spec.BrokerK8sApiServer},

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -207,6 +207,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	gatewayStatuses := buildGatewayStatusAndUpdateMetrics(gateways)
 
 	instance.Status.NatEnabled = instance.Spec.NatEnabled
+	instance.Status.AirGappedDeployment = instance.Spec.AirGappedDeployment
 	instance.Status.ColorCodes = instance.Spec.ColorCodes
 	instance.Status.ClusterID = instance.Spec.ClusterID
 	instance.Status.GlobalCIDR = instance.Spec.GlobalCIDR

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -118,6 +118,8 @@ spec:
           spec:
             description: SubmarinerSpec defines the desired state of Submariner.
             properties:
+              airGappedDeployment:
+                type: boolean
               broker:
                 type: string
               brokerK8sApiServer:
@@ -217,6 +219,8 @@ spec:
           status:
             description: SubmarinerStatus defines the observed state of Submariner.
             properties:
+              airGappedDeployment:
+                type: boolean
               clusterCIDR:
                 type: string
               clusterID:
@@ -931,6 +935,7 @@ spec:
               serviceCIDR:
                 type: string
             required:
+            - airGappedDeployment
             - clusterID
             - natEnabled
             type: object


### PR DESCRIPTION
This PR includes a new flag which can be used to specify
if the deployment is done on an AIR_GAPPED environment.
The flag will be used by Submariner Gateway pod to decide
whether to use public-ip discovery or not.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
