### PR TITLE
Revert to default mount behaviour for xtables.lock

### DIFF
--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -72,7 +72,7 @@ func newGlobalnetDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonS
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/run/xtables.lock", Type: ptr.To(corev1.HostPathFileOrCreate),
+							Path: "/run/xtables.lock",
 						}}},
 					},
 					Containers: []corev1.Container{

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -75,7 +75,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 					Volumes: []corev1.Volume{
 						// Share /run/xtables.lock with the host for iptables
 						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/run/xtables.lock", Type: ptr.To(corev1.HostPathFileOrCreate),
+							Path: "/run/xtables.lock",
 						}}},
 						// Share /run/openvswitch/db.sock and /run/openvswitch/ovnnb_db.sock with the host for OVS/OVN
 						{Name: "host-run-openvswitch", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{


### PR DESCRIPTION
The xtables.lock mount was fixed to specify its type: it must exist as a file, or be created as a file.

xtables.lock is only used with legacy iptables. On platforms using iptables-nft, the file isn't used and doesn't exist. As a result, previous versions of Submariner created it as a directory (this is the default behaviour for volume mounts in Kubernetes: if the mount doesn't exist, it is created as a directory). When the volume mount type is specified as a file, the existence of a directory causes the mount to fail and the corresponding pod is never scheduled.

To avoid this, revert to the default behaviour. On systems where the lock is important, it already exists so the directory isn't created and the correct behaviour is guaranteed. On systems where the lock isn't needed, it is created as a directory but that doesn't matter.

Future releases of Submariner will have to deal with this correctly, and handle upgrades, ideally without mounting all of /run permanently.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
