### PR TITLE
Ensure that ovn-ic/ovnnb_db.sock is created as a file

### DIFF
--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -89,7 +89,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 						}}},
 						// Path used by Openshift
 						{Name: "host-var-run-ovn-ic-nbdb-sock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/run/ovn-ic/ovnnb_db.sock",
+							Path: "/var/run/ovn-ic/ovnnb_db.sock", Type: ptr.To(corev1.HostPathFileOrCreate),
 						}}},
 					},
 					// The route agent needs to wait for the node to be ready before starting,


### PR DESCRIPTION
Apply fix similar to [1] for ovn-ic/ovnnb_db.sock

[1]
https://github.com/submariner-io/submariner-operator/commit/93f8d3aa66f1c2f898ef4c6a7a6644fa7a6bf956

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
