### PR TITLE
[0.14] Fix FindPodCommandParameter method when value contains '='

### DIFF
--- a/pkg/discovery/network/pods.go
+++ b/pkg/discovery/network/pods.go
@@ -38,13 +38,13 @@ func FindPodCommandParameter(client controllerClient.Client, labelSelector, para
 	for i := range pod.Spec.Containers {
 		for _, arg := range pod.Spec.Containers[i].Command {
 			if strings.HasPrefix(arg, parameter) {
-				return strings.Split(arg, "=")[1], nil
+				return strings.SplitN(arg, "=", 2)[1], nil
 			}
 			// Handling the case where the command is in the form of /bin/sh -c exec ....
 			if strings.Contains(arg, " ") {
 				for _, subArg := range strings.Split(arg, " ") {
 					if strings.HasPrefix(subArg, parameter) {
-						return strings.Split(subArg, "=")[1], nil
+						return strings.SplitN(subArg, "=", 2)[1], nil
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
