### PR TITLE
Restrict route agent secret access

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -9,7 +9,6 @@ rules:
     resources:
       - pods
       - services
-      - secrets
       - configmaps
       - endpoints
     verbs:

--- a/config/rbac/submariner-route-agent/ovn_cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/ovn_cluster_role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: submariner-routeagent-ovn
+rules:
+  - apiGroups:  # the route agent needs access to ovn secrets
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list

--- a/config/rbac/submariner-route-agent/ovn_role_binding.yaml
+++ b/config/rbac/submariner-route-agent/ovn_role_binding.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: submariner-routeagent-ovn
+  namespace: openshift-ovn-kubernetes
+subjects:
+  - kind: ServiceAccount
+    name: submariner-routeagent
+roleRef:
+  kind: ClusterRole
+  name: submariner-routeagent-ovn
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/embeddedyamls/generators/yamls2go.go
+++ b/pkg/embeddedyamls/generators/yamls2go.go
@@ -71,6 +71,8 @@ var files = []string{
 	"config/rbac/submariner-route-agent/cluster_role_binding.yaml",
 	"config/rbac/submariner-route-agent/ocp_cluster_role.yaml",
 	"config/rbac/submariner-route-agent/ocp_cluster_role_binding.yaml",
+	"config/rbac/submariner-route-agent/ovn_cluster_role.yaml",
+	"config/rbac/submariner-route-agent/ovn_role_binding.yaml",
 	"config/rbac/submariner-globalnet/service_account.yaml",
 	"config/rbac/submariner-globalnet/role.yaml",
 	"config/rbac/submariner-globalnet/role_binding.yaml",
@@ -154,6 +156,7 @@ const (
 
 	re := regexp.MustCompile("`([^`]*)`")
 	reNS := regexp.MustCompile(`(?s)\s*namespace:\s*placeholder\s*`)
+	reDoc := regexp.MustCompile("(^|\n+)---\n")
 	reTilde := regexp.MustCompile("`")
 
 	for _, f := range files {
@@ -163,6 +166,13 @@ const (
 		fmt.Println(f)
 		contents, err := os.ReadFile(path.Join(yamlsDirectory, f))
 		panicOnErr(err)
+
+		for _, index := range reDoc.FindAllIndex(contents, 2) {
+			if index[0] > 0 {
+				// Document starting inside the contents
+				panic(fmt.Sprintf("%s contains more than one document, use one file per document", f))
+			}
+		}
 
 		_, err = out.Write(
 			re.ReplaceAll(

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3005,7 +3005,6 @@ rules:
     resources:
       - pods
       - services
-      - secrets
       - configmaps
       - endpoints
     verbs:
@@ -3079,6 +3078,34 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-routeagent
+`
+	Config_rbac_submariner_route_agent_ovn_cluster_role_yaml = `---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: submariner-routeagent-ovn
+rules:
+  - apiGroups:  # the route agent needs access to ovn secrets
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+`
+	Config_rbac_submariner_route_agent_ovn_role_binding_yaml = `---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: submariner-routeagent-ovn
+  namespace: openshift-ovn-kubernetes
+subjects:
+  - kind: ServiceAccount
+    name: submariner-routeagent
+roleRef:
+  kind: ClusterRole
+  name: submariner-routeagent-ovn
+  apiGroup: rbac.authorization.k8s.io
 `
 	Config_rbac_submariner_globalnet_service_account_yaml = `---
 apiVersion: v1


### PR DESCRIPTION
The route agent needs to access OVN secrets; currently that's done by granting it access to all secrets. Access to secrets can be used for privilege escalation, so it's best to restrict this to only required secrets; for OVN this is the openshift-ovn-kubernetes namespace.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
