### PR TITLE
Bundle: restore the "replaces" calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,22 @@ ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+IS_CHANNEL_DEFAULT ?= 1
+ifneq ($(origin FROM_VERSION), undefined)
+ifneq ($(FROM_VERSION), 0.0.0)
+PKG_FROM_VERSION := --from-version=$(FROM_VERSION)
+REPLACES_OP := add
+else
+REPLACES_OP := remove
+endif
+endif
+ifneq ($(origin CHANNEL), undefined)
+PKG_CHANNELS := --channel=$(CHANNEL)
+endif
+ifeq ($(IS_CHANNEL_DEFAULT), 1)
+PKG_IS_DEFAULT_CHANNEL := --default-channel
+endif
+PKG_MAN_OPTS ?= $(PKG_FROM_VERSION) $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 
 # Set the kustomize base path
 ifeq ($(IS_OCP), true)

--- a/config/bundle/kustomization.template.yaml
+++ b/config/bundle/kustomization.template.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+patches:
+  - path: patches/submariner.csv.config.yaml
+    target:
+      group: operators.coreos.com
+      kind: ClusterServiceVersion
+      name: submariner.v${VERSION}
+      namespace: placeholder
+      version: v1alpha1
 commonAnnotations:
   createdAt: null


### PR DESCRIPTION
This ensures we end up with a valid "replaces" statement in the CSV, or none if we can't determine the version being replaced. Currently we end up with a CSV replacing "submariner.v0.0.0" which is invalid.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
