### PR TITLE
Expand wildcards in RBAC yaml files

### DIFF
--- a/config/broker/broker-admin/role.yaml
+++ b/config/broker/broker-admin/role.yaml
@@ -49,7 +49,7 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - '*'
+      - serviceimports
     verbs:
       - create
       - get

--- a/config/broker/broker-client/role.yaml
+++ b/config/broker/broker-client/role.yaml
@@ -27,7 +27,7 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - '*'
+      - serviceimports
     verbs:
       - create
       - get

--- a/config/rbac/submariner-diagnose/cluster_role.yaml
+++ b/config/rbac/submariner-diagnose/cluster_role.yaml
@@ -34,8 +34,8 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "serviceexports"
-      - "serviceimports"
+      - serviceexports
+      - serviceimports
     verbs:
       - get
       - list

--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -33,14 +33,19 @@ rules:
   - apiGroups:
       - submariner.io
     resources:
-      - '*'
+      - clusters
+      - endpoints
+      - gateways
+      - gatewayroutes
+      - nongatewayroutes
     verbs:
       - get
       - list
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "*"
+      - serviceexports
+      - serviceimports
     verbs:
       - get
       - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2473,7 +2473,7 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - '*'
+      - serviceimports
     verbs:
       - create
       - get
@@ -2544,7 +2544,7 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - '*'
+      - serviceimports
     verbs:
       - create
       - get
@@ -3317,14 +3317,19 @@ rules:
   - apiGroups:
       - submariner.io
     resources:
-      - '*'
+      - clusters
+      - endpoints
+      - gateways
+      - gatewayroutes
+      - nongatewayroutes
     verbs:
       - get
       - list
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "*"
+      - serviceexports
+      - serviceimports
     verbs:
       - get
       - list
@@ -3378,8 +3383,8 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "serviceexports"
-      - "serviceimports"
+      - serviceexports
+      - serviceimports
     verbs:
       - get
       - list


### PR DESCRIPTION
It's recommended to not use wildcards for resources and verbs as it can lead to security issues by granting overly broad permissions.

Even though the wildcard uses pertained to `multicluster.x-k8s.io `and `submariner.io` resources which may not carry security risk, we should be consistent and follow the recommendation. Also doing so avoids Sonar violations.