### PR TITLE
Automated backport of #3077: Add RBAC access to finalizers for the operator role

### DIFF
--- a/config/rbac/submariner-operator/role.yaml
+++ b/config/rbac/submariner-operator/role.yaml
@@ -86,3 +86,10 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - submariners/finalizers
+      - servicediscoveries/finalizers
+    verbs:
+      - update

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2677,6 +2677,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - submariners/finalizers
+      - servicediscoveries/finalizers
+    verbs:
+      - update
 `
 	Config_rbac_submariner_operator_role_binding_yaml = `---
 kind: RoleBinding


### PR DESCRIPTION
Backport of #3077 on release-0.17.

#3077: Add RBAC access to finalizers for the operator role

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.