### PR TITLE
Update K8s versions tested in E2E

### DIFF
--- a/.github/workflows/e2e-all-k8s.yml
+++ b/.github/workflows/e2e-all-k8s.yml
@@ -19,7 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.19', '1.24', '1.25', '1.26', '1.27']
+        # Top/bottom of supported version range. For details:
+        # https://submariner.io/development/building-testing/ci-maintenance/
+        k8s_version: ['1.26', '1.27', '1.28']
         lighthouse: ['', 'lighthouse']
         ovn: ['', 'ovn']
         exclude:

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.27']
+        k8s_version: ['1.28']
         lighthouse: ['', 'lighthouse']
         ovn: ['', 'ovn']
         exclude:
@@ -27,16 +27,8 @@ jobs:
           - ovn: 'ovn'
             globalnet: 'globalnet'
         include:
-          # Oldest Kubernetes version thought to work with SubM.
-          # This should match minK8sMajor.minK8sMinor in subctl/pkg/version/version.go.
-          # If this breaks, we may advance the minimum K8s version instead of fixing it. See:
-          # https://submariner.io/development/building-testing/ci-maintenance/
-          - k8s_version: '1.19'
-          # Run default E2E against all supported K8s versions
-          - k8s_version: '1.24'
-          - k8s_version: '1.25'
+          # Bottom of supported K8s version range
           - k8s_version: '1.26'
-          - k8s_version: '1.27'
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         cable_driver: ['libreswan', 'wireguard']
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.25']
+        # Run most tests against the latest K8s version
+        k8s_version: ['1.28']
         lighthouse: ['', 'lighthouse']
         include:
-          - k8s_version: '1.22'
-          - k8s_version: '1.23'
-          - k8s_version: '1.24'
+          # Bottom of supported K8s version range
+          - k8s_version: '1.26'
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
Add Kubernetes 1.28, remove end-of-life 1.24 and 1.25.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
