### PR TITLE
Use NewDynamicRESTMapper instead of NewDisoveryRESTMapper

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{namespace: {}},
 		},
-		MapperProvider: apiutil.NewDiscoveryRESTMapper,
+		MapperProvider: apiutil.NewDynamicRESTMapper,
 	})
 	if err != nil {
 		log.Error(err, "unable to start manager")


### PR DESCRIPTION
The latter isn't recommended and was removed by
https://github.com/kubernetes-sigs/controller-runtime/pull/2611 in controller-runtime _v0.17.0_.
