### PR TITLE
Backport: enable Calico IPPools deletecollection in RouteAgent RBAC

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -72,3 +72,4 @@ rules:
       - create
       - delete
       - update
+      - deletecollection

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3061,6 +3061,7 @@ rules:
       - create
       - delete
       - update
+      - deletecollection
 `
 	Config_rbac_submariner_route_agent_cluster_role_binding_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
When Submariner is uninstalled the Calico IPPools
are deleted using DeleteCollection command.

Orig PR: https://github.com/submariner-io/submariner-operator/pull/2856

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
