### PR TITLE
Update the Submariner dependency to the committed hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/submariner-io/admiral v0.15.0-rc0
 	github.com/submariner-io/shipyard v0.15.0-rc0
-	github.com/submariner-io/submariner v0.15.0-m4.0.20230401111446-1faf6115599a
+	github.com/submariner-io/submariner v0.15.0-rc0
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/text v0.8.0
 	k8s.io/api v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -1379,8 +1379,8 @@ github.com/submariner-io/admiral v0.15.0-rc0 h1:hW1DzKKNlyLcCsFdvxFicHrfx/TjPLr3
 github.com/submariner-io/admiral v0.15.0-rc0/go.mod h1:EZZL0MPJm7EtE3ivs01umqu3nZFUkoqU9u7XZ5RXM/k=
 github.com/submariner-io/shipyard v0.15.0-rc0 h1:ltGZj3qAZJgfwO0Rdl14IAFWgJl3csZ1bhW+Zis9Xpc=
 github.com/submariner-io/shipyard v0.15.0-rc0/go.mod h1:144QmfjjNMq7yqHrp2DHBrzAhef9laOKJdQq3QtfHGA=
-github.com/submariner-io/submariner v0.15.0-m4.0.20230401111446-1faf6115599a h1:Gw0s+CGrPY91/WEop87IR9SbkFRsW5DBSoUMEr0wrCY=
-github.com/submariner-io/submariner v0.15.0-m4.0.20230401111446-1faf6115599a/go.mod h1:LLkxjYLwKKaOHzNm4xZqlPP7RgvAfwpjwF8kGK1gufU=
+github.com/submariner-io/submariner v0.15.0-rc0 h1:xOBtESqfnmCfD21nxF5ukxaunyo857vFtLad3Eqb8ZQ=
+github.com/submariner-io/submariner v0.15.0-rc0/go.mod h1:LLkxjYLwKKaOHzNm4xZqlPP7RgvAfwpjwF8kGK1gufU=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=


### PR DESCRIPTION
go.mod was updated with the in-flight hash, this updates it to the really committed hash.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
