### PR TITLE
Drop the networkplugin-syncer system test

### DIFF
--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -99,8 +99,6 @@ function verify_subm_deployed() {
     if [[ "$GLOBALNET" == true ]]; then
         verify_daemonset submariner-globalnet
     fi
-
-    verify_network_plugin_syncer
 }
 
 # Uses `jq` to extract the content using the filter given, and matches it to the expected value
@@ -458,17 +456,6 @@ function verify_subm_broker_secrets() {
 function verify_subm_gateway_secrets() {
   # FIXME: There seems to be a strange error where the CA substantially match, but eventually actually are different
   verify_secrets "$subm_ns" "$operator_deployment_name" "${SUBMARINER_BROKER_CA:0:50}"
-}
-
-function verify_network_plugin_syncer {
-   # Verify service account
-  kubectl get sa --namespace=$subm_ns submariner-networkplugin-syncer
-
-  # Verify cluster reole
-  kubectl get clusterrole submariner-networkplugin-syncer
-
-  # Verify cluster role binding
-  kubectl get clusterrolebinding submariner-networkplugin-syncer
 }
 
 function deploy_env_once() {


### PR DESCRIPTION
networkplugin-syncer is no longer deployed so the test always fails and is irrelevant.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
