### PR TITLE
Automated backport of #3050: Fix issues with recent RBAC changes

### DIFF
--- a/.github/workflows/prometheus.yml
+++ b/.github/workflows/prometheus.yml
@@ -44,3 +44,6 @@ jobs:
           done;
           curl -s --data-urlencode query=submariner_gateways http://localhost:9090/api/v1/query | jq .;
           exit 1
+      - name: Post mortem
+        if: failure()
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel

--- a/config/rbac/submariner-operator/role.yaml
+++ b/config/rbac/submariner-operator/role.yaml
@@ -17,6 +17,16 @@ rules:
   - apiGroups:
       - ""
     resources:
+      # For syncing Secrets from the broker
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       # Temporarily needed for network-plugin syncer removal
       - serviceaccounts
     resourceNames:

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2608,6 +2608,16 @@ rules:
   - apiGroups:
       - ""
     resources:
+      # For syncing Secrets from the broker
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       # Temporarily needed for network-plugin syncer removal
       - serviceaccounts
     resourceNames:

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -62,7 +62,8 @@ func CreateServiceMonitors(ctx context.Context, config *rest.Config, ns string, 
 
 		// On OpenShift, we need to create the service monitors in the OpenShift monitoring namespace, not the
 		// service's. If that namespace doesn't exist then create in the provided namespace.
-		smc, err := mclient.ServiceMonitors(ns).Create(ctx, GenerateServiceMonitor(openshiftMonitoringNS, s), metav1.CreateOptions{})
+		smc, err := mclient.ServiceMonitors(openshiftMonitoringNS).Create(ctx, GenerateServiceMonitor(openshiftMonitoringNS, s),
+			metav1.CreateOptions{})
 
 		missingNS, _ := resource.IsMissingNamespaceErr(err)
 		if missingNS {


### PR DESCRIPTION
Backport of #3050 on release-0.17.

#3050: Use correct request namespace when creating

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.