### PR TITLE
Remove duplicate replicasets RBAC

### DIFF
--- a/config/rbac/submariner-gateway/role.yaml
+++ b/config/rbac/submariner-gateway/role.yaml
@@ -47,12 +47,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
       - submariner.io
     resources:
       - '*'

--- a/config/rbac/submariner-globalnet/role.yaml
+++ b/config/rbac/submariner-globalnet/role.yaml
@@ -49,12 +49,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
       - submariner.io
     resources:
       - '*'

--- a/config/rbac/submariner-operator/role.yaml
+++ b/config/rbac/submariner-operator/role.yaml
@@ -49,12 +49,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
       - submariner.io
     resources:
       - '*'

--- a/config/rbac/submariner-route-agent/role.yaml
+++ b/config/rbac/submariner-route-agent/role.yaml
@@ -46,12 +46,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
       - submariner.io
     resources:
       - '*'

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2109,12 +2109,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
       - submariner.io
     resources:
       - '*'
@@ -2300,12 +2294,6 @@ rules:
       - ""
     resources:
       - pods
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
     verbs:
       - get
   - apiGroups:
@@ -2498,12 +2486,6 @@ rules:
     verbs:
       - get
   - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
       - submariner.io
     resources:
       - '*'
@@ -2679,12 +2661,6 @@ rules:
       - ""
     resources:
       - pods
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
     verbs:
       - get
   - apiGroups:


### PR DESCRIPTION
The RBAC for replicasets duplicates the get permission, as it's granted * elsewhere.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
