### PR TITLE
Remove TODO in controllers/submariner/submariner_controller.go

### DIFF
--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -248,8 +248,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	// TODO: vthapar Add metrics-proxy status to Submariner CR so we can update it with daemonset status
-
 	if loadBalancer != nil {
 		instance.Status.LoadBalancerStatus.Status = &loadBalancer.Status.LoadBalancer
 	} else {


### PR DESCRIPTION
"_vthapar Add metrics-proxy status to Submariner CR so we can update it with daemonset status_"

Issue https://github.com/submariner-io/submariner-operator/issues/3169 created to track this.
