### PR TITLE
Automated backport of #2451: Add operator access to list DaemonSets cluster-wide

### DIFF
--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -69,3 +69,9 @@ rules:
     verbs:
       - get
       - create
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - list

--- a/pkg/discovery/network/flannel.go
+++ b/pkg/discovery/network/flannel.go
@@ -37,7 +37,7 @@ func discoverFlannelNetwork(client controllerClient.Client) (*ClusterNetwork, er
 
 	err := client.List(context.TODO(), daemonsets, controllerClient.InNamespace(metav1.NamespaceSystem))
 	if err != nil {
-		return nil, errors.WithMessage(err, "error listing the Daemonsets")
+		return nil, errors.WithMessage(err, "error listing the Daemonsets for flannel discovery")
 	}
 
 	volumes := make([]corev1.Volume, 0)
@@ -78,7 +78,7 @@ func discoverFlannelNetwork(client controllerClient.Client) (*ClusterNetwork, er
 			return nil, nil
 		}
 
-		return nil, errors.WithMessage(err, "error listing the Daemonsets")
+		return nil, errors.WithMessagef(err, "error retrieving the flannel ConfigMap %q", flannelConfigMap)
 	}
 
 	podCIDR := extractPodCIDRFromNetConfigJSON(cm)

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2206,6 +2206,12 @@ rules:
     verbs:
       - get
       - create
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - list
 `
 	Config_rbac_submariner_operator_cluster_role_binding_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #2451 on release-0.14.

#2451: Add operator access to list DaemonSets cluster-wide

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.