### PR TITLE
Create xtables.lock as a file if it doesn't already exist

### DIFF
--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -72,7 +72,7 @@ func newGlobalnetDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonS
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/run/xtables.lock",
+							Path: "/run/xtables.lock", Type: ptr.To(corev1.HostPathFileOrCreate),
 						}}},
 					},
 					Containers: []corev1.Container{

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -75,7 +75,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 					Volumes: []corev1.Volume{
 						// We need to share /run/xtables.lock with the host for iptables
 						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/run/xtables.lock",
+							Path: "/run/xtables.lock", Type: ptr.To(corev1.HostPathFileOrCreate),
 						}}},
 						// We need to share /run/openvswitch/db.sock with the host for OVS
 						{Name: "host-run-openvswitch-db-sock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{


### PR DESCRIPTION
Default host path mounts create a directory if the mounted path doesn't correspond to anything, which ends up breaking iptables. This fixes that by ensuring that xtables.lock is created as a file if it doesn't already exist; subsequent invocations of iptables on the host (if any) will then be able to use the new file for locking.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
