### PR TITLE
Automated backport of #3042: Restrict route agent secret access

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -9,7 +9,6 @@ rules:
     resources:
       - pods
       - services
-      - secrets
       - configmaps
       - endpoints
     verbs:

--- a/config/rbac/submariner-route-agent/ovn_cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/ovn_cluster_role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: submariner-routeagent-ovn
+rules:
+  - apiGroups:  # the route agent needs access to ovn secrets
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list

--- a/config/rbac/submariner-route-agent/ovn_role_binding.yaml
+++ b/config/rbac/submariner-route-agent/ovn_role_binding.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: submariner-routeagent-ovn
+  namespace: openshift-ovn-kubernetes
+subjects:
+  - kind: ServiceAccount
+    name: submariner-routeagent
+roleRef:
+  kind: ClusterRole
+  name: submariner-routeagent-ovn
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/embeddedyamls/generators/yamls2go.go
+++ b/pkg/embeddedyamls/generators/yamls2go.go
@@ -71,6 +71,8 @@ var files = []string{
 	"config/rbac/submariner-route-agent/cluster_role_binding.yaml",
 	"config/rbac/submariner-route-agent/ocp_cluster_role.yaml",
 	"config/rbac/submariner-route-agent/ocp_cluster_role_binding.yaml",
+	"config/rbac/submariner-route-agent/ovn_cluster_role.yaml",
+	"config/rbac/submariner-route-agent/ovn_role_binding.yaml",
 	"config/rbac/submariner-globalnet/service_account.yaml",
 	"config/rbac/submariner-globalnet/role.yaml",
 	"config/rbac/submariner-globalnet/role_binding.yaml",

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2902,7 +2902,6 @@ rules:
     resources:
       - pods
       - services
-      - secrets
       - configmaps
       - endpoints
     verbs:
@@ -2975,6 +2974,34 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-routeagent
+`
+	Config_rbac_submariner_route_agent_ovn_cluster_role_yaml = `---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: submariner-routeagent-ovn
+rules:
+  - apiGroups:  # the route agent needs access to ovn secrets
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+`
+	Config_rbac_submariner_route_agent_ovn_role_binding_yaml = `---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: submariner-routeagent-ovn
+  namespace: openshift-ovn-kubernetes
+subjects:
+  - kind: ServiceAccount
+    name: submariner-routeagent
+roleRef:
+  kind: ClusterRole
+  name: submariner-routeagent-ovn
+  apiGroup: rbac.authorization.k8s.io
 `
 	Config_rbac_submariner_globalnet_service_account_yaml = `---
 apiVersion: v1


### PR DESCRIPTION
Backport of #3042 on release-0.16.

#3042: Restrict route agent secret access

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.