### PR TITLE
Disable dependabot PRs for parent-managed dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,39 +2,50 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: '/'
+    directory: /
     schedule:
       interval: monthly
   - package-ecosystem: github-actions
-    directory: '/'
-    target-branch: "release-0.12"
+    directory: /
+    target-branch: release-0.12
     schedule:
       interval: monthly
   - package-ecosystem: github-actions
-    directory: '/'
-    target-branch: "release-0.13"
+    directory: /
+    target-branch: release-0.13
     schedule:
       interval: monthly
   - package-ecosystem: github-actions
-    directory: '/'
-    target-branch: "release-0.14"
+    directory: /
+    target-branch: release-0.14
     schedule:
       interval: monthly
   - package-ecosystem: github-actions
-    directory: '/'
-    target-branch: "release-0.15"
+    directory: /
+    target-branch: release-0.15
     schedule:
       interval: monthly
   - package-ecosystem: gomod
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
     ignore:
-      # Our internal dependencies
+      # Included with prometheus-operator/pkg/client
+      - dependency-name: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+      # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*
-      # These are included by k8s.io/apiextensions-apiserver
+      # Managed in admiral
+      - dependency-name: github.com/go-logr/logr
+      - dependency-name: github.com/onsi/ginkgo/v2
+      - dependency-name: github.com/onsi/gomega
+      - dependency-name: github.com/pkg/errors
+      - dependency-name: github.com/prometheus/client_golang
       - dependency-name: k8s.io/api
       - dependency-name: k8s.io/apimachinery
       - dependency-name: k8s.io/client-go
-      # Included with prometheus-operator/pkg/client
-      - dependency-name: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+      - dependency-name: sigs.k8s.io/controller-runtime
+      - dependency-name: sigs.k8s.io/yaml
+      # Managed in shipyard
+      - dependency-name: k8s.io/utils
+      # Managed in submariner
+      - dependency-name: github.com/uw-labs/lichen


### PR DESCRIPTION
To reduce the number of dependabot PRs across the various Submariner projects, this disables dependency updates for any direct dependencies of a parent Submariner project. Such dependencies will be automatically pulled in during releases, and can be manually updated if necessary during preparation of a release.

The dependabot configuration is generated automatically using a script which will be added to Shipyard.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
