### PR TITLE
Use the metricsproxy script

### DIFF
--- a/controllers/submariner/metrics_proxy_resources.go
+++ b/controllers/submariner/metrics_proxy_resources.go
@@ -91,7 +91,7 @@ func metricProxyContainer(cr *v1alpha1.Submariner, name, hostPort, podPort strin
 				},
 			}},
 		},
-		Command: []string{"/usr/bin/nc"},
-		Args:    []string{"-v", "-lk", "-p", hostPort, "-e", "nc", "$(NODE_IP)", podPort},
+		Command: []string{"/app/metricsproxy"},
+		Args:    []string{hostPort, "$(NODE_IP)", podPort},
 	}
 }


### PR DESCRIPTION
Instead of hard-coding arguments to nc, this uses the metricsproxy script to implement the metrics proxy.

Fixes: #2734

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
