### PR TITLE
Remove duplicate pod RBAC

### DIFF
--- a/config/rbac/submariner-gateway/role.yaml
+++ b/config/rbac/submariner-gateway/role.yaml
@@ -41,12 +41,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
       - apps
     resources:
       - replicasets

--- a/config/rbac/submariner-globalnet/role.yaml
+++ b/config/rbac/submariner-globalnet/role.yaml
@@ -43,12 +43,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
       - apps
     resources:
       - replicasets

--- a/config/rbac/submariner-operator/role.yaml
+++ b/config/rbac/submariner-operator/role.yaml
@@ -43,12 +43,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
       - apps
     resources:
       - replicasets

--- a/config/rbac/submariner-route-agent/role.yaml
+++ b/config/rbac/submariner-route-agent/role.yaml
@@ -40,12 +40,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
       - apps
     resources:
       - replicasets

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2103,12 +2103,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
       - apps
     resources:
       - replicasets
@@ -2295,12 +2289,6 @@ rules:
       - deployments/finalizers
     verbs:
       - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
   - apiGroups:
       - apps
     resources:
@@ -2490,12 +2478,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
       - apps
     resources:
       - replicasets
@@ -2672,12 +2654,6 @@ rules:
       - deployments/finalizers
     verbs:
       - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
The RBAC for pods duplicates the get permission, as it's granted * elsewhere.

This was recently modified in #2225, #2214, and #2008.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
