### PR TITLE
Add operator access to list DaemonSets cluster-wide

### DIFF
--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -69,3 +69,9 @@ rules:
     verbs:
       - get
       - create
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - list

--- a/pkg/discovery/network/flannel.go
+++ b/pkg/discovery/network/flannel.go
@@ -37,7 +37,7 @@ func discoverFlannelNetwork(ctx context.Context, client controllerClient.Client)
 
 	err := client.List(ctx, daemonsets, controllerClient.InNamespace(metav1.NamespaceSystem))
 	if err != nil {
-		return nil, errors.WithMessage(err, "error listing the Daemonsets")
+		return nil, errors.WithMessage(err, "error listing the Daemonsets for flannel discovery")
 	}
 
 	volumes := make([]corev1.Volume, 0)
@@ -78,7 +78,7 @@ func discoverFlannelNetwork(ctx context.Context, client controllerClient.Client)
 			return nil, nil
 		}
 
-		return nil, errors.WithMessage(err, "error listing the Daemonsets")
+		return nil, errors.WithMessagef(err, "error retrieving the flannel ConfigMap %q", flannelConfigMap)
 	}
 
 	podCIDR := extractPodCIDRFromNetConfigJSON(cm)

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2205,6 +2205,12 @@ rules:
     verbs:
       - get
       - create
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - list
 `
 	Config_rbac_submariner_operator_cluster_role_binding_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is needed for flannel discovery which searches for the flannel `DaemonSet` in the _kube-system_ namespace.

Fixes https://github.com/submariner-io/submariner-operator/issues/2450
