### PR TITLE
Add cluster role privileges for submariner-diagnose

### DIFF
--- a/config/rbac/submariner-diagnose/cluster_role.yaml
+++ b/config/rbac/submariner-diagnose/cluster_role.yaml
@@ -11,6 +11,7 @@ rules:
     resources:
       - configmaps
       - nodes
+      - services
     verbs:
       - get
       - list
@@ -20,6 +21,13 @@ rules:
       - clusterglobalegressips
       - globalegressips
     verbs:
+      - list
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
       - list
   - apiGroups:
       - multicluster.x-k8s.io

--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -19,7 +19,6 @@ rules:
     resources:
       - configmaps
       - namespaces
-      - services
     verbs:
       - get
       - list
@@ -28,13 +27,6 @@ rules:
     resources:
       - daemonsets
       - deployments
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
     verbs:
       - get
       - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2847,7 +2847,6 @@ rules:
     resources:
       - configmaps
       - namespaces
-      - services
     verbs:
       - get
       - list
@@ -2856,13 +2855,6 @@ rules:
     resources:
       - daemonsets
       - deployments
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
     verbs:
       - get
       - list
@@ -2907,6 +2899,7 @@ rules:
     resources:
       - configmaps
       - nodes
+      - services
     verbs:
       - get
       - list
@@ -2916,6 +2909,13 @@ rules:
       - clusterglobalegressips
       - globalegressips
     verbs:
+      - list
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
       - list
   - apiGroups:
       - multicluster.x-k8s.io


### PR DESCRIPTION
`subctl diagnose` needs to be able to retrieve `Services` and `EndpointSlices` in any namespace.

Needed by https://github.com/submariner-io/subctl/pull/240.

