### PR TITLE
Automated backport of #2769: Improve calico CNI detection

### DIFF
--- a/pkg/discovery/network/calico.go
+++ b/pkg/discovery/network/calico.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner/pkg/cni"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,23 +31,19 @@ import (
 
 //nolint:nilnil // Intentional as the purpose is to discover.
 func discoverCalicoNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
-	cmList := &corev1.ConfigMapList{}
-
-	err := client.List(ctx, cmList, controllerClient.InNamespace(metav1.NamespaceAll))
+	found, err := calicoConfigMapExists(ctx, client)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error listing ConfigMaps")
+		return nil, err
 	}
 
-	findCalicoConfigMap := false
-
-	for i := range cmList.Items {
-		if cmList.Items[i].Name == "calico-config" {
-			findCalicoConfigMap = true
-			break
+	if !found {
+		found, err = calicoDaemonSetExists(ctx, client)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	if !findCalicoConfigMap {
+	if !found {
 		return nil, nil
 	}
 
@@ -61,4 +58,38 @@ func discoverCalicoNetwork(ctx context.Context, client controllerClient.Client) 
 	}
 
 	return nil, nil
+}
+
+func calicoConfigMapExists(ctx context.Context, client controllerClient.Client) (bool, error) {
+	cmList := &corev1.ConfigMapList{}
+
+	err := client.List(ctx, cmList, controllerClient.InNamespace(metav1.NamespaceAll))
+	if err != nil {
+		return false, errors.Wrapf(err, "error listing ConfigMaps")
+	}
+
+	for i := range cmList.Items {
+		if cmList.Items[i].Name == "calico-config" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func calicoDaemonSetExists(ctx context.Context, client controllerClient.Client) (bool, error) {
+	dsList := &v1.DaemonSetList{}
+
+	err := client.List(ctx, dsList, controllerClient.InNamespace(metav1.NamespaceAll))
+	if err != nil {
+		return false, errors.Wrapf(err, "error listing DaemonSets")
+	}
+
+	for i := range dsList.Items {
+		if dsList.Items[i].Name == "calico-node" {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
Backport of #2769 on release-0.15.

#2769: Improve calico CNI detection

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.