### PR TITLE
Automated backport of #3064: Configure SAs to enforce mountable secrets

### DIFF
--- a/config/rbac/lighthouse-agent/service_account.yaml
+++ b/config/rbac/lighthouse-agent/service_account.yaml
@@ -3,3 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-agent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret

--- a/config/rbac/lighthouse-coredns/service_account.yaml
+++ b/config/rbac/lighthouse-coredns/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-coredns
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-diagnose/service_account.yaml
+++ b/config/rbac/submariner-diagnose/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-diagnose
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-gateway/service_account.yaml
+++ b/config/rbac/submariner-gateway/service_account.yaml
@@ -3,3 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-gateway
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret
+  - name: submariner-ipsec-psk

--- a/config/rbac/submariner-globalnet/service_account.yaml
+++ b/config/rbac/submariner-globalnet/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-globalnet
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-operator/service_account.yaml
+++ b/config/rbac/submariner-operator/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-route-agent/service_account.yaml
+++ b/config/rbac/submariner-route-agent/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-routeagent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -25,7 +25,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: brokers.submariner.io
 spec:
   group: submariner.io
@@ -98,7 +98,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -1092,7 +1092,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io
@@ -1247,7 +1247,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: clusters.submariner.io
 spec:
   group: submariner.io
@@ -1318,7 +1318,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: endpoints.submariner.io
 spec:
   group: submariner.io
@@ -1399,7 +1399,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: gateways.submariner.io
 spec:
   group: submariner.io
@@ -1572,7 +1572,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: clusterglobalegressips.submariner.io
 spec:
   group: submariner.io
@@ -1711,7 +1711,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: globalegressips.submariner.io
 spec:
   group: submariner.io
@@ -1897,7 +1897,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: globalingressips.submariner.io
 spec:
   group: submariner.io
@@ -2057,7 +2057,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: gatewayroutes.submariner.io
 spec:
   group: submariner.io
@@ -2118,7 +2118,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: nongatewayroutes.submariner.io
 spec:
   group: submariner.io
@@ -2588,6 +2588,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_operator_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2834,6 +2836,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-gateway
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret
+  - name: submariner-ipsec-psk
 `
 	Config_rbac_submariner_gateway_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2957,6 +2964,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-routeagent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_route_agent_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3098,6 +3107,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-globalnet
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_globalnet_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3257,6 +3268,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-diagnose
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_diagnose_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3406,6 +3419,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-agent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret
 `
 	Config_rbac_lighthouse_agent_cluster_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3519,6 +3536,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-coredns
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_lighthouse_coredns_cluster_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #3064 on release-0.17.

#3064: Configure SAs to enforce mountable secrets

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.