### PR TITLE
Ignore prometheus-operator/pkg/apis/monitoring dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,5 @@ updates:
       - dependency-name: k8s.io/api
       - dependency-name: k8s.io/apimachinery
       - dependency-name: k8s.io/client-go
+      # Included with prometheus-operator/pkg/client
+      - dependency-name: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring


### PR DESCRIPTION
...with dependabot as it's included with _prometheus-operator/pkg/client_.
