### PR TITLE
Automated backport of #2138: Add submariner-gateway role permissions for leases

### DIFF
--- a/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-gateway_rbac.authorization.k8s.io_v1_role.yaml
@@ -60,3 +60,14 @@ rules:
   - servicediscoveries
   verbs:
   - '*'
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete

--- a/config/rbac/submariner-gateway/role.yaml
+++ b/config/rbac/submariner-gateway/role.yaml
@@ -61,3 +61,14 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2348,6 +2348,17 @@ rules:
       - servicediscoveries
     verbs:
       - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 `
 	Config_rbac_submariner_gateway_role_binding_yaml = `---
 kind: RoleBinding


### PR DESCRIPTION
Backport of submariner-io/submariner-operator#2138 on release-0.13.

submariner-io/submariner-operator#2138: Add submariner-gateway role permissions for leases

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.