### PR TITLE
Automated backport of #2770: Improve podCIDR detection

### DIFF
--- a/pkg/discovery/network/generic.go
+++ b/pkg/discovery/network/generic.go
@@ -191,10 +191,11 @@ func findPodIPRangeFromNodeSpec(ctx context.Context, client controllerClient.Cli
 }
 
 func parseToPodCidr(nodes []corev1.Node) (string, error) {
-	for i := range nodes {
-		if nodes[i].Spec.PodCIDR != "" {
-			return nodes[i].Spec.PodCIDR, nil
-		}
+	// In K8s, each node is typically assigned a unique PodCIDR range for the pods that run on that node.
+	// Each node's PodCIDR is used to allocate IP addresses to the pods scheduled on that node. Only if
+	// the cluster is a single node deployment, we should rely on the node.Spec.PodCIDR as podCIDR of the cluster.
+	if len(nodes) == 1 {
+		return nodes[0].Spec.PodCIDR, nil
 	}
 
 	return "", nil

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -222,13 +222,12 @@ var _ = Describe("Generic Network", func() {
 		})
 	})
 
-	When("Pod CIDR information exists on a node", func() {
+	When("Pod CIDR information exists on a single node cluster", func() {
 		var clusterNet *network.ClusterNetwork
 
 		BeforeEach(func() {
 			clusterNet = testDiscoverGenericWith(
-				fakeNode("node1", ""),
-				fakeNode("node2", testPodCIDR),
+				fakeNode("node1", testPodCIDR),
 			)
 		})
 
@@ -242,6 +241,21 @@ var _ = Describe("Generic Network", func() {
 
 		It("Should return the ClusterNetwork structure with the service CIDR", func() {
 			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDRFromService}))
+		})
+	})
+
+	When("Pod CIDR information exists on a multi node cluster", func() {
+		var clusterNet *network.ClusterNetwork
+
+		BeforeEach(func() {
+			clusterNet = testDiscoverGenericWith(
+				fakeNode("node1", testPodCIDR),
+				fakeNode("node2", testPodCIDR),
+			)
+		})
+
+		It("Should return an empty ClusterNetwork structure with the pod CIDR", func() {
+			Expect(clusterNet.PodCIDRs).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
Backport of #2770 on release-0.15.

#2770: Improve podCIDR detection

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.