### PR TITLE
Pass the ConfigMap to globalnet.CreateConfigMap

### DIFF
--- a/controllers/submariner/broker_controller.go
+++ b/controllers/submariner/broker_controller.go
@@ -87,8 +87,8 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{}, err //nolint:wrapcheck // Errors are already wrapped
 	}
 
-	err = globalnet.CreateConfigMap(ctx, r.Client, instance.Spec.GlobalnetEnabled, instance.Spec.GlobalnetCIDRRange,
-		instance.Spec.DefaultGlobalnetClusterSize, request.Namespace)
+	err = globalnet.CreateConfigMap(ctx, r.Client, globalnet.NewGlobalnetConfigMap(instance.Spec.GlobalnetEnabled,
+		instance.Spec.GlobalnetCIDRRange, instance.Spec.DefaultGlobalnetClusterSize, request.Namespace))
 	if err != nil {
 		return ctrl.Result{}, err //nolint:wrapcheck // Errors are already wrapped
 	}


### PR DESCRIPTION
This allows the caller to use `NewGlobalnetConfigMap` to customize the `ConfigMap`, eg add labels.

Fixes https://github.com/submariner-io/submariner-operator/issues/2636
