### PR TITLE
Provide a cancellable context to tests

### DIFF
--- a/controllers/apply/apply_test.go
+++ b/controllers/apply/apply_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package apply_test
 
 import (
-	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -69,14 +68,14 @@ func testDaemonSet() {
 	})
 
 	When("the DaemonSet doesn't exist", func() {
-		It("should create it", func() {
-			actual, err := apply.DaemonSet(context.Background(), t.owner, daemonSet, log, t.client, scheme.Scheme)
+		It("should create it", func(ctx SpecContext) {
+			actual, err := apply.DaemonSet(ctx, t.owner, daemonSet, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(daemonSet))
 			t.verifyOwnerRef(actual)
 
 			actual = &appsv1.DaemonSet{}
-			Expect(t.client.Get(context.Background(), types.NamespacedName{
+			Expect(t.client.Get(ctx, types.NamespacedName{
 				Namespace: daemonSet.Namespace, Name: daemonSet.Name,
 			}, actual)).To(Succeed())
 			Expect(actual).To(Equal(daemonSet))
@@ -90,8 +89,8 @@ func testDaemonSet() {
 			daemonSet.Labels = map[string]string{"foo": "bar"}
 		})
 
-		It("should update it", func() {
-			actual, err := apply.DaemonSet(context.Background(), t.owner, daemonSet, log, t.client, scheme.Scheme)
+		It("should update it", func(ctx SpecContext) {
+			actual, err := apply.DaemonSet(ctx, t.owner, daemonSet, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(daemonSet))
 		})
@@ -107,8 +106,8 @@ func testDaemonSet() {
 					}}))
 			})
 
-			It("should re-create it", func() {
-				actual, err := apply.DaemonSet(context.Background(), t.owner, daemonSet, log, t.client, scheme.Scheme)
+			It("should re-create it", func(ctx SpecContext) {
+				actual, err := apply.DaemonSet(ctx, t.owner, daemonSet, log, t.client, scheme.Scheme)
 				Expect(err).To(Succeed())
 				Expect(actual).To(Equal(daemonSet))
 			})
@@ -144,14 +143,14 @@ func testDeployment() {
 	})
 
 	When("the Deployment doesn't exist", func() {
-		It("should create it", func() {
-			actual, err := apply.Deployment(context.Background(), t.owner, deployment, log, t.client, scheme.Scheme)
+		It("should create it", func(ctx SpecContext) {
+			actual, err := apply.Deployment(ctx, t.owner, deployment, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(deployment))
 			t.verifyOwnerRef(actual)
 
 			actual = &appsv1.Deployment{}
-			Expect(t.client.Get(context.Background(), types.NamespacedName{
+			Expect(t.client.Get(ctx, types.NamespacedName{
 				Namespace: deployment.Namespace, Name: deployment.Name,
 			}, actual)).To(Succeed())
 			Expect(actual).To(Equal(deployment))
@@ -164,8 +163,8 @@ func testDeployment() {
 			deployment.Spec.MinReadySeconds = 20
 		})
 
-		It("should update it", func() {
-			actual, err := apply.Deployment(context.Background(), t.owner, deployment, log, t.client, scheme.Scheme)
+		It("should update it", func(ctx SpecContext) {
+			actual, err := apply.Deployment(ctx, t.owner, deployment, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(deployment))
 		})
@@ -188,14 +187,14 @@ func testConfigMap() {
 	})
 
 	When("the ConfigMap doesn't exist", func() {
-		It("should create it", func() {
-			actual, err := apply.ConfigMap(context.Background(), t.owner, configMap, log, t.client, scheme.Scheme)
+		It("should create it", func(ctx SpecContext) {
+			actual, err := apply.ConfigMap(ctx, t.owner, configMap, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(configMap))
 			t.verifyOwnerRef(actual)
 
 			actual = &corev1.ConfigMap{}
-			Expect(t.client.Get(context.Background(), types.NamespacedName{
+			Expect(t.client.Get(ctx, types.NamespacedName{
 				Namespace: configMap.Namespace, Name: configMap.Name,
 			}, actual)).To(Succeed())
 			Expect(actual).To(Equal(configMap))
@@ -208,8 +207,8 @@ func testConfigMap() {
 			configMap.Data = map[string]string{"key2": "value2"}
 		})
 
-		It("should update it", func() {
-			actual, err := apply.ConfigMap(context.Background(), t.owner, configMap, log, t.client, scheme.Scheme)
+		It("should update it", func(ctx SpecContext) {
+			actual, err := apply.ConfigMap(ctx, t.owner, configMap, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(configMap))
 		})
@@ -235,14 +234,14 @@ func testService() {
 	})
 
 	When("the Service doesn't exist", func() {
-		It("should create it", func() {
-			actual, err := apply.Service(context.Background(), t.owner, service, log, t.client, scheme.Scheme)
+		It("should create it", func(ctx SpecContext) {
+			actual, err := apply.Service(ctx, t.owner, service, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(service))
 			t.verifyOwnerRef(actual)
 
 			actual = &corev1.Service{}
-			Expect(t.client.Get(context.Background(), types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, actual)).To(Succeed())
+			Expect(t.client.Get(ctx, types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, actual)).To(Succeed())
 			Expect(actual).To(Equal(service))
 		})
 	})
@@ -254,8 +253,8 @@ func testService() {
 			service.Annotations = map[string]string{"foo1": "bar1"}
 		})
 
-		It("should update it", func() {
-			actual, err := apply.Service(context.Background(), t.owner, service, log, t.client, scheme.Scheme)
+		It("should update it", func(ctx SpecContext) {
+			actual, err := apply.Service(ctx, t.owner, service, log, t.client, scheme.Scheme)
 			Expect(err).To(Succeed())
 			Expect(actual).To(Equal(service))
 		})

--- a/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package servicediscovery_test
 
 import (
-	"context"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -42,8 +41,8 @@ var _ = Describe("Service discovery controller", func() {
 func testReconciliation() {
 	t := newTestDriver()
 
-	It("should add a finalizer to the ServiceDiscovery resource", func() {
-		_, _ = t.DoReconcile()
+	It("should add a finalizer to the ServiceDiscovery resource", func(ctx SpecContext) {
+		_, _ = t.DoReconcile(ctx)
 		t.awaitFinalizer()
 	})
 
@@ -53,10 +52,10 @@ func testReconciliation() {
 				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(""), newDNSService(clusterIP))
 			})
 
-			It("should add it", func() {
-				t.AssertReconcileSuccess()
+			It("should add it", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
 
-				assertDNSConfigServers(t.assertDNSConfig(), newDNSConfig(clusterIP))
+				assertDNSConfigServers(t.assertDNSConfig(ctx), newDNSConfig(clusterIP))
 			})
 		})
 
@@ -67,10 +66,10 @@ func testReconciliation() {
 				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(clusterIP), newDNSService(updatedClusterIP))
 			})
 
-			It("should update the lighthouse config", func() {
-				t.AssertReconcileSuccess()
+			It("should update the lighthouse config", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
 
-				assertDNSConfigServers(t.assertDNSConfig(), newDNSConfig(updatedClusterIP))
+				assertDNSConfigServers(t.assertDNSConfig(ctx), newDNSConfig(updatedClusterIP))
 			})
 		})
 
@@ -79,14 +78,14 @@ func testReconciliation() {
 				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(""))
 			})
 
-			It("should create the service and add the lighthouse config", func() {
-				t.AssertReconcileError()
+			It("should create the service and add the lighthouse config", func(ctx SpecContext) {
+				t.AssertReconcileError(ctx)
 
-				t.setLighthouseCoreDNSServiceIP()
+				t.setLighthouseCoreDNSServiceIP(ctx)
 
-				t.AssertReconcileSuccess()
+				t.AssertReconcileSuccess(ctx)
 
-				assertDNSConfigServers(t.assertDNSConfig(), newDNSConfig(clusterIP))
+				assertDNSConfigServers(t.assertDNSConfig(ctx), newDNSConfig(clusterIP))
 			})
 		})
 	})
@@ -98,10 +97,10 @@ func testReconciliation() {
 				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newCoreDNSConfigMap(coreDNSCorefileData("")))
 			})
 
-			It("should add it", func() {
-				t.AssertReconcileSuccess()
+			It("should add it", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
 
-				Expect(strings.TrimSpace(t.assertCoreDNSConfigMap().Data["Corefile"])).To(Equal(coreDNSCorefileData(clusterIP)))
+				Expect(strings.TrimSpace(t.assertCoreDNSConfigMap(ctx).Data["Corefile"])).To(Equal(coreDNSCorefileData(clusterIP)))
 			})
 		})
 
@@ -113,10 +112,10 @@ func testReconciliation() {
 				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newCoreDNSConfigMap(coreDNSCorefileData(clusterIP)))
 			})
 
-			It("should update the lighthouse config", func() {
-				t.AssertReconcileSuccess()
+			It("should update the lighthouse config", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
 
-				Expect(strings.TrimSpace(t.assertCoreDNSConfigMap().Data["Corefile"])).To(Equal(coreDNSCorefileData(updatedClusterIP)))
+				Expect(strings.TrimSpace(t.assertCoreDNSConfigMap(ctx).Data["Corefile"])).To(Equal(coreDNSCorefileData(updatedClusterIP)))
 			})
 		})
 
@@ -125,14 +124,14 @@ func testReconciliation() {
 				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newCoreDNSConfigMap(coreDNSCorefileData("")))
 			})
 
-			It("should create the service and add the lighthouse config", func() {
-				t.AssertReconcileError()
+			It("should create the service and add the lighthouse config", func(ctx SpecContext) {
+				t.AssertReconcileError(ctx)
 
-				t.setLighthouseCoreDNSServiceIP()
+				t.setLighthouseCoreDNSServiceIP(ctx)
 
-				t.AssertReconcileSuccess()
+				t.AssertReconcileSuccess(ctx)
 
-				Expect(strings.TrimSpace(t.assertCoreDNSConfigMap().Data["Corefile"])).To(Equal(coreDNSCorefileData(clusterIP)))
+				Expect(strings.TrimSpace(t.assertCoreDNSConfigMap(ctx).Data["Corefile"])).To(Equal(coreDNSCorefileData(clusterIP)))
 			})
 		})
 	})
@@ -158,10 +157,10 @@ func testReconciliation() {
 				})
 			})
 
-			It("should update it", func() {
-				t.AssertReconcileSuccess()
+			It("should update it", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
 
-				Expect(strings.TrimSpace(t.assertConfigMap(t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
+				Expect(strings.TrimSpace(t.assertConfigMap(ctx, t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
 					t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace).Data["lighthouse.server"])).To(Equal(
 					strings.ReplaceAll(lighthouseDNSConfigFormat, "$IP", clusterIP)))
 			})
@@ -172,24 +171,24 @@ func testReconciliation() {
 				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
 			})
 
-			It("should create it", func() {
-				t.AssertReconcileSuccess()
+			It("should create it", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
 
-				Expect(strings.TrimSpace(t.assertConfigMap(t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
+				Expect(strings.TrimSpace(t.assertConfigMap(ctx, t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
 					t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace).Data["lighthouse.server"])).To(Equal(
 					strings.ReplaceAll(lighthouseDNSConfigFormat, "$IP", clusterIP)))
 			})
 		})
 
 		Context("and the lighthouse DNS service doesn't exist", func() {
-			It("should create the service and the custom coredns ConfigMap", func() {
-				t.AssertReconcileError()
+			It("should create the service and the custom coredns ConfigMap", func(ctx SpecContext) {
+				t.AssertReconcileError(ctx)
 
-				t.setLighthouseCoreDNSServiceIP()
+				t.setLighthouseCoreDNSServiceIP(ctx)
 
-				t.AssertReconcileSuccess()
+				t.AssertReconcileSuccess(ctx)
 
-				Expect(strings.TrimSpace(t.assertConfigMap(t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
+				Expect(strings.TrimSpace(t.assertConfigMap(ctx, t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
 					t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace).Data["lighthouse.server"])).To(Equal(
 					strings.ReplaceAll(lighthouseDNSConfigFormat, "$IP", clusterIP)))
 			})
@@ -207,16 +206,16 @@ func testCoreDNSCleanup() {
 		t.serviceDiscovery.SetDeletionTimestamp(&now)
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		deployment := t.NewDeployment(opnames.AppendUninstall(names.ServiceDiscoveryComponent))
 
 		var one int32 = 1
 		deployment.Spec.Replicas = &one
 
-		Expect(t.ScopedClient.Create(context.TODO(), deployment)).To(Succeed())
-		t.UpdateDeploymentToReady(deployment)
+		Expect(t.ScopedClient.Create(ctx, deployment)).To(Succeed())
+		t.UpdateDeploymentToReady(ctx, deployment)
 
-		t.AssertReconcileSuccess()
+		t.AssertReconcileSuccess(ctx)
 	})
 
 	When("the coredns ConfigMap exists", func() {
@@ -224,8 +223,8 @@ func testCoreDNSCleanup() {
 			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newCoreDNSConfigMap(coreDNSCorefileData(clusterIP)))
 		})
 
-		It("should remove the lighthouse config section", func() {
-			Expect(strings.TrimSpace(t.assertCoreDNSConfigMap().Data["Corefile"])).To(Equal(coreDNSCorefileData("")))
+		It("should remove the lighthouse config section", func(ctx SpecContext) {
+			Expect(strings.TrimSpace(t.assertCoreDNSConfigMap(ctx).Data["Corefile"])).To(Equal(coreDNSCorefileData("")))
 		})
 
 		t.testServiceDiscoveryDeleted()
@@ -236,8 +235,8 @@ func testCoreDNSCleanup() {
 			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(clusterIP))
 		})
 
-		It("should remove the lighthouse config", func() {
-			assertDNSConfigServers(t.assertDNSConfig(), newDNSConfig(""))
+		It("should remove the lighthouse config", func(ctx SpecContext) {
+			assertDNSConfigServers(t.assertDNSConfig(ctx), newDNSConfig(""))
 		})
 
 		t.testServiceDiscoveryDeleted()
@@ -264,8 +263,8 @@ func testCoreDNSCleanup() {
 				})
 			})
 
-			It("should remove the lighthouse config section", func() {
-				Expect(t.assertConfigMap(t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
+			It("should remove the lighthouse config section", func(ctx SpecContext) {
+				Expect(t.assertConfigMap(ctx, t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
 					t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace).Data).ToNot(HaveKey("lighthouse.server"))
 			})
 
@@ -294,23 +293,23 @@ func testDeploymentUninstall() {
 				t.NewDeployment(names.ServiceDiscoveryComponent))
 		})
 
-		It("should run a Deployment to uninstall the service discovery component", func() {
-			t.AssertReconcileRequeue()
+		It("should run a Deployment to uninstall the service discovery component", func(ctx SpecContext) {
+			t.AssertReconcileRequeue(ctx)
 
-			t.AssertNoDeployment(names.ServiceDiscoveryComponent)
+			t.AssertNoDeployment(ctx, names.ServiceDiscoveryComponent)
 
-			t.UpdateDeploymentToReady(t.assertUninstallServiceDiscoveryDeployment())
+			t.UpdateDeploymentToReady(ctx, t.assertUninstallServiceDiscoveryDeployment(ctx))
 
 			t.awaitFinalizer()
 
-			t.AssertReconcileSuccess()
+			t.AssertReconcileSuccess(ctx)
 
-			t.AssertNoDeployment(opnames.AppendUninstall(names.ServiceDiscoveryComponent))
+			t.AssertNoDeployment(ctx, opnames.AppendUninstall(names.ServiceDiscoveryComponent))
 
 			t.awaitServiceDiscoveryDeleted()
 
-			t.AssertReconcileSuccess()
-			t.AssertNoDeployment(opnames.AppendUninstall(names.ServiceDiscoveryComponent))
+			t.AssertReconcileSuccess(ctx)
+			t.AssertNoDeployment(ctx, opnames.AppendUninstall(names.ServiceDiscoveryComponent))
 		})
 	})
 
@@ -321,13 +320,13 @@ func testDeploymentUninstall() {
 			t.InitScopedClientObjs = append(t.InitScopedClientObjs, t.NewDeployment(names.ServiceDiscoveryComponent))
 		})
 
-		It("should not perform uninstall", func() {
-			t.AssertReconcileSuccess()
+		It("should not perform uninstall", func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
 
-			_, err := t.GetDeployment(names.ServiceDiscoveryComponent)
+			_, err := t.GetDeployment(ctx, names.ServiceDiscoveryComponent)
 			Expect(err).To(Succeed())
 
-			t.AssertNoDeployment(opnames.AppendUninstall(names.ServiceDiscoveryComponent))
+			t.AssertNoDeployment(ctx, opnames.AppendUninstall(names.ServiceDiscoveryComponent))
 
 			t.awaitServiceDiscoveryDeleted()
 		})

--- a/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -112,8 +112,8 @@ func (t *testDriver) awaitServiceDiscoveryDeleted() {
 	t.AwaitNoResource(t.serviceDiscovery)
 }
 
-func (t *testDriver) assertUninstallServiceDiscoveryDeployment() *appsv1.Deployment {
-	deployment := t.AssertDeployment(opnames.AppendUninstall(names.ServiceDiscoveryComponent))
+func (t *testDriver) assertUninstallServiceDiscoveryDeployment(ctx context.Context) *appsv1.Deployment {
+	deployment := t.AssertDeployment(ctx, opnames.AppendUninstall(names.ServiceDiscoveryComponent))
 
 	t.AssertUninstallInitContainer(&deployment.Spec.Template,
 		fmt.Sprintf("%s/%s:%s", t.serviceDiscovery.Spec.Repository, opnames.ServiceDiscoveryImage, t.serviceDiscovery.Spec.Version))
@@ -121,27 +121,27 @@ func (t *testDriver) assertUninstallServiceDiscoveryDeployment() *appsv1.Deploym
 	return deployment
 }
 
-func (t *testDriver) getDNSConfig() (*operatorv1.DNS, error) {
+func (t *testDriver) getDNSConfig(ctx context.Context) (*operatorv1.DNS, error) {
 	foundDNSConfig := &operatorv1.DNS{}
-	err := t.ScopedClient.Get(context.TODO(), types.NamespacedName{Name: openShiftDNSConfigName}, foundDNSConfig)
+	err := t.ScopedClient.Get(ctx, types.NamespacedName{Name: openShiftDNSConfigName}, foundDNSConfig)
 
 	return foundDNSConfig, err
 }
 
-func (t *testDriver) assertDNSConfig() *operatorv1.DNS {
-	foundDNSConfig, err := t.getDNSConfig()
+func (t *testDriver) assertDNSConfig(ctx context.Context) *operatorv1.DNS {
+	foundDNSConfig, err := t.getDNSConfig(ctx)
 	Expect(err).To(Succeed())
 
 	return foundDNSConfig
 }
 
-func (t *testDriver) assertCoreDNSConfigMap() *corev1.ConfigMap {
-	return t.assertConfigMap("coredns", "kube-system")
+func (t *testDriver) assertCoreDNSConfigMap(ctx context.Context) *corev1.ConfigMap {
+	return t.assertConfigMap(ctx, "coredns", "kube-system")
 }
 
-func (t *testDriver) assertConfigMap(name, namespace string) *corev1.ConfigMap {
+func (t *testDriver) assertConfigMap(ctx context.Context, name, namespace string) *corev1.ConfigMap {
 	foundCoreMap := &corev1.ConfigMap{}
-	err := t.GeneralClient.Get(context.TODO(), controllerClient.ObjectKey{Namespace: namespace, Name: name}, foundCoreMap)
+	err := t.GeneralClient.Get(ctx, controllerClient.ObjectKey{Namespace: namespace, Name: name}, foundCoreMap)
 	Expect(err).To(Succeed())
 
 	return foundCoreMap
@@ -228,9 +228,9 @@ func newDNSService(clusterIP string) *corev1.Service {
 	}
 }
 
-func (t *testDriver) assertLighthouseCoreDNSService() *corev1.Service {
+func (t *testDriver) assertLighthouseCoreDNSService(ctx context.Context) *corev1.Service {
 	service := &corev1.Service{}
-	Expect(t.ScopedClient.Get(context.TODO(), types.NamespacedName{Name: lighthouseDNSServiceName, Namespace: submarinerNamespace},
+	Expect(t.ScopedClient.Get(ctx, types.NamespacedName{Name: lighthouseDNSServiceName, Namespace: submarinerNamespace},
 		service)).To(Succeed())
 
 	Expect(service.Labels).To(HaveKeyWithValue("app", lighthouseDNSServiceName))
@@ -242,10 +242,10 @@ func (t *testDriver) assertLighthouseCoreDNSService() *corev1.Service {
 	return service
 }
 
-func (t *testDriver) setLighthouseCoreDNSServiceIP() {
-	service := t.assertLighthouseCoreDNSService()
+func (t *testDriver) setLighthouseCoreDNSServiceIP(ctx context.Context) {
+	service := t.assertLighthouseCoreDNSService(ctx)
 	service.Spec.ClusterIP = clusterIP
-	Expect(t.ScopedClient.Update(context.TODO(), service)).To(Succeed())
+	Expect(t.ScopedClient.Update(ctx, service)).To(Succeed())
 }
 
 func (t *testDriver) testServiceDiscoveryDeleted() {

--- a/controllers/submariner/broker_controller_test.go
+++ b/controllers/submariner/broker_controller_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package submariner_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
@@ -67,23 +65,23 @@ var _ = Describe("Broker controller tests", func() {
 		}
 	})
 
-	It("should create the globalnet ConfigMap", func() {
-		t.AssertReconcileSuccess()
+	It("should create the globalnet ConfigMap", func(ctx SpecContext) {
+		t.AssertReconcileSuccess(ctx)
 
-		globalnetInfo, _, err := globalnet.GetGlobalNetworks(context.Background(), t.ScopedClient, submarinerNamespace)
+		globalnetInfo, _, err := globalnet.GetGlobalNetworks(ctx, t.ScopedClient, submarinerNamespace)
 		Expect(err).To(Succeed())
 		Expect(globalnetInfo.CidrRange).To(Equal(broker.Spec.GlobalnetCIDRRange))
 		Expect(globalnetInfo.ClusterSize).To(Equal(broker.Spec.DefaultGlobalnetClusterSize))
 	})
 
-	It("should create the CRDs", func() {
-		t.AssertReconcileSuccess()
+	It("should create the CRDs", func(ctx SpecContext) {
+		t.AssertReconcileSuccess(ctx)
 
 		crd := &apiextensions.CustomResourceDefinition{}
-		Expect(t.ScopedClient.Get(context.Background(), client.ObjectKey{Name: "clusters.submariner.io"}, crd)).To(Succeed())
-		Expect(t.ScopedClient.Get(context.Background(), client.ObjectKey{Name: "endpoints.submariner.io"}, crd)).To(Succeed())
-		Expect(t.ScopedClient.Get(context.Background(), client.ObjectKey{Name: "gateways.submariner.io"}, crd)).To(Succeed())
-		Expect(t.ScopedClient.Get(context.Background(), client.ObjectKey{Name: "serviceimports.multicluster.x-k8s.io"}, crd)).To(Succeed())
+		Expect(t.ScopedClient.Get(ctx, client.ObjectKey{Name: "clusters.submariner.io"}, crd)).To(Succeed())
+		Expect(t.ScopedClient.Get(ctx, client.ObjectKey{Name: "endpoints.submariner.io"}, crd)).To(Succeed())
+		Expect(t.ScopedClient.Get(ctx, client.ObjectKey{Name: "gateways.submariner.io"}, crd)).To(Succeed())
+		Expect(t.ScopedClient.Get(ctx, client.ObjectKey{Name: "serviceimports.multicluster.x-k8s.io"}, crd)).To(Succeed())
 	})
 
 	When("the Broker resource doesn't exist", func() {
@@ -91,8 +89,8 @@ var _ = Describe("Broker controller tests", func() {
 			t.InitScopedClientObjs = nil
 		})
 
-		It("should return success", func() {
-			t.AssertReconcileSuccess()
+		It("should return success", func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
 		})
 	})
 })

--- a/controllers/submariner/migration_test.go
+++ b/controllers/submariner/migration_test.go
@@ -35,9 +35,9 @@ var _ = Describe("Migration tests", func() {
 			t.clusterNetwork.NetworkPlugin = cni.OVNKubernetes
 		})
 
-		JustBeforeEach(func() {
-			t.AssertReconcileSuccess()
-			t.AssertNoDeployment(submariner.NetworkPluginSyncerComponent)
+		JustBeforeEach(func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
+			t.AssertNoDeployment(ctx, submariner.NetworkPluginSyncerComponent)
 		})
 
 		When("the Deployment doesn't exist", func() {

--- a/controllers/submariner/submariner_suite_test.go
+++ b/controllers/submariner/submariner_suite_test.go
@@ -108,16 +108,16 @@ func (t *testDriver) awaitSubmarinerDeleted() {
 	t.AwaitNoResource(t.submariner)
 }
 
-func (t *testDriver) getSubmariner() *v1alpha1.Submariner {
+func (t *testDriver) getSubmariner(ctx context.Context) *v1alpha1.Submariner {
 	obj := &v1alpha1.Submariner{}
-	err := t.ScopedClient.Get(context.TODO(), types.NamespacedName{Name: submarinerName, Namespace: submarinerNamespace}, obj)
+	err := t.ScopedClient.Get(ctx, types.NamespacedName{Name: submarinerName, Namespace: submarinerNamespace}, obj)
 	Expect(err).To(Succeed())
 
 	return obj
 }
 
-func (t *testDriver) assertRouteAgentDaemonSet() {
-	daemonSet := t.AssertDaemonSet(names.RouteAgentComponent)
+func (t *testDriver) assertRouteAgentDaemonSet(ctx context.Context) {
+	daemonSet := t.AssertDaemonSet(ctx, names.RouteAgentComponent)
 
 	Expect(daemonSet.Spec.Template.Spec.Containers).To(HaveLen(1))
 	Expect(daemonSet.Spec.Template.Spec.Containers[0].Image).To(
@@ -126,8 +126,8 @@ func (t *testDriver) assertRouteAgentDaemonSet() {
 	t.assertRouteAgentDaemonSetEnv(t.withNetworkDiscovery(), test.EnvMapFrom(daemonSet))
 }
 
-func (t *testDriver) assertUninstallRouteAgentDaemonSet() *appsv1.DaemonSet {
-	daemonSet := t.AssertDaemonSet(opnames.AppendUninstall(names.RouteAgentComponent))
+func (t *testDriver) assertUninstallRouteAgentDaemonSet(ctx context.Context) *appsv1.DaemonSet {
+	daemonSet := t.AssertDaemonSet(ctx, opnames.AppendUninstall(names.RouteAgentComponent))
 
 	envMap := t.AssertUninstallInitContainer(&daemonSet.Spec.Template,
 		fmt.Sprintf("%s/%s:%s", t.submariner.Spec.Repository, opnames.RouteAgentImage, t.submariner.Spec.Version))
@@ -145,8 +145,8 @@ func (t *testDriver) assertRouteAgentDaemonSetEnv(submariner *v1alpha1.Submarine
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_DEBUG", strconv.FormatBool(submariner.Spec.Debug)))
 }
 
-func (t *testDriver) assertGatewayDaemonSet() {
-	daemonSet := t.AssertDaemonSet(names.GatewayComponent)
+func (t *testDriver) assertGatewayDaemonSet(ctx context.Context) {
+	daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
 	assertGatewayNodeSelector(daemonSet)
 
 	Expect(daemonSet.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -156,8 +156,8 @@ func (t *testDriver) assertGatewayDaemonSet() {
 	t.assertGatewayDaemonSetEnv(t.withNetworkDiscovery(), test.EnvMapFrom(daemonSet))
 }
 
-func (t *testDriver) assertUninstallGatewayDaemonSet() *appsv1.DaemonSet {
-	daemonSet := t.AssertDaemonSet(opnames.AppendUninstall(names.GatewayComponent))
+func (t *testDriver) assertUninstallGatewayDaemonSet(ctx context.Context) *appsv1.DaemonSet {
+	daemonSet := t.AssertDaemonSet(ctx, opnames.AppendUninstall(names.GatewayComponent))
 	assertGatewayNodeSelector(daemonSet)
 
 	envMap := t.AssertUninstallInitContainer(&daemonSet.Spec.Template,
@@ -187,8 +187,8 @@ func (t *testDriver) assertGatewayDaemonSetEnv(submariner *v1alpha1.Submariner, 
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_DEBUG", strconv.FormatBool(submariner.Spec.Debug)))
 }
 
-func (t *testDriver) assertGlobalnetDaemonSet() {
-	daemonSet := t.AssertDaemonSet(names.GlobalnetComponent)
+func (t *testDriver) assertGlobalnetDaemonSet(ctx context.Context) {
+	daemonSet := t.AssertDaemonSet(ctx, names.GlobalnetComponent)
 	assertGatewayNodeSelector(daemonSet)
 
 	Expect(daemonSet.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -198,8 +198,8 @@ func (t *testDriver) assertGlobalnetDaemonSet() {
 	t.assertGlobalnetDaemonSetEnv(t.withNetworkDiscovery(), test.EnvMapFrom(daemonSet))
 }
 
-func (t *testDriver) assertUninstallGlobalnetDaemonSet() *appsv1.DaemonSet {
-	daemonSet := t.AssertDaemonSet(opnames.AppendUninstall(names.GlobalnetComponent))
+func (t *testDriver) assertUninstallGlobalnetDaemonSet(ctx context.Context) *appsv1.DaemonSet {
+	daemonSet := t.AssertDaemonSet(ctx, opnames.AppendUninstall(names.GlobalnetComponent))
 	assertGatewayNodeSelector(daemonSet)
 
 	envMap := t.AssertUninstallInitContainer(&daemonSet.Spec.Template,

--- a/pkg/crd/updater_test.go
+++ b/pkg/crd/updater_test.go
@@ -53,8 +53,8 @@ var _ = Describe("Updater", func() {
 		updater = crd.UpdaterFromClientSet(client)
 	})
 
-	assertCRDExists := func(name string) {
-		crd, err := updater.Get(context.TODO(), name, metav1.GetOptions{})
+	assertCRDExists := func(ctx context.Context, name string) {
+		crd, err := updater.Get(ctx, name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		Expect(crd.Spec.Names.Kind).Should(Equal("Submariner"))
 	}
@@ -77,21 +77,21 @@ var _ = Describe("Updater", func() {
 		}
 
 		When("the CRD doesn't exist", func() {
-			It("should create it", func() {
-				created, err := updater.CreateOrUpdateFromEmbedded(context.TODO(), crdYAML)
+			It("should create it", func(ctx SpecContext) {
+				created, err := updater.CreateOrUpdateFromEmbedded(ctx, crdYAML)
 				Expect(created).To(BeTrue())
 				Expect(err).To(Succeed())
-				assertCRDExists(crd.Name)
+				assertCRDExists(ctx, crd.Name)
 			})
 		})
 
 		When("the CRD already exists", func() {
-			It("should not update it", func() {
-				_, err := updater.Create(context.TODO(), crd, metav1.CreateOptions{})
+			It("should not update it", func(ctx SpecContext) {
+				_, err := updater.Create(ctx, crd, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
-				assertCRDExists(crd.Name)
+				assertCRDExists(ctx, crd.Name)
 
-				created, err := updater.CreateOrUpdateFromEmbedded(context.TODO(), crdYAML)
+				created, err := updater.CreateOrUpdateFromEmbedded(ctx, crdYAML)
 				Expect(created).To(BeFalse())
 				Expect(err).To(Succeed())
 

--- a/pkg/discovery/network/calico_test.go
+++ b/pkg/discovery/network/calico_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package network_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
@@ -50,19 +48,19 @@ var _ = Describe("Calico Network", func() {
 		initObjs = nil
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(initObjs...).Build()
-		clusterNet, err = network.Discover(context.TODO(), client, "")
+		clusterNet, err = network.Discover(ctx, client, "")
 	})
 
 	When("no kube pod information is available", func() {
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx SpecContext) {
 			initObjs = []client.Object{
 				calicoCfgMap,
 			}
 
 			client := newTestClient(initObjs...)
-			clusterNet, err = network.Discover(context.TODO(), client, "")
+			clusterNet, err = network.Discover(ctx, client, "")
 		})
 
 		It("should return a ClusterNetwork with only service CIDRs", func() {
@@ -75,7 +73,7 @@ var _ = Describe("Calico Network", func() {
 	})
 
 	When("kube pod information is available", func() {
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx SpecContext) {
 			initObjs = []client.Object{
 				calicoCfgMap,
 				fakeKubeAPIServerPod(),
@@ -83,7 +81,7 @@ var _ = Describe("Calico Network", func() {
 			}
 
 			client := newTestClient(initObjs...)
-			clusterNet, err = network.Discover(context.TODO(), client, "")
+			clusterNet, err = network.Discover(ctx, client, "")
 		})
 		It("should return a ClusterNetwork with pod and service CIDRs", func() {
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/discovery/network/canal_test.go
+++ b/pkg/discovery/network/canal_test.go
@@ -32,8 +32,8 @@ import (
 
 var _ = Describe("Canal Flannel Network", func() {
 	When("There are no generic k8s pods to look at", func() {
-		It("Should return the ClusterNetwork structure with the pod CIDR and the service CIDR", func() {
-			clusterNet := testDiscoverCanalFlannelWith(&canalFlannelCfgMap)
+		It("Should return the ClusterNetwork structure with the pod CIDR and the service CIDR", func(ctx SpecContext) {
+			clusterNet := testDiscoverCanalFlannelWith(ctx, &canalFlannelCfgMap)
 			Expect(clusterNet).NotTo(BeNil())
 			Expect(clusterNet.NetworkPlugin).To(Equal(cni.CanalFlannel))
 			Expect(clusterNet.PodCIDRs).To(Equal([]string{testCannalFlannelPodCIDR}))
@@ -42,8 +42,9 @@ var _ = Describe("Canal Flannel Network", func() {
 	})
 
 	When("There is a kube-api pod", func() {
-		It("Should return the ClusterNetwork structure with the pod CIDR and the service CIDR", func() {
+		It("Should return the ClusterNetwork structure with the pod CIDR and the service CIDR", func(ctx SpecContext) {
 			clusterNet := testDiscoverWith(
+				ctx,
 				&canalFlannelCfgMap,
 				fakeKubeAPIServerPod(),
 			)
@@ -55,17 +56,17 @@ var _ = Describe("Canal Flannel Network", func() {
 	})
 })
 
-func testDiscoverCanalFlannelWith(objects ...controllerClient.Object) *network.ClusterNetwork {
+func testDiscoverCanalFlannelWith(ctx context.Context, objects ...controllerClient.Object) *network.ClusterNetwork {
 	client := newTestClient(objects...)
-	clusterNet, err := network.Discover(context.TODO(), client, "")
+	clusterNet, err := network.Discover(ctx, client, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	return clusterNet
 }
 
-func testDiscoverWith(objects ...controllerClient.Object) *network.ClusterNetwork {
+func testDiscoverWith(ctx context.Context, objects ...controllerClient.Object) *network.ClusterNetwork {
 	client := newTestClient(objects...)
-	clusterNet, err := network.Discover(context.TODO(), client, "")
+	clusterNet, err := network.Discover(ctx, client, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	return clusterNet

--- a/pkg/discovery/network/flannel_test.go
+++ b/pkg/discovery/network/flannel_test.go
@@ -37,8 +37,8 @@ const (
 
 var _ = Describe("Flannel Network", func() {
 	When("the flannel DaemonSet and ConfigMap exist", func() {
-		It("should return a ClusterNetwork with the plugin name and CIDRs set correctly", func() {
-			clusterNet := testDiscoverFlannelWith(&flannelDaemonSet, &flannelCfgMap)
+		It("should return a ClusterNetwork with the plugin name and CIDRs set correctly", func(ctx SpecContext) {
+			clusterNet := testDiscoverFlannelWith(ctx, &flannelDaemonSet, &flannelCfgMap)
 			Expect(clusterNet).NotTo(BeNil())
 			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Flannel))
 			Expect(clusterNet.PodCIDRs).To(Equal([]string{testFlannelPodCIDR}))
@@ -47,25 +47,25 @@ var _ = Describe("Flannel Network", func() {
 	})
 
 	When("the flannel DaemonSet does not exist", func() {
-		It("should return a ClusterNetwork with the generic plugin", func() {
-			clusterNet := testDiscoverFlannelWith()
+		It("should return a ClusterNetwork with the generic plugin", func(ctx SpecContext) {
+			clusterNet := testDiscoverFlannelWith(ctx)
 			Expect(clusterNet).NotTo(BeNil())
 			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Generic))
 		})
 	})
 
 	When("the flannel ConfigMap does not exist", func() {
-		It("should return a ClusterNetwork with the generic plugin", func() {
-			clusterNet := testDiscoverFlannelWith(&flannelDaemonSet)
+		It("should return a ClusterNetwork with the generic plugin", func(ctx SpecContext) {
+			clusterNet := testDiscoverFlannelWith(ctx, &flannelDaemonSet)
 			Expect(clusterNet).NotTo(BeNil())
 			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Generic))
 		})
 	})
 })
 
-func testDiscoverFlannelWith(objects ...controllerClient.Object) *network.ClusterNetwork {
+func testDiscoverFlannelWith(ctx context.Context, objects ...controllerClient.Object) *network.ClusterNetwork {
 	client := newTestClient(objects...)
-	clusterNet, err := network.Discover(context.TODO(), client, "")
+	clusterNet, err := network.Discover(ctx, client, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	return clusterNet

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -43,8 +43,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kube-proxy with no expected parameters", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakePod("kube-proxy", []string{"kube-proxy", "--cluster-ABCD=1.2.3.4"}, []corev1.EnvVar{}),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -66,8 +67,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kube-controller with no expected parameters", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakePod("kube-controller-manager", []string{"kube-controller-manager", "--cluster-ABCD=1.2.3.4"}, []corev1.EnvVar{}),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -89,8 +91,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kube-api with no expected parameters", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakePod("kube-apiserver", []string{"kube-apiserver", "--cluster-ABCD=1.2.3.4"}, []corev1.EnvVar{}),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -112,8 +115,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kube-controller pod with the right parameter", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeKubeControllerManagerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -135,8 +139,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kube-proxy pod but no kube-controller", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeKubeProxyPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -158,8 +163,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kubeapi pod", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeKubeAPIServerPod(),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -181,8 +187,9 @@ var _ = Describe("Generic Network", func() {
 	When("There is a kube-proxy and api pods", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeKubeProxyPod(),
 				fakeKubeAPIServerPod(),
 			)
@@ -202,8 +209,9 @@ var _ = Describe("Generic Network", func() {
 	When("No pod CIDR information exists on any node", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeNode("node1", ""),
 				fakeNode("node2", ""),
 			)
@@ -225,8 +233,9 @@ var _ = Describe("Generic Network", func() {
 	When("Pod CIDR information exists on a single node cluster", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeNode("node1", testPodCIDR),
 			)
 		})
@@ -247,8 +256,9 @@ var _ = Describe("Generic Network", func() {
 	When("Pod CIDR information exists on a multi node cluster", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeNode("node1", testPodCIDR),
 				fakeNode("node2", testPodCIDR),
 			)
@@ -262,8 +272,9 @@ var _ = Describe("Generic Network", func() {
 	When("Both pod and service CIDR information exists", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
+				ctx,
 				fakeNode("node1", testPodCIDR),
 				fakeKubeAPIServerPod(),
 			)
@@ -280,21 +291,21 @@ var _ = Describe("Generic Network", func() {
 	})
 
 	When("No kube-api pod exists and invalid service creation returns no error", func() {
-		It("Should return error and nil cluster network", func() {
+		It("Should return error and nil cluster network", func(ctx SpecContext) {
 			client := fakeClient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-			clusterNet, err := network.Discover(context.TODO(), client, "")
+			clusterNet, err := network.Discover(ctx, client, "")
 			Expect(err).To(HaveOccurred())
 			Expect(clusterNet).To(BeNil())
 		})
 	})
 
 	When("No kube-api pod exists and invalid service creation returns an unexpected error", func() {
-		It("Should return error and nil cluster network", func() {
+		It("Should return error and nil cluster network", func(ctx SpecContext) {
 			// Inject error for create services to return expectedErr
 			client := fake.NewReactingClient(nil).AddReactor(fake.Create, &corev1.Service{},
 				fake.FailingReaction(fmt.Errorf("%s", testServiceCIDR)))
 
-			clusterNet, err := network.Discover(context.TODO(), client, "")
+			clusterNet, err := network.Discover(ctx, client, "")
 			Expect(err).To(HaveOccurred())
 			Expect(clusterNet).To(BeNil())
 		})
@@ -303,8 +314,8 @@ var _ = Describe("Generic Network", func() {
 	When("No kube-api pod exists and invalid service creation returns the expected error", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
-			clusterNet = testDiscoverGenericWith()
+		BeforeEach(func(ctx SpecContext) {
+			clusterNet = testDiscoverGenericWith(ctx)
 		})
 
 		It("Should return the ClusterNetwork structure with empty pod CIDR", func() {
@@ -321,9 +332,9 @@ var _ = Describe("Generic Network", func() {
 	})
 })
 
-func testDiscoverGenericWith(objects ...controllerClient.Object) *network.ClusterNetwork {
+func testDiscoverGenericWith(ctx context.Context, objects ...controllerClient.Object) *network.ClusterNetwork {
 	client := newTestClient(objects...)
-	clusterNet, err := network.Discover(context.TODO(), client, "")
+	clusterNet, err := network.Discover(ctx, client, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	return clusterNet

--- a/pkg/discovery/network/kindnet_test.go
+++ b/pkg/discovery/network/kindnet_test.go
@@ -30,8 +30,9 @@ var _ = Describe("Kindnet CNI", func() {
 	When("There are kindnet pods but there are no kube-api pods", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverNetwork(
+				ctx,
 				fakePod("kindnet", []string{"kindnet"}, []v1.EnvVar{{Name: "POD_SUBNET", Value: testPodCIDR}}),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -50,8 +51,9 @@ var _ = Describe("Kindnet CNI", func() {
 	When("There are kindnet and kube-api pods", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverNetwork(
+				ctx,
 				fakePod("kindnet", []string{"kindnet"}, []v1.EnvVar{{Name: "POD_SUBNET", Value: testPodCIDR}}),
 				fakeKubeAPIServerPod(),
 			)

--- a/pkg/discovery/network/openshift4_test.go
+++ b/pkg/discovery/network/openshift4_test.go
@@ -32,8 +32,8 @@ import (
 
 var _ = Describe("OpenShift4 Network", func() {
 	When("JSON contains a pod network", func() {
-		It("Should parse properly pod and service networks", func() {
-			cn, err := testOS4DiscoveryWith(getNetworkJSON())
+		It("Should parse properly pod and service networks", func(ctx SpecContext) {
+			cn, err := testOS4DiscoveryWith(ctx, getNetworkJSON())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cn.PodCIDRs).To(HaveLen(2))
 			Expect(cn.ServiceCIDRs).To(HaveLen(1))
@@ -44,26 +44,26 @@ var _ = Describe("OpenShift4 Network", func() {
 	})
 
 	When("JSON is missing the clusterNetworks list", func() {
-		It("Should return error", func() {
-			_, err := testOS4DiscoveryWith(getNetworkJSONMissingCN())
+		It("Should return error", func(ctx SpecContext) {
+			_, err := testOS4DiscoveryWith(ctx, getNetworkJSONMissingCN())
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("JSON is missing the serviceNetwork field", func() {
-		It("Should return error", func() {
-			_, err := testOS4DiscoveryWith(getNetworkJSONMissingSN())
+		It("Should return error", func(ctx SpecContext) {
+			_, err := testOS4DiscoveryWith(ctx, getNetworkJSONMissingSN())
 			Expect(err).To(HaveOccurred())
 		})
 	})
 })
 
-func testOS4DiscoveryWith(json []byte) (*network.ClusterNetwork, error) {
+func testOS4DiscoveryWith(ctx context.Context, json []byte) (*network.ClusterNetwork, error) {
 	obj := &unstructured.Unstructured{}
 	err := obj.UnmarshalJSON(json)
 	Expect(err).NotTo(HaveOccurred())
 
-	return network.Discover(context.TODO(), fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(obj).Build(), "")
+	return network.Discover(ctx, fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(obj).Build(), "")
 }
 
 func getNetworkJSON() []byte {

--- a/pkg/discovery/network/ovnkubernetes_test.go
+++ b/pkg/discovery/network/ovnkubernetes_test.go
@@ -36,8 +36,9 @@ var _ = Describe("OvnKubernetes Network", func() {
 	const ovnKubeSvcTest = "ovnkube-node"
 
 	When("ovn-kubernetes database and service found, no configmap", func() {
-		It("Should return cluster network with default CIDRs", func() {
+		It("Should return cluster network with default CIDRs", func(ctx SpecContext) {
 			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				ctx,
 				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
 				fakeService(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest),
 			)
@@ -51,8 +52,9 @@ var _ = Describe("OvnKubernetes Network", func() {
 	})
 
 	When("ovn-kubernetes database, configmap and service found", func() {
-		It("Should return cluster network with correct CIDRs", func() {
+		It("Should return cluster network with correct CIDRs", func(ctx SpecContext) {
 			clusterNet, err := testOvnKubernetesDiscoveryWith(
+				ctx,
 				fakePodWithNamespace(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest, []string{}, []v1.EnvVar{}),
 				fakeService(ovnKubeNamespace, ovnKubeSvcTest, ovnKubeSvcTest),
 				ovnFakeConfigMap(ovnKubeNamespace, "ovn-config"),
@@ -66,9 +68,9 @@ var _ = Describe("OvnKubernetes Network", func() {
 	})
 })
 
-func testOvnKubernetesDiscoveryWith(objects ...controllerClient.Object) (*network.ClusterNetwork, error) {
+func testOvnKubernetesDiscoveryWith(ctx context.Context, objects ...controllerClient.Object) (*network.ClusterNetwork, error) {
 	client := newTestClient(objects...)
-	return network.Discover(context.TODO(), client, "")
+	return network.Discover(ctx, client, "")
 }
 
 func ovnFakeConfigMap(namespace, name string) *v1.ConfigMap {

--- a/pkg/discovery/network/pods_test.go
+++ b/pkg/discovery/network/pods_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package network_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
@@ -48,24 +46,24 @@ var _ = Describe("findPod", func() {
 	})
 
 	When("There are no pods to be found", func() {
-		It("Should return nil", func() {
-			pod, err := network.FindPod(context.TODO(), client, "component=not-to-be-found")
+		It("Should return nil", func(ctx SpecContext) {
+			pod, err := network.FindPod(ctx, client, "component=not-to-be-found")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod).To(BeNil())
 		})
 	})
 
 	When("A pod is found", func() {
-		It("Should return the pod", func() {
-			pod, err := network.FindPod(context.TODO(), client, componentLabel(testComponent1))
+		It("Should return the pod", func(ctx SpecContext) {
+			pod, err := network.FindPod(ctx, client, componentLabel(testComponent1))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod.Name).To(Equal(testFirstPod))
 		})
 	})
 
 	When("Multiple pods are found", func() {
-		It("Should return the first pod", func() {
-			pod, err := network.FindPod(context.TODO(), client, componentLabel(testComponent2))
+		It("Should return the first pod", func(ctx SpecContext) {
+			pod, err := network.FindPod(ctx, client, componentLabel(testComponent2))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod.Name).To(Equal(testSecondPod))
 		})
@@ -92,32 +90,32 @@ var _ = Describe("findPodCommandParameter", func() {
 	})
 
 	When("There are no pods to be found", func() {
-		It("Should return empty string", func() {
-			param, err := network.FindPodCommandParameter(context.TODO(), client, componentLabel("not-to-be-found"), testParameter1)
+		It("Should return empty string", func(ctx SpecContext) {
+			param, err := network.FindPodCommandParameter(ctx, client, componentLabel("not-to-be-found"), testParameter1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(param).To(BeEmpty())
 		})
 	})
 
 	When("A pod is found, but does not contain the parameter", func() {
-		It("Should return an empty string", func() {
-			param, err := network.FindPodCommandParameter(context.TODO(), client, componentLabel(testComponent1), "unknown-parameter")
+		It("Should return an empty string", func(ctx SpecContext) {
+			param, err := network.FindPodCommandParameter(ctx, client, componentLabel(testComponent1), "unknown-parameter")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(param).To(BeEmpty())
 		})
 	})
 
 	When("A pod is found, and contains the parameter", func() {
-		It("Should return the parameter value", func() {
-			param, err := network.FindPodCommandParameter(context.TODO(), client, componentLabel(testComponent2), testParameter1)
+		It("Should return the parameter value", func(ctx SpecContext) {
+			param, err := network.FindPodCommandParameter(ctx, client, componentLabel(testComponent2), testParameter1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(param).To(Equal(testValue1))
 		})
 	})
 
 	When("A pod is found, and the parameter is wrapped in a sh call", func() {
-		It("Should return the parameter value", func() {
-			param, err := network.FindPodCommandParameter(context.TODO(), client, componentLabel(testComponent3), testParameter1)
+		It("Should return the parameter value", func(ctx SpecContext) {
+			param, err := network.FindPodCommandParameter(ctx, client, componentLabel(testComponent3), testParameter1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(param).To(Equal(testValue1))
 		})

--- a/pkg/discovery/network/weavenet_test.go
+++ b/pkg/discovery/network/weavenet_test.go
@@ -33,8 +33,9 @@ var _ = Describe("Weave Network", func() {
 	When("There are weave pods but no kube api", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverNetwork(
+				ctx,
 				fakePod("weave-net", []string{"weave-net"}, []v1.EnvVar{{Name: "IPALLOC_RANGE", Value: testPodCIDR}}),
 			)
 			Expect(clusterNet).NotTo(BeNil())
@@ -52,8 +53,9 @@ var _ = Describe("Weave Network", func() {
 	When("There are weave and kube api pods", func() {
 		var clusterNet *network.ClusterNetwork
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverNetwork(
+				ctx,
 				fakePod("weave-net", []string{"weave-net"}, []v1.EnvVar{{Name: "IPALLOC_RANGE", Value: testPodCIDR}}),
 				fakeKubeAPIServerPod(),
 			)
@@ -71,9 +73,9 @@ var _ = Describe("Weave Network", func() {
 	})
 })
 
-func testDiscoverNetwork(objects ...controllerClient.Object) *network.ClusterNetwork {
+func testDiscoverNetwork(ctx context.Context, objects ...controllerClient.Object) *network.ClusterNetwork {
 	client := newTestClient(objects...)
-	clusterNet, err := network.Discover(context.TODO(), client, "")
+	clusterNet, err := network.Discover(ctx, client, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	return clusterNet


### PR DESCRIPTION
Ginkgo can provide a cancellable context, use that instead of ad hoc context.TODO() or context.Background().

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
