### PR TITLE
Add healthcheck configuration and RBAC in route agent and register crds

### DIFF
--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -41,6 +41,7 @@ rules:
       - nongatewayroutes
       - servicediscoveries
       - submariners
+      - routeagents
     verbs:
       - get
       - list

--- a/config/rbac/submariner-route-agent/role.yaml
+++ b/config/rbac/submariner-route-agent/role.yaml
@@ -25,3 +25,13 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - submariner.io
+    resources:
+      - routeagents
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete

--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -45,6 +45,18 @@ func (r *Reconciler) reconcileRouteagentDaemonSet(ctx context.Context, instance 
 }
 
 func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonSet {
+	// Default healthCheck Values
+	healthCheckEnabled := true
+	// The values are in seconds
+	healthCheckInterval := uint64(1)
+	healthCheckMaxPacketLossCount := uint64(5)
+
+	if cr.Spec.ConnectionHealthCheck != nil {
+		healthCheckEnabled = cr.Spec.ConnectionHealthCheck.Enabled
+		healthCheckInterval = cr.Spec.ConnectionHealthCheck.IntervalSeconds
+		healthCheckMaxPacketLossCount = cr.Spec.ConnectionHealthCheck.MaxPacketLossCount
+	}
+
 	labels := map[string]string{
 		"app":       name,
 		"component": "routeagent",
@@ -142,6 +154,9 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 										FieldPath: "spec.nodeName",
 									},
 								}},
+								{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
+								{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(healthCheckInterval, 10)},
+								{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(healthCheckMaxPacketLossCount, 10)},
 							}),
 						},
 					},

--- a/pkg/embeddedyamls/generators/yamls2go.go
+++ b/pkg/embeddedyamls/generators/yamls2go.go
@@ -42,6 +42,7 @@ var files = []string{
 	"deploy/submariner/crds/submariner.io_globalingressips.yaml",
 	"deploy/submariner/crds/submariner.io_gatewayroutes.yaml",
 	"deploy/submariner/crds/submariner.io_nongatewayroutes.yaml",
+	"deploy/submariner/crds/submariner.io_routeagents.yaml",
 	"deploy/mcsapi/crds/multicluster.x_k8s.io_serviceexports.yaml",
 	"deploy/mcsapi/crds/multicluster.x_k8s.io_serviceimports.yaml",
 	"config/broker/broker-admin/service_account.yaml",

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2196,6 +2196,127 @@ spec:
     served: true
     storage: true
 `
+	Deploy_submariner_crds_submariner_io_routeagents_yaml = `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: routeagents.submariner.io
+spec:
+  group: submariner.io
+  names:
+    kind: RouteAgent
+    listKind: RouteAgentList
+    plural: routeagents
+    singular: routeagent
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            properties:
+              remoteEndpoints:
+                items:
+                  properties:
+                    latencyRTT:
+                      description: |-
+                        LatencySpec describes the round trip time information for a packet
+                        between the gateway pods of two clusters.
+                      properties:
+                        average:
+                          type: string
+                        last:
+                          type: string
+                        max:
+                          type: string
+                        min:
+                          type: string
+                        stdDev:
+                          type: string
+                      type: object
+                    spec:
+                      properties:
+                        backend:
+                          type: string
+                        backend_config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        cable_name:
+                          type: string
+                        cluster_id:
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                        healthCheckIP:
+                          type: string
+                        hostname:
+                          type: string
+                        nat_enabled:
+                          type: boolean
+                        private_ip:
+                          type: string
+                        public_ip:
+                          type: string
+                        subnets:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - backend
+                      - cable_name
+                      - cluster_id
+                      - hostname
+                      - nat_enabled
+                      - private_ip
+                      - public_ip
+                      - subnets
+                      type: object
+                    status:
+                      type: string
+                    statusMessage:
+                      type: string
+                  required:
+                  - spec
+                  - status
+                  - statusMessage
+                  type: object
+                type: array
+              statusFailure:
+                type: string
+              version:
+                type: string
+            required:
+            - remoteEndpoints
+            - statusFailure
+            - version
+            type: object
+        required:
+        - status
+        type: object
+    served: true
+    storage: true
+`
 	Deploy_mcsapi_crds_multicluster_x_k8s_io_serviceexports_yaml = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3018,6 +3139,16 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - submariner.io
+    resources:
+      - routeagents
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
 `
 	Config_rbac_submariner_route_agent_role_binding_yaml = `---
 kind: RoleBinding
@@ -3337,6 +3468,7 @@ rules:
       - nongatewayroutes
       - servicediscoveries
       - submariners
+      - routeagents
     verbs:
       - get
       - list

--- a/pkg/gateway/crds.go
+++ b/pkg/gateway/crds.go
@@ -80,5 +80,11 @@ func Ensure(ctx context.Context, crdUpdater crd.Updater) error {
 		return errors.Wrap(err, "error getting non-Gateway routes")
 	}
 
+	_, err = crdUpdater.CreateOrUpdateFromEmbedded(ctx,
+		embeddedyamls.Deploy_submariner_crds_submariner_io_routeagents_yaml)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrap(err, "error getting Route Agent")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Add the healthcheker configuration in route agent and give
permission for routegent permission for crud operation of
routeagent resources.

Register the routeagent crds
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
