### PR TITLE
Reduce string constant duplication

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,3 +191,8 @@ issues:
     - path: pkg/metrics/service-monitor.go
       linters:
         - goheader
+
+    # Ignore duplicate strings in generated code
+    - path: pkg/embeddedyamls/yamls.go
+      linters:
+        - goconst

--- a/pkg/discovery/network/calico_test.go
+++ b/pkg/discovery/network/calico_test.go
@@ -78,8 +78,8 @@ var _ = Describe("Calico Network", func() {
 		JustBeforeEach(func() {
 			initObjs = []client.Object{
 				calicoCfgMap,
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []v1.EnvVar{}),
-				fakePod("kube-controller-manager", []string{"kube-controller-manager", "--cluster-cidr=" + testPodCIDR}, []v1.EnvVar{}),
+				fakeKubeAPIServerPod(),
+				fakeKubeControllerManagerPod(),
 			}
 
 			client := newTestClient(initObjs...)

--- a/pkg/discovery/network/canal_test.go
+++ b/pkg/discovery/network/canal_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Canal Flannel Network", func() {
 		It("Should return the ClusterNetwork structure with the pod CIDR and the service CIDR", func() {
 			clusterNet := testDiscoverWith(
 				&canalFlannelCfgMap,
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []v1.EnvVar{}),
+				fakeKubeAPIServerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 			Expect(clusterNet.NetworkPlugin).To(Equal(cni.CanalFlannel))

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Generic Network", func() {
 
 		BeforeEach(func() {
 			clusterNet = testDiscoverGenericWith(
-				fakePod("kube-controller-manager", []string{"kube-controller-manager", "--cluster-cidr=" + testPodCIDR}, []corev1.EnvVar{}),
+				fakeKubeControllerManagerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})
@@ -137,7 +137,7 @@ var _ = Describe("Generic Network", func() {
 
 		BeforeEach(func() {
 			clusterNet = testDiscoverGenericWith(
-				fakePod("kube-proxy", []string{"kube-proxy", "--cluster-cidr=" + testPodCIDR}, []corev1.EnvVar{}),
+				fakeKubeProxyPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})
@@ -160,7 +160,7 @@ var _ = Describe("Generic Network", func() {
 
 		BeforeEach(func() {
 			clusterNet = testDiscoverGenericWith(
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []corev1.EnvVar{}),
+				fakeKubeAPIServerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})
@@ -183,8 +183,8 @@ var _ = Describe("Generic Network", func() {
 
 		BeforeEach(func() {
 			clusterNet = testDiscoverGenericWith(
-				fakePod("kube-proxy", []string{"kube-proxy", "--cluster-cidr=" + testPodCIDR}, []corev1.EnvVar{}),
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []corev1.EnvVar{}),
+				fakeKubeProxyPod(),
+				fakeKubeAPIServerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})
@@ -265,7 +265,7 @@ var _ = Describe("Generic Network", func() {
 		BeforeEach(func() {
 			clusterNet = testDiscoverGenericWith(
 				fakeNode("node1", testPodCIDR),
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []corev1.EnvVar{}),
+				fakeKubeAPIServerPod(),
 			)
 		})
 

--- a/pkg/discovery/network/kindnet_test.go
+++ b/pkg/discovery/network/kindnet_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Kindnet CNI", func() {
 		BeforeEach(func() {
 			clusterNet = testDiscoverNetwork(
 				fakePod("kindnet", []string{"kindnet"}, []v1.EnvVar{{Name: "POD_SUBNET", Value: testPodCIDR}}),
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []v1.EnvVar{}),
+				fakeKubeAPIServerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})

--- a/pkg/discovery/network/network_suite_test.go
+++ b/pkg/discovery/network/network_suite_test.go
@@ -59,6 +59,18 @@ func fakePodWithNamespace(namespace, name, component string, command []string, e
 	}
 }
 
+func fakeKubeAPIServerPod() *v1.Pod {
+	return fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []v1.EnvVar{})
+}
+
+func fakeKubeControllerManagerPod() *v1.Pod {
+	return fakePod("kube-controller-manager", []string{"kube-controller-manager", "--cluster-cidr=" + testPodCIDR}, []v1.EnvVar{})
+}
+
+func fakeKubeProxyPod() *v1.Pod {
+	return fakePod("kube-proxy", []string{"kube-proxy", "--cluster-cidr=" + testPodCIDR}, []v1.EnvVar{})
+}
+
 func fakeService(namespace, name, component string) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: v1meta.ObjectMeta{

--- a/pkg/discovery/network/weavenet_test.go
+++ b/pkg/discovery/network/weavenet_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Weave Network", func() {
 		BeforeEach(func() {
 			clusterNet = testDiscoverNetwork(
 				fakePod("weave-net", []string{"weave-net"}, []v1.EnvVar{{Name: "IPALLOC_RANGE", Value: testPodCIDR}}),
-				fakePod("kube-apiserver", []string{"kube-apiserver", "--service-cluster-ip-range=" + testServiceCIDR}, []v1.EnvVar{}),
+				fakeKubeAPIServerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})


### PR DESCRIPTION
Newer versions of goconst detect more instances of string duplication. Address that by providing pod construction functions for common pods (API server, controller manager, proxy). Disable goconst on the generated embedded YAMLs file (it doesn't seem useful to avoid string duplication there).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
