### PR TITLE
Automated backport of #3090: Use the GeneralClient when accessing operatorv1.DNS resources

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -49,7 +49,8 @@ func testReconciliation() {
 	When("the openshift DNS config exists", func() {
 		Context("and the lighthouse config isn't present", func() {
 			BeforeEach(func() {
-				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(""), newDNSService(clusterIP))
+				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
 			})
 
 			It("should add it", func() {
@@ -63,7 +64,8 @@ func testReconciliation() {
 			updatedClusterIP := "10.10.10.11"
 
 			BeforeEach(func() {
-				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(clusterIP), newDNSService(updatedClusterIP))
+				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(updatedClusterIP))
+				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(clusterIP))
 			})
 
 			It("should update the lighthouse config", func() {
@@ -75,7 +77,7 @@ func testReconciliation() {
 
 		Context("and the lighthouse DNS service doesn't exist", func() {
 			BeforeEach(func() {
-				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(""))
+				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
 			})
 
 			It("should create the service and add the lighthouse config", func() {
@@ -232,7 +234,7 @@ func testCoreDNSCleanup() {
 
 	When("the openshift DNS config exists", func() {
 		BeforeEach(func() {
-			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSConfig(clusterIP))
+			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(clusterIP))
 		})
 
 		It("should remove the lighthouse config", func() {

--- a/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -122,7 +122,7 @@ func (t *testDriver) assertUninstallServiceDiscoveryDeployment() *appsv1.Deploym
 
 func (t *testDriver) getDNSConfig() (*operatorv1.DNS, error) {
 	foundDNSConfig := &operatorv1.DNS{}
-	err := t.ScopedClient.Get(context.TODO(), types.NamespacedName{Name: openShiftDNSConfigName}, foundDNSConfig)
+	err := t.GeneralClient.Get(context.TODO(), types.NamespacedName{Name: openShiftDNSConfigName}, foundDNSConfig)
 
 	return foundDNSConfig, err
 }


### PR DESCRIPTION
Backport of #3090 on release-0.15.

#3090: Use the GeneralClient when accessing operatorv1.DNS resources

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.