### PR TITLE
Stop pretending to support Kubernetes 1.17

### DIFF
--- a/.github/workflows/e2e-all-k8s.yml
+++ b/.github/workflows/e2e-all-k8s.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.17', '1.22', '1.23', '1.24', '1.25']
+        k8s_version: ['1.19', '1.22', '1.23', '1.24', '1.25']
         lighthouse: ['', 'lighthouse']
         ovn: ['', 'ovn']
         exclude:

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -31,7 +31,7 @@ jobs:
           # This should match minK8sMajor.minK8sMinor in subctl/pkg/version/version.go.
           # If this breaks, we may advance the minimum K8s version instead of fixing it. See:
           # https://submariner.io/development/building-testing/ci-maintenance/
-          - k8s_version: '1.17'
+          - k8s_version: '1.19'
           # Run default E2E against all supported K8s versions
           - k8s_version: '1.22'
           - k8s_version: '1.23'


### PR DESCRIPTION
At some point we lost the ability to test against Kubernetes 1.17; let's stop pretending to support it (it reached EOL on 2021-01-13).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
