### PR TITLE
Automated backport of #3064: Configure SAs to enforce mountable secrets

### DIFF
--- a/config/rbac/lighthouse-agent/service_account.yaml
+++ b/config/rbac/lighthouse-agent/service_account.yaml
@@ -3,3 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-agent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret

--- a/config/rbac/lighthouse-coredns/service_account.yaml
+++ b/config/rbac/lighthouse-coredns/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-coredns
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-diagnose/service_account.yaml
+++ b/config/rbac/submariner-diagnose/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-diagnose
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-gateway/service_account.yaml
+++ b/config/rbac/submariner-gateway/service_account.yaml
@@ -3,3 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-gateway
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret
+  - name: submariner-ipsec-psk

--- a/config/rbac/submariner-globalnet/service_account.yaml
+++ b/config/rbac/submariner-globalnet/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-globalnet
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-operator/service_account.yaml
+++ b/config/rbac/submariner-operator/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/config/rbac/submariner-route-agent/service_account.yaml
+++ b/config/rbac/submariner-route-agent/service_account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-routeagent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2497,6 +2497,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_operator_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2743,6 +2745,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-gateway
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret
+  - name: submariner-ipsec-psk
 `
 	Config_rbac_submariner_gateway_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2866,6 +2873,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-routeagent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_route_agent_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3006,6 +3015,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-globalnet
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_globalnet_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3165,6 +3176,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-diagnose
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_diagnose_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3314,6 +3327,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-agent
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+secrets:
+  - name: submariner-broker-secret
 `
 	Config_rbac_lighthouse_agent_cluster_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3427,6 +3444,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-lighthouse-coredns
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_lighthouse_coredns_cluster_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #3064 on release-0.16.

#3064: Configure SAs to enforce mountable secrets

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.