### PR TITLE
Disable SC2317 on an indirect function

### DIFF
--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -158,6 +158,7 @@ function verify_clusters_crd() {
 # retries are necessary for the status field, which can take some seconds to fill up
 # properly by the operator
 function verify_subm_cr_status_with_retries() {
+  # shellcheck disable=SC2317 # this function is called through with_retries
   function verify_subm_cr_status_() {
     if ! verify_subm_cr_status; then
       sleep 5 && return 1


### PR DESCRIPTION
Shellcheck trips over verify_subm_cr_status_ which is defined inside verify_subm_cr_status_with_retries and is only called indirectly. Disable this detection for that function.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
