### PR TITLE
Override the ImageMagick license detection

### DIFF
--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -15,18 +15,7 @@ allow:
   - "PostgreSQL"
   - "X11"
   - "Zlib"
-  - "ImageMagick"
 
 override:
-  - path: "./api"
-    licenses: ["Apache-2.0"]
-  - path: "github.com/rdegges/go-ipify"
-    licenses: ["Unlicense"]
-  - path: "github.com/docker/spdystream"
-    licenses: ["Apache-2.0"]
-
-# https://github.com/cncf/foundation/tree/master/license-exceptions
-exceptions:
-  licenseNotPermitted:
-    - path: "github.com/hashicorp/golang-lru"
-      licenses: ["MPL-2.0"]
+  - path: "sigs.k8s.io/yaml"
+    licenses: ["Apache-2.0", "MIT"]


### PR DESCRIPTION
Instead of adding a blanket approval for the ImageMagick license (which technically can't be done without CNCF approval), override the detected licenses for sigs.k8s.io/yaml.

The golang-lru exception is no longer needed, remove it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
