### PR TITLE
Add more missing resources for diagnose and broker-client

### DIFF
--- a/config/broker/broker-admin/role.yaml
+++ b/config/broker/broker-admin/role.yaml
@@ -50,6 +50,7 @@ rules:
       - multicluster.x-k8s.io
     resources:
       - serviceimports
+      - serviceimports/status
     verbs:
       - create
       - get

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2474,6 +2474,7 @@ rules:
       - multicluster.x-k8s.io
     resources:
       - serviceimports
+      - serviceimports/status
     verbs:
       - create
       - get


### PR DESCRIPTION
The broker-client role needs to be able to update
serviceimports/status. The broker-admin role needs to have at least the same privileges as broker-client to be able to grant those permissions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
