### PR TITLE
Ignore the controller version in generated files

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -180,4 +180,4 @@ jobs:
       - name: Run make pkg/embeddedyamls/yamls.go to update embedded YAMLs
         run: make pkg/embeddedyamls/yamls.go
       - name: Validate that nothing has changed
-        run: git add -A && git diff --staged --exit-code -- pkg/embeddedyamls
+        run: git add -A && git diff -Icontroller-gen.kubebuilder.io/version --staged --exit-code -- pkg/embeddedyamls


### PR DESCRIPTION
When checking for changes to files generated by controller-tools, ignore the field indicating the version of the generator. If nothing else changes, we don't care about the version used to generate the files.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
