### PR TITLE
Add "serviceimports" get permission to submariner-diagnose role

### DIFF
--- a/config/rbac/submariner-diagnose/cluster_role.yaml
+++ b/config/rbac/submariner-diagnose/cluster_role.yaml
@@ -35,5 +35,7 @@ rules:
       - multicluster.x-k8s.io
     resources:
       - "serviceexports"
+      - "serviceimports"
     verbs:
+      - get
       - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3069,7 +3069,9 @@ rules:
       - multicluster.x-k8s.io
     resources:
       - "serviceexports"
+      - "serviceimports"
     verbs:
+      - get
       - list
 `
 	Config_rbac_submariner_diagnose_cluster_role_binding_yaml = `---


### PR DESCRIPTION
`subctl diagnose service-discovery` needs to be able to retrieve the aggregated `ServiceImports` in any namespace so add the permission to the `submariner-diagnose` role.
