### PR TITLE
Automated backport of #3104: Set BrokerK8sSecret in the ServiceDiscovery resource

### DIFF
--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -48,6 +48,7 @@ func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner 
 					BrokerK8sApiServerToken:  submariner.Spec.BrokerK8sApiServerToken,
 					BrokerK8sApiServer:       submariner.Spec.BrokerK8sApiServer,
 					BrokerK8sInsecure:        submariner.Spec.BrokerK8sInsecure,
+					BrokerK8sSecret:          submariner.Spec.BrokerK8sSecret,
 					HaltOnCertificateError:   submariner.Spec.HaltOnCertificateError,
 					Debug:                    submariner.Spec.Debug,
 					ClusterID:                submariner.Spec.ClusterID,

--- a/controllers/test/driver.go
+++ b/controllers/test/driver.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
 	admtest "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/controllers/uninstall"
@@ -71,7 +72,8 @@ func (d *Driver) JustBeforeEach() {
 
 func (d *Driver) NewScopedClient() client.Client {
 	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(d.InitScopedClientObjs...).
-		WithStatusSubresource(&v1alpha1.Submariner{}).WithInterceptorFuncs(d.InterceptorFuncs).Build()
+		WithStatusSubresource(&v1alpha1.Submariner{}).WithInterceptorFuncs(d.InterceptorFuncs).
+		WithRESTMapper(test.GetRESTMapperFor(&corev1.Secret{})).Build()
 }
 
 func (d *Driver) NewGeneralClient() client.Client {


### PR DESCRIPTION
Backport of #3104 on release-0.18.

#3104: Set BrokerK8sSecret in the ServiceDiscovery resource

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.