### PR TITLE
Add RBAC access to finalizers for the operator role

### DIFF
--- a/config/rbac/submariner-operator/role.yaml
+++ b/config/rbac/submariner-operator/role.yaml
@@ -86,3 +86,10 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - submariners/finalizers
+      - servicediscoveries/finalizers
+    verbs:
+      - update

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2693,6 +2693,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - submariners/finalizers
+      - servicediscoveries/finalizers
+    verbs:
+      - update
 `
 	Config_rbac_submariner_operator_role_binding_yaml = `---
 kind: RoleBinding


### PR DESCRIPTION
On Openshift, the operator failed with error

"_\"submariner-gateway\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on_"

Openshift enables [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement), so in order to set `blockOwnerDeletion` for an object, the user needs update permission for the finalizers subresource of the referenced owner. In this case the owner is the `Submariner` object.