### PR TITLE
Allow broker access to broker-client role

### DIFF
--- a/config/broker/broker-client/role.yaml
+++ b/config/broker/broker-client/role.yaml
@@ -18,6 +18,13 @@ rules:
       - update
       - delete
   - apiGroups:
+      - submariner.io
+    resources:
+      - brokers
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - multicluster.x-k8s.io
     resources:
       - '*'


### PR DESCRIPTION
This allows other clusters to get/list broker CR using Broker restconfig.

Epic: https://github.com/submariner-io/enhancements/issues/143

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
