### PR TITLE
Automated backport of #2979: Ignore helm CVE-2024-25620

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,3 +10,10 @@ ignore:
   - vulnerability: CVE-2021-22570
     package:
       name: google.golang.org/protobuf
+  # Fixing this CVE requires updating K8s et al to incompatible versions.
+  - vulnerability: GHSA-r53h-jv2g-vpx6
+    package:
+      name: helm.sh/helm/v3
+  - vulnerability: GHSA-v53g-5gjp-272r
+    package:
+      name: helm.sh/helm/v3


### PR DESCRIPTION
Backport of #2979 on release-0.15.

#2979: Ignore helm CVE-2024-25620

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.