### PR TITLE
Automated backport of #2668: Add Version field to Submariner status

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -260,6 +260,10 @@ type SubmarinerStatus struct {
 	// Information about the deployment.
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Deployment Information"
 	DeploymentInfo DeploymentInfo `json:"deploymentInfo,omitempty"`
+
+	// The image version in use by the various Submariner DaemonSets and Deployments.
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Version"
+	Version string `json:"version,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -942,6 +942,10 @@ spec:
               serviceCIDR:
                 description: The current service CIDR.
                 type: string
+              version:
+                description: The image version in use by the various Submariner DaemonSets
+                  and Deployments.
+                type: string
             required:
             - clusterID
             - natEnabled

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -207,6 +207,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	gatewayStatuses := buildGatewayStatusAndUpdateMetrics(gateways)
 
+	instance.Status.Version = instance.Spec.Version
 	instance.Status.NatEnabled = instance.Spec.NatEnabled
 	instance.Status.AirGappedDeployment = instance.Spec.AirGappedDeployment
 	instance.Status.ColorCodes = instance.Spec.ColorCodes

--- a/controllers/submariner/submariner_controller_test.go
+++ b/controllers/submariner/submariner_controller_test.go
@@ -62,6 +62,25 @@ func testReconciliation() {
 		t.awaitFinalizer()
 	})
 
+	Context("", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.NatEnabled = true
+			t.submariner.Spec.AirGappedDeployment = true
+		})
+
+		It("should populate general Submariner resource Status fields from the Spec", func() {
+			t.AssertReconcileSuccess()
+
+			updated := t.getSubmariner()
+			Expect(updated.Status.NatEnabled).To(BeTrue())
+			Expect(updated.Status.AirGappedDeployment).To(BeTrue())
+			Expect(updated.Status.ClusterID).To(Equal(t.submariner.Spec.ClusterID))
+			Expect(updated.Status.GlobalCIDR).To(Equal(t.submariner.Spec.GlobalCIDR))
+			Expect(updated.Status.NetworkPlugin).To(Equal(t.clusterNetwork.NetworkPlugin))
+			Expect(updated.Status.Version).To(Equal(t.submariner.Spec.Version))
+		})
+	})
+
 	When("the network details are not provided", func() {
 		It("should use the detected network", func() {
 			t.AssertReconcileSuccess()

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -1033,6 +1033,10 @@ spec:
               serviceCIDR:
                 description: The current service CIDR.
                 type: string
+              version:
+                description: The image version in use by the various Submariner DaemonSets
+                  and Deployments.
+                type: string
             required:
             - clusterID
             - natEnabled


### PR DESCRIPTION
Backport of #2668 on release-0.15.

#2668: Add Version field to Submariner status

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.