### PR TITLE
Automated backport of #2293: Expose `Nettest{Component,Image}`

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -31,6 +31,8 @@ const (
 	OperatorComponent            = "submariner-operator"
 	ServiceDiscoveryCrName       = "service-discovery"
 	SubmarinerCrName             = "submariner"
+	MetricsProxyComponent        = "submariner-metrics-proxy"
+	NettestComponent             = "submariner-nettest"
 )
 
 /* These values are used by downstream distributions to override the component default image name. */
@@ -42,6 +44,8 @@ var (
 	ServiceDiscoveryImage    = "lighthouse-agent"
 	LighthouseCoreDNSImage   = "lighthouse-coredns"
 	OperatorImage            = "submariner-operator"
+	MetricsProxyImage        = "nettest"
+	NettestImage             = "nettest"
 )
 
 /* Deprecated: These values are used by downstream distributions to patch the image names by adding a prefix/suffix. */


### PR DESCRIPTION
Backport of #2293 on release-0.13.

#2293: Expose `Nettest{Component,Image}`

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.