### PR TITLE
Automated backport of #2889: Revert "Create xtables.lock as a file if it doesn't already

### DIFF
--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -72,7 +72,7 @@ func newGlobalnetDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonS
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/run/xtables.lock", Type: ptr.To(corev1.HostPathFileOrCreate),
+							Path: "/run/xtables.lock",
 						}}},
 					},
 					Containers: []corev1.Container{

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -75,7 +75,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 					Volumes: []corev1.Volume{
 						// Share /run/xtables.lock with the host for iptables
 						{Name: "host-run-xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-							Path: "/run/xtables.lock", Type: ptr.To(corev1.HostPathFileOrCreate),
+							Path: "/run/xtables.lock",
 						}}},
 						// Share /run/openvswitch/db.sock and /run/openvswitch/ovnnb_db.sock with the host for OVS/OVN
 						{Name: "host-run-openvswitch", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{


### PR DESCRIPTION
Backport of #2889 on release-0.16.

#2889: Revert "Create xtables.lock as a file if it doesn't already

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.