### PR TITLE
Use BeEmpty() for emptiness tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ linters:
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
     # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
     - gci
+    - ginkgolinter
     # - gochecknoglobals # We don't want to forbid global variable constants
     # - gochecknoinits # We use init functions for valid reasons
     - gocognit

--- a/pkg/discovery/network/ovnkubernetes_test.go
+++ b/pkg/discovery/network/ovnkubernetes_test.go
@@ -60,7 +60,7 @@ var _ = Describe("OvnKubernetes Network", func() {
 			connectionStr := fmt.Sprintf("tcp:%s.%s", ovnKubeSvcTest, ovnKubeNamespace)
 			Expect(clusterNet.PluginSettings["OVN_NBDB"]).To(Equal(connectionStr + ":6641"))
 			Expect(clusterNet.PluginSettings["OVN_SBDB"]).To(Equal(connectionStr + ":6642"))
-			Expect(clusterNet.PodCIDRs).To(HaveLen(0))
+			Expect(clusterNet.PodCIDRs).To(BeEmpty())
 			Expect(clusterNet.ServiceCIDRs).To(HaveLen(1))
 		})
 	})

--- a/test/e2e/cleanup/submariner.go
+++ b/test/e2e/cleanup/submariner.go
@@ -315,7 +315,7 @@ func (m *podMonitor) assertUninstallPodsCompleted() {
 	m.Lock()
 	defer m.Unlock()
 
-	Expect(len(m.pods)).ToNot(BeZero(), fmt.Sprintf("No uninstall pods were created for component %q", m.name))
+	Expect(m.pods).ToNot(BeEmpty(), fmt.Sprintf("No uninstall pods were created for component %q", m.name))
 
 	for name, info := range m.pods {
 		if info.status.Phase == corev1.PodRunning {


### PR DESCRIPTION
... and enable ginkgolinter to catch such issues automatically.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
