### PR TITLE
Expose `Nettest{Component,Image}`

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -32,6 +32,7 @@ const (
 	ServiceDiscoveryCrName       = "service-discovery"
 	SubmarinerCrName             = "submariner"
 	MetricsProxyComponent        = "submariner-metrics-proxy"
+	NettestComponent             = "submariner-nettest"
 )
 
 /* These values are used by downstream distributions to override the component default image name. */
@@ -44,6 +45,7 @@ var (
 	LighthouseCoreDNSImage   = "lighthouse-coredns"
 	OperatorImage            = "submariner-operator"
 	MetricsProxyImage        = "nettest"
+	NettestImage             = "nettest"
 )
 
 var ValidImageNames = []string{


### PR DESCRIPTION
Expose as generic Nettest image (instead of specific to metrics proxy) so that it can be consumed by other projects (such as `subctl`) and properly overriden in downstream forks.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
