### PR TITLE
Automated backport of #3155: Fix SD error updating Openshift operator DNS instance

### DIFF
--- a/main.go
+++ b/main.go
@@ -190,7 +190,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	generalClient, _ := client.New(mgr.GetConfig(), client.Options{})
+	generalClient, _ := client.New(mgr.GetConfig(), client.Options{
+		Scheme: scheme,
+	})
 
 	if err = submariner.NewReconciler(&submariner.Config{
 		ScopedClient:  mgr.GetClient(),


### PR DESCRIPTION
Backport of #3155 on release-0.14.

#3155: Fix SD error updating Openshift operator DNS instance

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.