### PR TITLE
Automated backport of #3107: Remove DeleteAllOf call for deployments in SD controller

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -104,14 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		// Request object not found, could have been deleted after reconcile request.
 		// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 		// Return and don't requeue
-		deployment := &appsv1.Deployment{}
-		opts := []controllerClient.DeleteAllOfOption{
-			controllerClient.InNamespace(request.NamespacedName.Namespace),
-			controllerClient.MatchingLabels{"app": names.ServiceDiscoveryComponent},
-		}
-		err := r.ScopedClient.DeleteAllOf(ctx, deployment, opts...)
-
-		return reconcile.Result{}, errors.Wrap(err, "error deleting resource")
+		return reconcile.Result{}, nil
 	}
 
 	if err != nil {


### PR DESCRIPTION
Backport of #3107 on release-0.18.

#3107: Remove DeleteAllOf call for deployments in SD controller

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.