### PR TITLE
Automated backport of #2863: Make HaltOnCertificateError optional

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -172,7 +172,7 @@ type SubmarinerSpec struct {
 	// Halt on certificate error (so the pod gets restarted).
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Halt (and restart) on certificate error"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	HaltOnCertificateError bool `json:"haltOnCertificateError"`
+	HaltOnCertificateError bool `json:"haltOnCertificateError,omitempty"`
 
 	// Name of the custom CoreDNS configmap to configure forwarding to Lighthouse.
 	// It should be in <namespace>/<name> format where <namespace> is optional and defaults to kube-system.

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -300,7 +300,6 @@ spec:
             - clusterCIDR
             - clusterID
             - debug
-            - haltOnCertificateError
             - namespace
             - natEnabled
             - serviceCIDR


### PR DESCRIPTION
Backport of #2863 on release-0.16.

#2863: Make HaltOnCertificateError optional

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.