### PR TITLE
Automated backport of #2837: Add lease RBAC permissions for globalnet

### DIFF
--- a/config/rbac/submariner-globalnet/role.yaml
+++ b/config/rbac/submariner-globalnet/role.yaml
@@ -60,3 +60,14 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3165,6 +3165,17 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 `
 	Config_rbac_submariner_globalnet_role_binding_yaml = `---
 kind: RoleBinding


### PR DESCRIPTION
Backport of #2837 on release-0.16.

#2837: Add lease RBAC permissions for globalnet

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.