### PR TITLE
Fix operator ClusterRole permissions

### DIFF
--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -76,3 +76,10 @@ rules:
       - daemonsets
     verbs:
       - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - delete

--- a/config/rbac/submariner-operator/role.yaml
+++ b/config/rbac/submariner-operator/role.yaml
@@ -25,13 +25,6 @@ rules:
     verbs:
       - delete
   - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-      - clusterrolebindings
-    verbs:
-      - delete
-  - apiGroups:
       - apps
     resources:
       - deployments

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2520,13 +2520,6 @@ rules:
     verbs:
       - delete
   - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-      - clusterrolebindings
-    verbs:
-      - delete
-  - apiGroups:
       - apps
     resources:
       - deployments
@@ -2660,6 +2653,13 @@ rules:
       - daemonsets
     verbs:
       - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - delete
 `
 	Config_rbac_submariner_operator_cluster_role_binding_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
`ClusterRole` and `ClusterRoleBinding` delete permissions were recently added to the operator `Role` but they need to be in the operator `ClusterRole`.
