### PR TITLE
Automated backport of #2946: Add Makefile.shipyard to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ vendor/
 .shflags
 junit.xml
 Makefile.dapper
+Makefile.shipyard
 /Dockerfile.*
 


### PR DESCRIPTION
Backport of #2946 on release-0.17.

#2946: Add Makefile.shipyard to .gitignore

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.