### PR TITLE
Status AirGappedDeployment field should not be required

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -77,7 +77,7 @@ type SubmarinerStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	NatEnabled                bool                    `json:"natEnabled"`
-	AirGappedDeployment       bool                    `json:"airGappedDeployment"`
+	AirGappedDeployment       bool                    `json:"airGappedDeployment,omitempty"`
 	ColorCodes                string                  `json:"colorCodes,omitempty"`
 	ClusterID                 string                  `json:"clusterID"`
 	ServiceCIDR               string                  `json:"serviceCIDR,omitempty"`

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -852,7 +852,6 @@ spec:
               serviceCIDR:
                 type: string
             required:
-            - airGappedDeployment
             - clusterID
             - natEnabled
             type: object

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -935,7 +935,6 @@ spec:
               serviceCIDR:
                 type: string
             required:
-            - airGappedDeployment
             - clusterID
             - natEnabled
             type: object


### PR DESCRIPTION
This breaks the upgrade CI jobs:

`2022-10-13T17:13:04.994Z ERR ..oller/controller.go:326                      Reconciler error error="error removing finalizer \"controllers.submariner.io/cleanup\" from \"submariner\": error creating or updating resource: error updating &v1alpha1.Submariner{...}: Submariner.submariner.io \"submariner\" is invalid: status.airGappedDeployment: Required value"` 

