### PR TITLE
Remove automountServiceAccountToken from manager.yaml

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,7 +47,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 10
-      automountServiceAccountToken: false
       serviceAccountName: submariner-operator
       containers:
         - name: submariner-operator


### PR DESCRIPTION
This was added recently based on misunderstanding (mine). Setting to false applies to pods that don't access the API server at all.
