### PR TITLE
Reduce params in metrics.Setup

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -683,8 +683,15 @@ func (r *Reconciler) ensureLightHouseAgent(ctx context.Context, instance *submar
 		return errors.Wrap(err, "error reconciling agent deployment")
 	}
 
-	err := metrics.Setup(ctx, names.ServiceDiscoveryComponent, instance.Namespace, "app", names.ServiceDiscoveryComponent,
-		instance, 8082, r.ScopedClient, r.RestConfig, r.Scheme, reqLogger)
+	err := metrics.Setup(ctx, r.ScopedClient, r.RestConfig, r.Scheme,
+		&metrics.ServiceInfo{
+			Name:            names.ServiceDiscoveryComponent,
+			Namespace:       instance.Namespace,
+			ApplicationKey:  "app",
+			ApplicationName: names.ServiceDiscoveryComponent,
+			Owner:           instance,
+			Port:            8082,
+		}, reqLogger)
 	if err != nil {
 		return errors.Wrap(err, "error setting up metrics")
 	}
@@ -702,8 +709,15 @@ func (r *Reconciler) ensureLighthouseCoreDNSDeployment(ctx context.Context, inst
 		return errors.Wrap(err, "error reconciling coredns deployment")
 	}
 
-	err := metrics.Setup(ctx, names.LighthouseCoreDNSComponent, instance.Namespace, "app", names.LighthouseCoreDNSComponent, instance,
-		9153, r.ScopedClient, r.RestConfig, r.Scheme, reqLogger)
+	err := metrics.Setup(ctx, r.ScopedClient, r.RestConfig, r.Scheme,
+		&metrics.ServiceInfo{
+			Name:            names.LighthouseCoreDNSComponent,
+			Namespace:       instance.Namespace,
+			ApplicationKey:  "app",
+			ApplicationName: names.LighthouseCoreDNSComponent,
+			Owner:           instance,
+			Port:            9153,
+		}, reqLogger)
 	if err != nil {
 		return errors.Wrap(err, "error setting up coredns metrics")
 	}

--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -260,8 +260,15 @@ func (r *Reconciler) reconcileGatewayDaemonSet(
 		return nil, err
 	}
 
-	err = metrics.Setup(ctx, names.GatewayComponent, instance.Namespace, "app", names.MetricsProxyComponent, instance,
-		gatewayMetricsServicePort, r.config.ScopedClient, r.config.RestConfig, r.config.Scheme, reqLogger)
+	err = metrics.Setup(ctx, r.config.ScopedClient, r.config.RestConfig, r.config.Scheme,
+		&metrics.ServiceInfo{
+			Name:            names.GatewayComponent,
+			Namespace:       instance.Namespace,
+			ApplicationKey:  "app",
+			ApplicationName: names.MetricsProxyComponent,
+			Owner:           instance,
+			Port:            gatewayMetricsServicePort,
+		}, reqLogger)
 
 	return daemonSet, err
 }

--- a/controllers/submariner/globalnet_resources.go
+++ b/controllers/submariner/globalnet_resources.go
@@ -44,8 +44,15 @@ func (r *Reconciler) reconcileGlobalnetDaemonSet(ctx context.Context, instance *
 		return nil, err
 	}
 
-	err = metrics.Setup(ctx, names.GlobalnetComponent, instance.Namespace, "app", names.MetricsProxyComponent,
-		instance, globalnetMetricsServicePort, r.config.ScopedClient, r.config.RestConfig, r.config.Scheme, reqLogger)
+	err = metrics.Setup(ctx, r.config.ScopedClient, r.config.RestConfig, r.config.Scheme,
+		&metrics.ServiceInfo{
+			Name:            names.GlobalnetComponent,
+			Namespace:       instance.Namespace,
+			ApplicationKey:  "app",
+			ApplicationName: names.MetricsProxyComponent,
+			Owner:           instance,
+			Port:            globalnetMetricsServicePort,
+		}, reqLogger)
 
 	return daemonSet, err
 }

--- a/main.go
+++ b/main.go
@@ -196,7 +196,14 @@ func main() {
 		log.Error(err, "Error obtaining a Kubernetes client")
 	}
 
-	if err := metrics.Setup(ctx, name, namespace, "name", name, nil, metricsPort, metricsClient, cfg, scheme, log); err != nil {
+	if err := metrics.Setup(ctx, metricsClient, cfg, scheme,
+		&metrics.ServiceInfo{
+			Name:            name,
+			Namespace:       namespace,
+			ApplicationKey:  "name",
+			ApplicationName: name,
+			Port:            metricsPort,
+		}, log); err != nil {
 		log.Error(err, "Error setting up metrics services and monitors")
 	}
 


### PR DESCRIPTION
11 params was flagged by Sonar so move the service-related ones to a ServiceInfo struct to reduce it to 6.
