### PR TITLE
Fix the bundle build following networkplugin-syncer removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ kustomization: $(OPERATOR_SDK) $(KUSTOMIZE) is-semantic-version manifests
 
 # Generate bundle manifests and metadata, then validate generated files
 bundle: $(KUSTOMIZE) $(OPERATOR_SDK) kustomization
-	($(KUSTOMIZE) build $(KUSTOMIZE_BASE_PATH) \
+	(set -o pipefail; $(KUSTOMIZE) build $(KUSTOMIZE_BASE_PATH) \
 	| $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS))
 	(cd config/bundle && $(KUSTOMIZE) edit add resource ../../bundle/manifests/submariner.clusterserviceversion.yaml)
 	$(KUSTOMIZE) build config/bundle/ --load_restrictor=LoadRestrictionsNone --output bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: submariners.submariner.io
 spec:
   group: submariner.io

--- a/config/manifests/bases/submariner.clusterserviceversion.yaml
+++ b/config/manifests/bases/submariner.clusterserviceversion.yaml
@@ -314,6 +314,10 @@ spec:
         path: serviceCIDR
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The image version in use by the various Submariner DaemonSets
+          and Deployments.
+        displayName: Version
+        path: version
       version: v1alpha1
   description: |
     [Submariner](https://submariner.io) enables direct networking between Pods and Services in different Kubernetes

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -45,11 +45,6 @@ resources:
   - lighthouse-coredns/cluster_role_binding.yaml
   - lighthouse-coredns/ocp_cluster_role.yaml
   - lighthouse-coredns/ocp_cluster_role_binding.yaml
-  - networkplugin_syncer/service_account.yaml
-  - networkplugin_syncer/cluster_role.yaml
-  - networkplugin_syncer/cluster_role_binding.yaml
-  - networkplugin_syncer/ocp_cluster_role.yaml
-  - networkplugin_syncer/ocp_cluster_role_binding.yaml
 # - leader_election/leader_election_role.yaml
 # - leader_election/leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable


### PR DESCRIPTION
See individual commits for details. This fixes the bundle build, and fixes the `Makefile` so that future errors of this kind fail the build in CI.