### PR TITLE
Backport of subctl #518: Only call cloud prepare when it's needed

### DIFF
--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -83,7 +83,11 @@ func prepareAws(cmd *cobra.Command, args []string) {
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, reporter)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, reporter)
+			}
+
+			return nil
 		})
 
 	exit.OnErrorWithMessage(err, "Failed to prepare AWS cloud")

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -80,7 +80,11 @@ func prepareGCP(cmd *cobra.Command, args []string) {
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, reporter)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, reporter)
+			}
+
+			return nil
 		})
 
 	exit.OnErrorWithMessage(err, "Failed to prepare GCP cloud")

--- a/pkg/subctl/cmd/cloud/prepare/rhos.go
+++ b/pkg/subctl/cmd/cloud/prepare/rhos.go
@@ -82,7 +82,11 @@ func prepareRHOS(cmd *cobra.Command, args []string) {
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, reporter)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, reporter)
+			}
+
+			return nil
 		})
 
 	exit.OnErrorWithMessage(err, "Failed to prepare RHOS  cloud")


### PR DESCRIPTION
Since the cloud prepare step opens internal ports and nothing else, we should only call it when there are ports to open.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
