### PR TITLE
Automated backport of #2491: Add LH coredns permission to access Submariner resource

### DIFF
--- a/config/rbac/lighthouse-coredns/cluster_role.yaml
+++ b/config/rbac/lighthouse-coredns/cluster_role.yaml
@@ -32,6 +32,7 @@ rules:
       - submariner.io
     resources:
       - "gateways"
+      - "submariners"
     verbs:
       - get
       - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3112,6 +3112,7 @@ rules:
       - submariner.io
     resources:
       - "gateways"
+      - "submariners"
     verbs:
       - get
       - list


### PR DESCRIPTION
Backport of #2491 on release-0.14.

#2491: Add LH coredns permission to access Submariner resource

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.