### PR TITLE
Verify broker-admin secret in system tests

### DIFF
--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -13,7 +13,7 @@ function verify_subm_gateway_label() {
 
 function broker_vars() {
     SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
-    SUBMARINER_BROKER_CA=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${SUBMARINER_BROKER_NS}-client')].data['ca\.crt']}")
+    SUBMARINER_BROKER_CA=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${SUBMARINER_BROKER_NS}-admin')].data['ca\.crt']}")
     #SUBMARINER_BROKER_TOKEN=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${SUBMARINER_BROKER_NS}-client')].data.token}"|base64 --decode)
 }
 
@@ -22,7 +22,6 @@ function create_subm_vars() {
     operator_deployment_name=submariner-operator
     gateway_deployment_name=submariner-gateway
     routeagent_deployment_name=submariner-routeagent
-    broker_deployment_name=submariner-k8s-broker
 
     declare_cidrs
     natEnabled=false
@@ -452,7 +451,7 @@ function verify_secrets() {
 }
 
 function verify_subm_broker_secrets() {
-  verify_secrets "$SUBMARINER_BROKER_NS" "$broker_deployment_name-client" "$SUBMARINER_BROKER_CA"
+  verify_secrets "$SUBMARINER_BROKER_NS" "cluster-$cluster" "$SUBMARINER_BROKER_CA"
 }
 
 function verify_subm_gateway_secrets() {


### PR DESCRIPTION
...instead of broker-client secret as is currently done because with https://github.com/submariner-io/subctl/pull/653, subctl no longer creates a broker client SA and its associated secret.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
