### PR TITLE
OVNKubernetes CNI IC deployment support

### DIFF
--- a/controllers/submariner/cleanup.go
+++ b/controllers/submariner/cleanup.go
@@ -58,7 +58,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 		},
 		{
 			Resource:          newDaemonSet(names.RouteAgentComponent, instance.Namespace),
-			UninstallResource: newRouteAgentDaemonSet(instance, names.AppendUninstall(names.RouteAgentComponent)),
+			UninstallResource: newRouteAgentDaemonSet(instance, clusterNetwork, names.AppendUninstall(names.RouteAgentComponent)),
 		},
 		{
 			Resource:          newDaemonSet(names.GlobalnetComponent, instance.Namespace),

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -135,20 +135,18 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, clusterNetwork *network.Clu
 		},
 	}
 
-	if clusterNetwork.PluginSettings != nil {
-		if ovndb, ok := clusterNetwork.PluginSettings[network.OvnNBDB]; ok {
-			ds.Spec.Template.Spec.Containers[0].Env = append(
-				ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-					Name: network.OvnNBDB, Value: ovndb,
-				})
-		}
+	if ovndb, ok := clusterNetwork.PluginSettings[network.OvnNBDB]; ok {
+		ds.Spec.Template.Spec.Containers[0].Env = append(
+			ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+				Name: network.OvnNBDB, Value: ovndb,
+			})
+	}
 
-		if ovnsb, ok := clusterNetwork.PluginSettings[network.OvnSBDB]; ok {
-			ds.Spec.Template.Spec.Containers[0].Env = append(
-				ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-					Name: network.OvnSBDB, Value: ovnsb,
-				})
-		}
+	if ovnsb, ok := clusterNetwork.PluginSettings[network.OvnSBDB]; ok {
+		ds.Spec.Template.Spec.Containers[0].Env = append(
+			ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+				Name: network.OvnSBDB, Value: ovnsb,
+			})
 	}
 
 	return ds

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/controllers/apply"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,13 +36,14 @@ import (
 )
 
 //nolint:wrapcheck // No need to wrap errors here.
-func (r *Reconciler) reconcileRouteagentDaemonSet(ctx context.Context, instance *v1alpha1.Submariner, reqLogger logr.Logger,
+func (r *Reconciler) reconcileRouteagentDaemonSet(ctx context.Context, instance *v1alpha1.Submariner,
+	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger,
 ) (*appsv1.DaemonSet, error) {
-	return apply.DaemonSet(ctx, instance, newRouteAgentDaemonSet(instance, names.RouteAgentComponent), reqLogger, r.config.ScopedClient,
-		r.config.Scheme)
+	return apply.DaemonSet(ctx, instance, newRouteAgentDaemonSet(instance, clusterNetwork, names.RouteAgentComponent),
+		reqLogger, r.config.ScopedClient, r.config.Scheme)
 }
 
-func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonSet {
+func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, clusterNetwork *network.ClusterNetwork, name string) *appsv1.DaemonSet {
 	labels := map[string]string{
 		"app":       name,
 		"component": "routeagent",
@@ -49,7 +51,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 
 	maxUnavailable := intstr.FromString("100%")
 
-	return &appsv1.DaemonSet{
+	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
 			Name:      name,
@@ -83,6 +85,9 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 						{Name: "host-sys", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 							Path: "/sys",
 						}}},
+						{Name: "host-var-run-openvswitch-nbdb-sock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/run/openvswitch/ovnnb_db.sock",
+						}}},
 					},
 					Containers: []corev1.Container{
 						{
@@ -102,6 +107,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 								{Name: "host-sys", MountPath: "/sys", ReadOnly: true},
 								{Name: "host-run-xtables-lock", MountPath: "/run/xtables.lock"},
 								{Name: "host-run-openvswitch-db-sock", MountPath: "/run/openvswitch/db.sock"},
+								{Name: "host-var-run-openvswitch-nbdb-sock", MountPath: "/var/run/openvswitch/ovnnb_db.sock"},
 							},
 							Env: []corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
@@ -128,4 +134,22 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 			},
 		},
 	}
+
+	if clusterNetwork.PluginSettings != nil {
+		if ovndb, ok := clusterNetwork.PluginSettings[network.OvnNBDB]; ok {
+			ds.Spec.Template.Spec.Containers[0].Env = append(
+				ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+					Name: network.OvnNBDB, Value: ovndb,
+				})
+		}
+
+		if ovnsb, ok := clusterNetwork.PluginSettings[network.OvnSBDB]; ok {
+			ds.Spec.Template.Spec.Containers[0].Env = append(
+				ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+					Name: network.OvnSBDB, Value: ovnsb,
+				})
+		}
+	}
+
+	return ds
 }

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -172,7 +172,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	routeagentDaemonSet, err := r.reconcileRouteagentDaemonSet(ctx, instance, reqLogger)
+	routeagentDaemonSet, err := r.reconcileRouteagentDaemonSet(ctx, instance, clusterNetwork, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
With OVN IC CNI 3 kind of deployment are possible

1)SIngle Zone (Or in non-ic deployment)

This is similar to the current deployment. Here a OVN Kubernetes db service will be running and it will be passed by submariner-operator to the routeagent/network plugin syncer code.

2)MultiZone and more than one node per zone.

In this case there will be no OVN db service will be present. But there will be an endpoint per zone. Submariner operator will pass the comma separated list of IP Port and protocol and the endpoint name to the route agent and networkpluginsyncer. The pod will chose one of them depending on the zone it is running

3)Multizone , one node per zone.

For this deployment there will be no service or endpoints. Submariner-Operator will pass the value local. The pods needs to use socket connection to program ovn.

Fixes: https://github.com/submariner-io/enhancements/issues/191

This PR also passed the NBDB and SBDB values to the submariner-route agent daemon set as route agent will be now responsible for programming the OVN routes and policies.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
