### PR TITLE
Fix SD error updating Openshift operator DNS instance

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,7 +196,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	generalClient, _ := client.New(mgr.GetConfig(), client.Options{})
+	generalClient, _ := client.New(mgr.GetConfig(), client.Options{
+		Scheme: scheme,
+	})
 
 	if err = submariner.NewReconciler(&submariner.Config{
 		ScopedClient:  mgr.GetClient(),


### PR DESCRIPTION
This error was observed from the `ServiceDiscovery` controller:

"_error updating Openshift DNS operator: no kind is registered for the type v1.DNS in scheme
"k8s.io/client-go/kubernetes/scheme/register.go:79"_"

The Openshift operator types are added to the scheme used by the controller manager but the `GeneralClient` needs to be set up with the same scheme.
