### PR TITLE
Use configured node configuration

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -259,6 +259,8 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 					},
 
 					ServiceAccountName:            "submariner-lighthouse-agent",
+					Tolerations:                   cr.Spec.Tolerations,
+					NodeSelector:                  cr.Spec.NodeSelector,
 					TerminationGracePeriodSeconds: pointer.Int64(0),
 					Volumes:                       volumes,
 				},
@@ -359,6 +361,8 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 
 					ServiceAccountName:            "submariner-lighthouse-coredns",
 					TerminationGracePeriodSeconds: pointer.Int64(0),
+					Tolerations:                   cr.Spec.Tolerations,
+					NodeSelector:                  cr.Spec.NodeSelector,
 					Volumes: []corev1.Volume{
 						{Name: "config-volume", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: names.LighthouseCoreDNSComponent},

--- a/controllers/submariner/np_syncer_resources.go
+++ b/controllers/submariner/np_syncer_resources.go
@@ -55,6 +55,12 @@ func newNetworkPluginSyncerDeployment(cr *v1alpha1.Submariner, clusterNetwork *n
 		"component": "networkplugin-syncer",
 	}
 
+	tolerations := cr.Spec.Tolerations
+
+	if len(tolerations) == 0 {
+		tolerations = append(tolerations, corev1.Toleration{Operator: corev1.TolerationOpExists})
+	}
+
 	networkPluginSyncerDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
@@ -98,7 +104,8 @@ func newNetworkPluginSyncerDeployment(cr *v1alpha1.Submariner, clusterNetwork *n
 						},
 					},
 					ServiceAccountName: names.NetworkPluginSyncerComponent,
-					Tolerations:        []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+					NodeSelector:       cr.Spec.NodeSelector,
+					Tolerations:        tolerations,
 				},
 			},
 		},

--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -53,6 +53,8 @@ func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner 
 					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
 					ImageOverrides:           submariner.Spec.ImageOverrides,
 					CoreDNSCustomConfig:      submariner.Spec.CoreDNSCustomConfig,
+					NodeSelector:             submariner.Spec.NodeSelector,
+					Tolerations:              submariner.Spec.Tolerations,
 				}
 
 				if len(submariner.Spec.CustomDomains) > 0 {


### PR DESCRIPTION
Use configured `NodeSelector` and `Tolerations` fields in Submariner and ServiceDiscovery` CRs when creating following deployments/daemonsets:

* NetworkPluinSyncer
* LighthouseAgent
* LighthouseCoreDNS

Epic: https://github.com/submariner-io/enhancements/issues/149

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
