### PR TITLE
Refactor ordering of CNI discovery

### DIFF
--- a/pkg/discovery/network/calico.go
+++ b/pkg/discovery/network/calico.go
@@ -28,10 +28,6 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func init() {
-	registerNetworkPluginDiscoveryFunction(discoverCalicoNetwork)
-}
-
 //nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCalicoNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
 	cmList := &corev1.ConfigMapList{}

--- a/pkg/discovery/network/canal.go
+++ b/pkg/discovery/network/canal.go
@@ -30,10 +30,6 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func init() {
-	registerNetworkPluginDiscoveryFunction(discoverCanalFlannelNetwork)
-}
-
 //nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCanalFlannelNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
 	// TODO: this must be smarter, looking for the canal daemonset, with labels k8s-app=canal

--- a/pkg/discovery/network/kindnet.go
+++ b/pkg/discovery/network/kindnet.go
@@ -25,10 +25,6 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func init() {
-	registerNetworkPluginDiscoveryFunction(discoverKindNetwork)
-}
-
 func discoverKindNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
 	kindNetPod, err := FindPod(ctx, client, "app=kindnet")
 

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -105,10 +105,14 @@ func Discover(ctx context.Context, client controllerClient.Client, operatorNames
 
 type pluginDiscoveryFn func(context.Context, controllerClient.Client) (*ClusterNetwork, error)
 
-var discoverFunctions = []pluginDiscoveryFn{}
-
-func registerNetworkPluginDiscoveryFunction(function pluginDiscoveryFn) {
-	discoverFunctions = append(discoverFunctions, function)
+var discoverFunctions = []pluginDiscoveryFn{
+	discoverOpenShift4Network,
+	discoverOvnKubernetesNetwork,
+	discoverWeaveNetwork,
+	discoverCanalFlannelNetwork,
+	discoverCalicoNetwork,
+	discoverFlannelNetwork,
+	discoverKindNetwork,
 }
 
 //nolint:nilnil // Intentional as the purpose is to discover.
@@ -118,11 +122,6 @@ func networkPluginsDiscovery(ctx context.Context, client controllerClient.Client
 		if err != nil || network != nil {
 			return network, err
 		}
-	}
-
-	flanelNet, err := discoverFlannelNetwork(ctx, client)
-	if err != nil || flanelNet != nil {
-		return flanelNet, err
 	}
 
 	return nil, nil

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -32,10 +32,6 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func init() {
-	registerNetworkPluginDiscoveryFunction(discoverOpenShift4Network)
-}
-
 //nolint:nilnil // Intentional as the purpose is to discover.
 func discoverOpenShift4Network(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
 	network := &unstructured.Unstructured{}

--- a/pkg/discovery/network/ovnkubernetes.go
+++ b/pkg/discovery/network/ovnkubernetes.go
@@ -37,10 +37,6 @@ const (
 	OvnSBDBDefaultPort = 6642
 )
 
-func init() {
-	registerNetworkPluginDiscoveryFunction(discoverOvnKubernetesNetwork)
-}
-
 func discoverOvnKubernetesNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
 	ovnDBPod, err := FindPod(ctx, client, "name=ovnkube-db")
 

--- a/pkg/discovery/network/weavenet.go
+++ b/pkg/discovery/network/weavenet.go
@@ -25,10 +25,6 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func init() {
-	registerNetworkPluginDiscoveryFunction(discoverWeaveNetwork)
-}
-
 func discoverWeaveNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
 	weaveNetPod, err := FindPod(ctx, client, "name=weave-net")
 


### PR DESCRIPTION
List the discovery functions specifically instead of populating the list via init functions so we can deterministically order them. In particular ensure `kindnet` is discovered last so that we at least execute the other CNI discovery functions in CI to avoid latent issues like https://github.com/submariner-io/submariner-operator/issues/2450.
