### PR TITLE
Uninstall npsyncer before deletion

### DIFF
--- a/controllers/submariner/np_syncer_resources.go
+++ b/controllers/submariner/np_syncer_resources.go
@@ -20,23 +20,42 @@ package submariner
 
 import (
 	"context"
+	"time"
 
+	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	"github.com/submariner-io/submariner-operator/controllers/uninstall"
 	"github.com/submariner-io/submariner/pkg/cni"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const NetworkPluginSyncerComponent = "submariner-networkplugin-syncer"
 
 //nolint:wrapcheck // No need to wrap errors here.
-func (r *Reconciler) removeNetworkPluginSyncerDeployment(ctx context.Context, instance *v1alpha1.Submariner) error {
+func (r *Reconciler) removeNetworkPluginSyncerDeployment(ctx context.Context, instance *v1alpha1.Submariner) (reconcile.Result, error) {
 	if instance.Status.NetworkPlugin != cni.OVNKubernetes || r.networkPluginSyncerRemoved {
-		return nil
+		return reconcile.Result{}, nil
+	}
+
+	if !r.networkPluginSyncerUninstalled {
+		requeue, err := r.uninstallNetworkPluginSyncerDeployment(ctx, instance)
+
+		if err != nil && !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		if requeue {
+			return reconcile.Result{RequeueAfter: time.Millisecond * 500}, err
+		}
+
+		r.networkPluginSyncerUninstalled = true
 	}
 
 	r.networkPluginSyncerRemoved = true
@@ -56,7 +75,7 @@ func (r *Reconciler) removeNetworkPluginSyncerDeployment(ctx context.Context, in
 		return nil
 	}
 
-	return deleteAll(
+	return reconcile.Result{}, deleteAll(
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: instance.Namespace,
@@ -94,4 +113,88 @@ func (r *Reconciler) removeNetworkPluginSyncerDeployment(ctx context.Context, in
 			},
 		},
 	)
+}
+
+//nolint:wrapcheck // No need to wrap errors here.
+func (r *Reconciler) uninstallNetworkPluginSyncerDeployment(ctx context.Context, instance *v1alpha1.Submariner) (bool, error) {
+	if r.uninstallNPSyncerDeployment != nil {
+		return false, nil
+	}
+
+	npDeployment := &appsv1.Deployment{}
+
+	err := r.config.ScopedClient.Get(ctx, types.NamespacedName{
+		Namespace: instance.Namespace, Name: names.NetworkPluginSyncerComponent,
+	}, npDeployment)
+	if err != nil {
+		return false, err
+	}
+
+	npDeployment = networkPluginSyncerUninstallDeployment(npDeployment)
+	r.uninstallNPSyncerDeployment = npDeployment
+
+	component := []*uninstall.Component{
+		{
+			Resource:          newDeployment(names.NetworkPluginSyncerComponent, instance.Namespace),
+			UninstallResource: npDeployment,
+			CheckInstalled:    func() bool { return true },
+		},
+	}
+
+	uninstallInfo := &uninstall.Info{
+		Client:     r.config.ScopedClient,
+		Components: component,
+		StartTime:  time.Now(),
+		Log:        log,
+		GetImageInfo: func(imageName, componentName string) (string, corev1.PullPolicy) {
+			container := npDeployment.Spec.Template.Spec.Containers[0]
+			return container.Image, container.ImagePullPolicy
+		},
+	}
+
+	requeue, _, err := uninstallInfo.Run(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if requeue {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func networkPluginSyncerUninstallDeployment(oldDeployment *appsv1.Deployment) *appsv1.Deployment {
+	name := oldDeployment.Name + "-uninstall"
+	labels := map[string]string{
+		"app":       name,
+		"component": "networkplugin-syncer",
+	}
+	networkPluginSyncerDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: oldDeployment.Namespace,
+			Name:      name,
+			Labels:    labels,
+		},
+	}
+	networkPluginSyncerDeployment.Spec = oldDeployment.Spec
+	networkPluginSyncerDeployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{
+		"app": name,
+	}}
+
+	networkPluginSyncerDeployment.Spec.Template.SetLabels(labels)
+	networkPluginSyncerDeployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
+
+	return networkPluginSyncerDeployment
+}
+
+func newDeployment(name, namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
 }


### PR DESCRIPTION
As part of upgrade of OVN from non-IC to IC, submariner is upgraded before OVN/OCP. To cleanup routes and flows installed by NP Syncer, run uninstall before deletion.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
