### PR TITLE
Use NewClientset instead of NewSimpleClientset

### DIFF
--- a/pkg/crd/updater_test.go
+++ b/pkg/crd/updater_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Updater", func() {
 	)
 
 	BeforeEach(func() {
-		client = extendedfakeclientset.NewSimpleClientset()
+		client = extendedfakeclientset.NewClientset()
 		updater = crd.UpdaterFromClientSet(client)
 	})
 


### PR DESCRIPTION
The latter is deprecated in Kubernetes 1.31.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
