### PR TITLE
Adjust globalnet RBAC permissions

### DIFF
--- a/config/rbac/submariner-globalnet/role.yaml
+++ b/config/rbac/submariner-globalnet/role.yaml
@@ -6,6 +6,15 @@ metadata:
   name: submariner-globalnet
 rules:
   - apiGroups:
+      - submariner.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3141,6 +3141,15 @@ metadata:
   name: submariner-globalnet
 rules:
   - apiGroups:
+      - submariner.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases


### PR DESCRIPTION
Globalnet now annotates `Gateways` instead of nodes.

Related to https://github.com/submariner-io/submariner/pull/3019
