### PR TITLE
Automated backport of #2958: Add support for Calico IPPools get

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -69,6 +69,7 @@ rules:
     resources:
       - ippools
     verbs:
+      - get
       - create
       - delete
       - update

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3148,6 +3148,7 @@ rules:
     resources:
       - ippools
     verbs:
+      - get
       - create
       - delete
       - update


### PR DESCRIPTION
Backport of #2958 on release-0.17.

#2958: Add support for Calico IPPools get

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.