### PR TITLE
Automated backport of #2315: Use the nettest image for the pause container

### DIFF
--- a/controllers/servicediscovery/cleanup.go
+++ b/controllers/servicediscovery/cleanup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/submariner-io/submariner-operator/controllers/constants"
 	ctrlresource "github.com/submariner-io/submariner-operator/controllers/resource"
 	"github.com/submariner-io/submariner-operator/controllers/uninstall"
+	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -83,6 +84,9 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 		Components: components,
 		StartTime:  instance.DeletionTimestamp.Time,
 		Log:        log,
+		GetImageInfo: func(imageName, componentName string) (string, corev1.PullPolicy) {
+			return getImagePath(instance, imageName, componentName), images.GetPullPolicy(instance.Spec.Version)
+		},
 	}
 
 	requeue, _, err := uninstallInfo.Run(ctx)

--- a/controllers/submariner/cleanup.go
+++ b/controllers/submariner/cleanup.go
@@ -27,8 +27,10 @@ import (
 	"github.com/submariner-io/submariner-operator/controllers/constants"
 	"github.com/submariner-io/submariner-operator/controllers/resource"
 	"github.com/submariner-io/submariner-operator/controllers/uninstall"
+	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -81,6 +83,9 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 		Components: components,
 		StartTime:  instance.DeletionTimestamp.Time,
 		Log:        log,
+		GetImageInfo: func(imageName, componentName string) (string, corev1.PullPolicy) {
+			return getImagePath(instance, imageName, componentName), images.GetPullPolicy(instance.Spec.Version)
+		},
 	}
 
 	requeue, timedOut, err := uninstallInfo.Run(ctx)


### PR DESCRIPTION
Backport of #2315 on release-0.13.

#2315: Use the nettest image for the pause container

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.