### PR TITLE
Remove space between // and nolint

### DIFF
--- a/controllers/apply/apply.go
+++ b/controllers/apply/apply.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:dupl // These functions are similar but not duplicated.
+//nolint:dupl // These functions are similar but not duplicated.
 package apply
 
 import (
@@ -59,7 +59,7 @@ func DaemonSet(owner metav1.Object, daemonSet *appsv1.DaemonSet, reqLogger logr.
 			copyLabels(daemonSet, toUpdate)
 
 			// Set the owner and controller.
-			return controllerutil.SetControllerReference(owner, toUpdate, scheme) // nolint:wrapcheck // No need to wrap here
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme) //nolint:wrapcheck // No need to wrap here
 		})
 		if err != nil {
 			if isImmutableError(err) {
@@ -67,16 +67,16 @@ func DaemonSet(owner metav1.Object, daemonSet *appsv1.DaemonSet, reqLogger logr.
 					daemonSet.Namespace, "DaemonSet.Name", daemonSet.Name)
 
 				if err := client.Delete(context.TODO(), toUpdate); err != nil {
-					return err // nolint:wrapcheck // No need to wrap here
+					return err //nolint:wrapcheck // No need to wrap here
 				}
 
 				if err := client.Create(context.TODO(), daemonSet); err != nil {
-					return err // nolint:wrapcheck // No need to wrap here
+					return err //nolint:wrapcheck // No need to wrap here
 				}
 
 				return nil
 			}
-			return err // nolint:wrapcheck // No need to wrap here
+			return err //nolint:wrapcheck // No need to wrap here
 		}
 
 		if result == controllerutil.OperationResultCreated {
@@ -118,10 +118,10 @@ func Deployment(owner metav1.Object, deployment *appsv1.Deployment, reqLogger lo
 			copyLabels(deployment, toUpdate)
 
 			// Set the owner and controller
-			return controllerutil.SetControllerReference(owner, toUpdate, scheme) // nolint:wrapcheck // No need to wrap here
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme) //nolint:wrapcheck // No need to wrap here
 		})
 		if err != nil {
-			return err // nolint:wrapcheck // No need to wrap here
+			return err //nolint:wrapcheck // No need to wrap here
 		}
 
 		if result == controllerutil.OperationResultCreated {
@@ -163,10 +163,10 @@ func ConfigMap(owner metav1.Object, configMap *corev1.ConfigMap, reqLogger logr.
 			copyLabels(configMap, toUpdate)
 
 			// Set the owner and controller
-			return controllerutil.SetControllerReference(owner, toUpdate, scheme) // nolint:wrapcheck // No need to wrap here
+			return controllerutil.SetControllerReference(owner, toUpdate, scheme) //nolint:wrapcheck // No need to wrap here
 		})
 		if err != nil {
-			return err // nolint:wrapcheck // No need to wrap here
+			return err //nolint:wrapcheck // No need to wrap here
 		}
 
 		if result == controllerutil.OperationResultCreated {
@@ -225,12 +225,12 @@ func Service(owner metav1.Object, service *corev1.Service, reqLogger logr.Logger
 			}
 			if owner != nil {
 				// Set the owner and controller
-				return controllerutil.SetControllerReference(owner, toUpdate, scheme) // nolint:wrapcheck // No need to wrap here
+				return controllerutil.SetControllerReference(owner, toUpdate, scheme) //nolint:wrapcheck // No need to wrap here
 			}
 			return nil
 		})
 		if err != nil {
-			return err // nolint:wrapcheck // No need to wrap here
+			return err //nolint:wrapcheck // No need to wrap here
 		}
 
 		if result == controllerutil.OperationResultCreated {

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -40,7 +40,7 @@ func Setup(serviceName, namespace, applicationKey, applicationName string, owner
 	metricsService, err := apply.Service(owner, newMetricsService(serviceName, namespace, applicationKey,
 		applicationName, port), reqLogger, client, scheme)
 	if err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	}
 
 	if config != nil {
@@ -53,7 +53,7 @@ func Setup(serviceName, namespace, applicationKey, applicationName string, owner
 			if errors.Is(err, metrics.ErrServiceMonitorNotPresent) {
 				reqLogger.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
 			} else if !k8serrors.IsAlreadyExists(err) {
-				return err // nolint:wrapcheck // No need to wrap here
+				return err //nolint:wrapcheck // No need to wrap here
 			}
 		}
 	}

--- a/controllers/resource/client.go
+++ b/controllers/resource/client.go
@@ -28,7 +28,7 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// nolint:wrapcheck // These functions are pass-through wrappers for the k8s APIs.
+//nolint:wrapcheck // These functions are pass-through wrappers for the k8s APIs.
 func ForControllerClient(client controllerClient.Client, namespace string, objType controllerClient.Object) resource.Interface {
 	return &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {

--- a/controllers/servicediscovery/cleanup.go
+++ b/controllers/servicediscovery/cleanup.go
@@ -87,7 +87,7 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 
 	requeue, _, err := uninstallInfo.Run(ctx)
 	if err != nil {
-		return reconcile.Result{}, err // nolint:wrapcheck // No need to wrap
+		return reconcile.Result{}, err //nolint:wrapcheck // No need to wrap
 	}
 
 	if requeue {
@@ -97,7 +97,7 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 	return reconcile.Result{}, r.removeFinalizer(ctx, instance)
 }
 
-// nolint:wrapcheck // No need to wrap
+//nolint:wrapcheck // No need to wrap
 func (r *Reconciler) removeFinalizer(ctx context.Context, instance *operatorv1alpha1.ServiceDiscovery) error {
 	return finalizer.Remove(ctx, ctrlresource.ForControllerClient(r.ScopedClient, instance.Namespace, instance),
 		instance, constants.CleanupFinalizer)

--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -184,7 +184,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context,
 	added, err := finalizer.Add(ctx, resource.ForControllerClient(r.ScopedClient, instance.Namespace,
 		&submarinerv1alpha1.ServiceDiscovery{}), instance, constants.CleanupFinalizer)
 	if err != nil {
-		return nil, err // nolint:wrapcheck // No need to wrap
+		return nil, err //nolint:wrapcheck // No need to wrap
 	}
 
 	if !added {
@@ -561,7 +561,7 @@ func (r *Reconciler) configureOpenshiftClusterDNSOperator(ctx context.Context, i
 func (r *Reconciler) updateLighthouseConfigInOpenshiftDNSOperator(ctx context.Context, instance *submarinerv1alpha1.ServiceDiscovery,
 	clusterIP string,
 ) error {
-	// nolint:wrapcheck // No need to wrap errors here
+	//nolint:wrapcheck // No need to wrap errors here
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		dnsOperator := &operatorv1.DNS{}
 		if err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: defaultOpenShiftDNSController}, dnsOperator); err != nil {
@@ -669,7 +669,7 @@ func getImagePath(submariner *submarinerv1alpha1.ServiceDiscovery, imageName, co
 		submariner.Spec.ImageOverrides)
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// These are required so that we can manipulate DNS ConfigMap
 	if err := operatorv1.Install(mgr.GetScheme()); err != nil {

--- a/controllers/submariner/broker_controller.go
+++ b/controllers/submariner/broker_controller.go
@@ -72,31 +72,31 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 	err = gateway.Ensure(crdUpdater)
 	if err != nil {
-		return ctrl.Result{}, err // nolint:wrapcheck // Errors are already wrapped
+		return ctrl.Result{}, err //nolint:wrapcheck // Errors are already wrapped
 	}
 
 	// Lighthouse CRDs
 	_, err = lighthouse.Ensure(crdUpdater, lighthouse.BrokerCluster)
 	if err != nil {
-		return ctrl.Result{}, err // nolint:wrapcheck // Errors are already wrapped
+		return ctrl.Result{}, err //nolint:wrapcheck // Errors are already wrapped
 	}
 
 	// Globalnet
 	err = globalnet.ValidateExistingGlobalNetworks(r.Client, request.Namespace)
 	if err != nil {
-		return ctrl.Result{}, err // nolint:wrapcheck // Errors are already wrapped
+		return ctrl.Result{}, err //nolint:wrapcheck // Errors are already wrapped
 	}
 
 	err = globalnet.CreateConfigMap(r.Client, instance.Spec.GlobalnetEnabled, instance.Spec.GlobalnetCIDRRange,
 		instance.Spec.DefaultGlobalnetClusterSize, request.Namespace)
 	if err != nil {
-		return ctrl.Result{}, err // nolint:wrapcheck // Errors are already wrapped
+		return ctrl.Result{}, err //nolint:wrapcheck // Errors are already wrapped
 	}
 
 	return ctrl.Result{}, nil
 }
 
-// nolint:wrapcheck // No need to wrap here.
+//nolint:wrapcheck // No need to wrap here.
 func (r *BrokerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Broker{}).

--- a/controllers/submariner/cleanup.go
+++ b/controllers/submariner/cleanup.go
@@ -85,7 +85,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 
 	requeue, timedOut, err := uninstallInfo.Run(ctx)
 	if err != nil {
-		return reconcile.Result{}, err // nolint:wrapcheck // No need to wrap
+		return reconcile.Result{}, err //nolint:wrapcheck // No need to wrap
 	}
 
 	if !timedOut && instance.Spec.ServiceDiscoveryEnabled {
@@ -99,7 +99,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 	return reconcile.Result{}, r.removeFinalizer(ctx, instance)
 }
 
-// nolint:wrapcheck // No need to wrap
+//nolint:wrapcheck // No need to wrap
 func (r *Reconciler) removeFinalizer(ctx context.Context, instance *operatorv1alpha1.Submariner) error {
 	return finalizer.Remove(ctx, resource.ForControllerClient(r.config.ScopedClient, instance.Namespace, &operatorv1alpha1.Submariner{}),
 		instance, constants.CleanupFinalizer)

--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -245,7 +245,7 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 	return podTemplate
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileGatewayDaemonSet(
 	instance *v1alpha1.Submariner, reqLogger logr.Logger,
 ) (*appsv1.DaemonSet, error) {

--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileGlobalnetDaemonSet(instance *v1alpha1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet,
 	error,
 ) {

--- a/controllers/submariner/loadbalancer_resources.go
+++ b/controllers/submariner/loadbalancer_resources.go
@@ -37,7 +37,7 @@ const (
 	nattDiscoveryPortName = "natt-discovery"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileLoadBalancer(
 	instance *v1alpha1.Submariner, reqLogger logr.Logger,
 ) (*corev1.Service, error) {

--- a/controllers/submariner/metrics_proxy_resources.go
+++ b/controllers/submariner/metrics_proxy_resources.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileMetricsProxyDaemonSet(instance *v1alpha1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet,
 	error,
 ) {

--- a/controllers/submariner/np_syncer_resources.go
+++ b/controllers/submariner/np_syncer_resources.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileNetworkPluginSyncerDeployment(instance *v1alpha1.Submariner,
 	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger,
 ) error {

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileRouteagentDaemonSet(instance *v1alpha1.Submariner, reqLogger logr.Logger) (*appsv1.DaemonSet,
 	error,
 ) {

--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -34,7 +34,7 @@ import (
 func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner *v1alpha1.Submariner, reqLogger logr.Logger,
 	isEnabled bool,
 ) error {
-	// nolint:wrapcheck // No need to wrap errors here
+	//nolint:wrapcheck // No need to wrap errors here
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if isEnabled {
 			sd := newServiceDiscoveryCR(submariner.Namespace)

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -118,7 +118,7 @@ func NewReconciler(config *Config) *Reconciler {
 
 // +kubebuilder:rbac:groups=submariner.io,resources=submariners,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=submariner.io,resources=submariners/status,verbs=get;update;patch
-// nolint:gocyclo // Refactoring would yield functions with a lot of params which isn't ideal either.
+//nolint:gocyclo // Refactoring would yield functions with a lot of params which isn't ideal either.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.V(2).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Submariner")
@@ -276,7 +276,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context, instance *submopv1a1.Subm
 	added, err := finalizer.Add(ctx, resourceiface.ForControllerClient(r.config.ScopedClient, instance.Namespace, &submopv1a1.Submariner{}),
 		instance, constants.CleanupFinalizer)
 	if err != nil {
-		return nil, err // nolint:wrapcheck // No need to wrap
+		return nil, err //nolint:wrapcheck // No need to wrap
 	}
 
 	if !added {
@@ -300,7 +300,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 		})
 
-	// nolint:wrapcheck // No need to wrap here
+	//nolint:wrapcheck // No need to wrap here
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("submariner-controller").
 		// Watch for changes to primary resource Submariner

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func init() {
 	flag.BoolVar(&help, "help", help, "Print usage options")
 }
 
-// nolint:gocyclo // No further refactors necessary
+//nolint:gocyclo // No further refactors necessary
 func main() {
 	var enableLeaderElection bool
 	var probeAddr string

--- a/pkg/crd/updater.go
+++ b/pkg/crd/updater.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:wrapcheck // These functions are basically wrappers for the k8s APIs.
+//nolint:wrapcheck // These functions are basically wrappers for the k8s APIs.
 package crd
 
 import (
@@ -125,7 +125,7 @@ func (c *controllerClientCreator) Get(ctx context.Context, name string,
 }
 
 func (c *controllerClientCreator) Delete(ctx context.Context, name string,
-	options metav1.DeleteOptions, // nolint:gocritic // Match K8s API
+	options metav1.DeleteOptions, //nolint:gocritic // Match K8s API
 ) error {
 	crd, err := c.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/discovery/globalnet/config_map.go
+++ b/pkg/discovery/globalnet/config_map.go
@@ -134,13 +134,13 @@ func updateConfigMap(client controllerClient.Client, configMap *corev1.ConfigMap
 	return errors.Wrapf(err, "error updating ConfigMap")
 }
 
-// nolint:wrapcheck // No need to wrap here
+//nolint:wrapcheck // No need to wrap here
 func GetConfigMap(client controllerClient.Client, namespace string) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
 	return cm, client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: globalCIDRConfigMapName}, cm)
 }
 
-// nolint:wrapcheck // No need to wrap here
+//nolint:wrapcheck // No need to wrap here
 func DeleteConfigMap(client controllerClient.Client, namespace string) error {
 	return client.Delete(context.TODO(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 		Name:      globalCIDRConfigMapName,

--- a/pkg/discovery/globalnet/globalnet.go
+++ b/pkg/discovery/globalnet/globalnet.go
@@ -69,13 +69,13 @@ var globalCidr = GlobalCIDR{allocatedCount: 0}
 func isOverlappingCIDR(cidrList []string, cidr string) (bool, error) {
 	_, newNet, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return false, err // nolint:wrapcheck // No need to wrap here
+		return false, err //nolint:wrapcheck // No need to wrap here
 	}
 
 	for _, v := range cidrList {
 		_, baseNet, err := net.ParseCIDR(v)
 		if err != nil {
-			return false, err // nolint:wrapcheck // No need to wrap here
+			return false, err //nolint:wrapcheck // No need to wrap here
 		}
 
 		if baseNet.Contains(newNet.IP) || newNet.Contains(baseNet.IP) {
@@ -217,7 +217,7 @@ func uintToIP(ip uint) net.IP {
 func GetValidClusterSize(cidrRange string, clusterSize uint) (uint, error) {
 	_, network, err := net.ParseCIDR(cidrRange)
 	if err != nil {
-		return 0, err // nolint:wrapcheck // No need to wrap here
+		return 0, err //nolint:wrapcheck // No need to wrap here
 	}
 
 	ones, totalbits := network.Mask.Size()
@@ -418,7 +418,7 @@ func AssignGlobalnetIPs(globalnetInfo *Info, netconfig Config, status reporter.I
 func IsValidCIDR(cidr string) error {
 	ip, _, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	}
 
 	if ip.IsUnspecified() {
@@ -504,5 +504,5 @@ func AllocateAndUpdateGlobalCIDRConfigMap(brokerAdminClient controllerClient.Cli
 		return nil
 	})
 
-	return retryErr // nolint:wrapcheck // No need to wrap here
+	return retryErr //nolint:wrapcheck // No need to wrap here
 }

--- a/pkg/discovery/network/calico.go
+++ b/pkg/discovery/network/calico.go
@@ -32,7 +32,7 @@ func init() {
 	registerNetworkPluginDiscoveryFunction(discoverCalicoNetwork)
 }
 
-// nolint:nilnil // Intentional as the purpose is to discover.
+//nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCalicoNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	cmList := &corev1.ConfigMapList{}
 

--- a/pkg/discovery/network/canal.go
+++ b/pkg/discovery/network/canal.go
@@ -34,7 +34,7 @@ func init() {
 	registerNetworkPluginDiscoveryFunction(discoverCanalFlannelNetwork)
 }
 
-// nolint:nilnil // Intentional as the purpose is to discover.
+//nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCanalFlannelNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	// TODO: this must be smarter, looking for the canal daemonset, with labels k8s-app=canal
 	//  and then the reference on the container volumes:

--- a/pkg/discovery/network/generic.go
+++ b/pkg/discovery/network/generic.go
@@ -32,7 +32,7 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// nolint:nilnil // Intentional as the purpose is to discover.
+//nolint:nilnil // Intentional as the purpose is to discover.
 func discoverGenericNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	clusterNetwork, err := discoverNetwork(client)
 	if err != nil {
@@ -47,7 +47,7 @@ func discoverGenericNetwork(client controllerClient.Client) (*ClusterNetwork, er
 	return nil, nil
 }
 
-// nolint:nilnil // Intentional as the purpose is to discover.
+//nolint:nilnil // Intentional as the purpose is to discover.
 func discoverNetwork(client controllerClient.Client) (*ClusterNetwork, error) {
 	clusterNetwork := &ClusterNetwork{}
 

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -111,7 +111,7 @@ func registerNetworkPluginDiscoveryFunction(function pluginDiscoveryFn) {
 	discoverFunctions = append(discoverFunctions, function)
 }
 
-// nolint:nilnil // Intentional as the purpose is to discover.
+//nolint:nilnil // Intentional as the purpose is to discover.
 func networkPluginsDiscovery(client controllerClient.Client) (*ClusterNetwork, error) {
 	for _, function := range discoverFunctions {
 		network, err := function(client)

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -36,7 +36,7 @@ func init() {
 	registerNetworkPluginDiscoveryFunction(discoverOpenShift4Network)
 }
 
-// nolint:nilnil // Intentional as the purpose is to discover.
+//nolint:nilnil // Intentional as the purpose is to discover.
 func discoverOpenShift4Network(client controllerClient.Client) (*ClusterNetwork, error) {
 	network := &unstructured.Unstructured{}
 	network.SetGroupVersionKind(schema.GroupVersionKind{

--- a/pkg/discovery/network/pods.go
+++ b/pkg/discovery/network/pods.go
@@ -54,7 +54,7 @@ func FindPodCommandParameter(client controllerClient.Client, labelSelector, para
 	return "", nil
 }
 
-// nolint:nilnil // Intentional as the purpose is to find.
+//nolint:nilnil // Intentional as the purpose is to find.
 func FindPod(client controllerClient.Client, labelSelector string) (*corev1.Pod, error) {
 	selector, err := labels.Parse(labelSelector)
 	if err != nil {

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -155,7 +155,7 @@ func hasServiceMonitor(config *rest.Config) (bool, error) {
 
 	_, apiLists, err := discovery.NewDiscoveryClientForConfigOrDie(config).ServerGroupsAndResources()
 	if err != nil {
-		return false, err // nolint:wrapcheck // No need to wrap here
+		return false, err //nolint:wrapcheck // No need to wrap here
 	}
 
 	for _, apiList := range apiLists {


### PR DESCRIPTION
This is enforced by newer releases of golangci-lint.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
