### PR TITLE
Reduce dependabot frequency, target k8s bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,22 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.12"
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.13"
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.14"
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: gomod
     directory: "/"
     schedule:
@@ -27,3 +27,7 @@ updates:
     ignore:
       # Our internal dependencies
       - dependency-name: github.com/submariner-io/*
+      # These are included by k8s.io/apiextensions-apiserver
+      - dependency-name: k8s.io/api
+      - dependency-name: k8s.io/apimachinery
+      - dependency-name: k8s.io/client-go


### PR DESCRIPTION
- Check monthly for gh-actions
- Ignore k8s dependencies included with apiextensions-apiserver