### PR TITLE
Remove release-notes files

### DIFF
--- a/release-notes/20220216-flannel-cni.md
+++ b/release-notes/20220216-flannel-cni.md
@@ -1,2 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-The flannel CNI is now properly identified during join.

--- a/release-notes/20220808-ra-gw-privs.md
+++ b/release-notes/20220808-ra-gw-privs.md
@@ -1,3 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Privileges of the Route Agent and Gateway pods were reduced as they don’t need to access
-persistentvolumeclaims and secrets.

--- a/release-notes/20220908-metrics-proxy.md
+++ b/release-notes/20220908-metrics-proxy.md
@@ -1,6 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Users no longer need to open ports `8080` and `8081` on the host for querying metrics. A new `submariner-metrics-proxy`
-DaemonSet runs pods on gateway nodes and forwards http requests for metrics services to gateway and globalnet pods running
-on the nodes. Gateway and Globalnet pods now listen on ports `32780` and `32781` instead of well known ports `8080` and
-`8081` to avoid conflict with any other services that might be using those ports. Users will continue to query existing
-`submariner-gateway-metrics` and `submariner-globalnet-metrics` services to query the metrics.


### PR DESCRIPTION
We're no longer checking in such files to the projects, also once the notes were merged into the web-site doc, the files no longer serve any purpose.
