### PR TITLE
Remove OVN db discovery code from submariner-operator

### DIFF
--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -34,7 +34,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - get
       - list

--- a/controllers/submariner/cleanup.go
+++ b/controllers/submariner/cleanup.go
@@ -47,7 +47,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 	}
 
 	// This has the side effect of setting the CIDRs in the Submariner instance.
-	clusterNetwork, err := r.discoverNetwork(ctx, instance, log)
+	_, err := r.discoverNetwork(ctx, instance, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -59,7 +59,7 @@ func (r *Reconciler) runComponentCleanup(ctx context.Context, instance *operator
 		},
 		{
 			Resource:          newDaemonSet(names.RouteAgentComponent, instance.Namespace),
-			UninstallResource: newRouteAgentDaemonSet(instance, clusterNetwork, opnames.AppendUninstall(names.RouteAgentComponent)),
+			UninstallResource: newRouteAgentDaemonSet(instance, opnames.AppendUninstall(names.RouteAgentComponent)),
 		},
 		{
 			Resource:          newDaemonSet(names.GlobalnetComponent, instance.Namespace),

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -26,7 +26,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/controllers/apply"
-	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,13 +37,13 @@ import (
 
 //nolint:wrapcheck // No need to wrap errors here.
 func (r *Reconciler) reconcileRouteagentDaemonSet(ctx context.Context, instance *v1alpha1.Submariner,
-	clusterNetwork *network.ClusterNetwork, reqLogger logr.Logger,
+	reqLogger logr.Logger,
 ) (*appsv1.DaemonSet, error) {
-	return apply.DaemonSet(ctx, instance, newRouteAgentDaemonSet(instance, clusterNetwork, names.RouteAgentComponent),
+	return apply.DaemonSet(ctx, instance, newRouteAgentDaemonSet(instance, names.RouteAgentComponent),
 		reqLogger, r.config.ScopedClient, r.config.Scheme)
 }
 
-func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, clusterNetwork *network.ClusterNetwork, name string) *appsv1.DaemonSet {
+func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonSet {
 	labels := map[string]string{
 		"app":       name,
 		"component": "routeagent",
@@ -139,20 +138,6 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, clusterNetwork *network.Clu
 				},
 			},
 		},
-	}
-
-	if ovndb, ok := clusterNetwork.PluginSettings[network.OvnNBDB]; ok {
-		ds.Spec.Template.Spec.Containers[0].Env = append(
-			ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-				Name: network.OvnNBDB, Value: ovndb,
-			})
-	}
-
-	if ovnsb, ok := clusterNetwork.PluginSettings[network.OvnSBDB]; ok {
-		ds.Spec.Template.Spec.Containers[0].Env = append(
-			ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-				Name: network.OvnSBDB, Value: ovnsb,
-			})
 	}
 
 	return ds

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -156,7 +156,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	initialStatus := instance.Status.DeepCopy()
 
-	clusterNetwork, err := r.discoverNetwork(ctx, instance, reqLogger)
+	// This has the side effect of setting the CIDRs in the Submariner instance.
+	_, err = r.discoverNetwork(ctx, instance, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -174,7 +175,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	routeagentDaemonSet, err := r.reconcileRouteagentDaemonSet(ctx, instance, clusterNetwork, reqLogger)
+	routeagentDaemonSet, err := r.reconcileRouteagentDaemonSet(ctx, instance, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -49,27 +49,7 @@ func discoverOpenShift4Network(ctx context.Context, client controllerClient.Clie
 		return nil, errors.WithMessage(err, "error obtaining the default 'cluster' OpenShift4 Network config resource")
 	}
 
-	clusterNetwork, err := parseOS4Network(network)
-	if err != nil {
-		return nil, err
-	}
-
-	if clusterNetwork.NetworkPlugin == cni.OVNKubernetes {
-		ovnDBPod, err := FindPod(ctx, client, "name=ovnkube-db")
-		if err != nil {
-			return nil, err
-		}
-
-		if ovnDBPod == nil {
-			// IC is enabled and Openshift uses zone per node and to connect to OVN DB using
-			// socket connection we need to use this path.
-			clusterNetwork.PluginSettings = map[string]string{
-				OvnNBDB: "unix:/var/run/ovn-ic/ovnnb_db.sock",
-			}
-		}
-	}
-
-	return clusterNetwork, err
+	return parseOS4Network(network)
 }
 
 func parseOS4Network(cr *unstructured.Unstructured) (*ClusterNetwork, error) {

--- a/pkg/discovery/network/ovnkubernetes_test.go
+++ b/pkg/discovery/network/ovnkubernetes_test.go
@@ -20,7 +20,6 @@ package network_test
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,18 +33,7 @@ import (
 const ovnKubeNamespace = "ovn-kubernetes"
 
 var _ = Describe("OvnKubernetes Network", func() {
-	const ovnKubeSvcTest = "ovnkube-db"
-
-	When("ovn-kubernetes database is found, but no database service", func() {
-		It("Should return error", func() {
-			clusterNet, err := testOvnKubernetesDiscoveryWith(
-				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
-			)
-
-			Expect(err).To(HaveOccurred())
-			Expect(clusterNet).To(BeNil())
-		})
-	})
+	const ovnKubeSvcTest = "ovnkube-node"
 
 	When("ovn-kubernetes database and service found, no configmap", func() {
 		It("Should return cluster network with default CIDRs", func() {
@@ -57,9 +45,6 @@ var _ = Describe("OvnKubernetes Network", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(clusterNet).NotTo(BeNil())
 			Expect(clusterNet.NetworkPlugin).To(Equal(cni.OVNKubernetes))
-			connectionStr := fmt.Sprintf("tcp:%s.%s", ovnKubeSvcTest, ovnKubeNamespace)
-			Expect(clusterNet.PluginSettings["OVN_NBDB"]).To(Equal(connectionStr + ":6641"))
-			Expect(clusterNet.PluginSettings["OVN_SBDB"]).To(Equal(connectionStr + ":6642"))
 			Expect(clusterNet.PodCIDRs).To(BeEmpty())
 			Expect(clusterNet.ServiceCIDRs).To(HaveLen(1))
 		})

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2611,7 +2611,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - get
       - list


### PR DESCRIPTION
Remove OVN db discovery code from submariner-operator. This code was moved to route-agent https://github.com/submariner-io/submariner/pull/2662
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
