### PR TITLE
Qualify the /lib/modules host path mount

### DIFF
--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -99,7 +99,9 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 	volumes := []corev1.Volume{
 		{Name: "ipsecd", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "ipsecnss", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-		{Name: "libmodules", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/lib/modules"}}},
+		{Name: "libmodules", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+			Path: "/lib/modules", Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+		}}},
 	}
 
 	if cr.Spec.BrokerK8sSecret != "" {


### PR DESCRIPTION
/lib/modules is expected to exist and be a directory, so the current default for host paths (create a directory if it doesn't exist) works; but qualifying explicitly avoids any confusion.

Strictly speaking we could assert that /lib/modules must exist, but we don't really care if it doesn't, so it seems better to create it if it's not there instead of preventing the container from being created.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
