### PR TITLE
Bump shipyard and address golangci-lint v1.60.3 errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,7 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     # - cyclop # This is equivalent to gocyclo
     # - depguard # depguard now denies by default, it should only be enabled if we actually use it
     - dogsled
@@ -67,7 +68,6 @@ linters:
     - errname
     - exhaustive
     # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
-    - exportloopref
     # - forbidigo # We don't forbid any statements
     # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful

--- a/controllers/submariner/gateway_resources.go
+++ b/controllers/submariner/gateway_resources.go
@@ -169,8 +169,8 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          encapsPortName,
-							HostPort:      int32(cr.Spec.CeIPSecNATTPort),
-							ContainerPort: int32(cr.Spec.CeIPSecNATTPort),
+							HostPort:      toInt32(cr.Spec.CeIPSecNATTPort),
+							ContainerPort: toInt32(cr.Spec.CeIPSecNATTPort),
 							Protocol:      corev1.ProtocolUDP,
 						},
 						{
@@ -324,4 +324,8 @@ func (r *Reconciler) retrieveGateways(ctx context.Context, owner metav1.Object,
 	}
 
 	return foundGateways.Items, nil
+}
+
+func toInt32(from int) int32 {
+	return int32(from) //nolint:gosec // Need to ignore reported integer overflow conversion
 }

--- a/controllers/submariner/loadbalancer_resources.go
+++ b/controllers/submariner/loadbalancer_resources.go
@@ -125,8 +125,8 @@ func newLoadBalancerService(instance *v1alpha1.Submariner, platformTypeOCP strin
 			Ports: []corev1.ServicePort{
 				{
 					Name:       encapsPortName,
-					Port:       int32(instance.Spec.CeIPSecNATTPort),
-					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: int32(instance.Spec.CeIPSecNATTPort)},
+					Port:       toInt32(instance.Spec.CeIPSecNATTPort),
+					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: toInt32(instance.Spec.CeIPSecNATTPort)},
 					Protocol:   corev1.ProtocolUDP,
 				},
 				{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/go-logr/logr v1.4.2
-	github.com/onsi/ginkgo/v2 v2.20.0
+	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v0.0.0-20230714214528-de6ad7979b00
 	github.com/operator-framework/operator-lib v0.14.0
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.76.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/submariner-io/admiral v0.19.0-m2.0.20240820215844-1487e5c4b941
-	github.com/submariner-io/shipyard v0.19.0-m2
+	github.com/submariner-io/shipyard v0.19.0-m2.0.20240828133900-3d3c2316f606
 	github.com/submariner-io/submariner v0.19.0-m2
 	golang.org/x/net v0.28.0
 	golang.org/x/text v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo/v2 v2.20.0 h1:PE84V2mHqoT1sglvHc8ZdQtPcwmvvt29WLEEO3xmdZw=
-github.com/onsi/ginkgo/v2 v2.20.0/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
+github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo=
+github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -393,8 +393,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/submariner-io/admiral v0.19.0-m2.0.20240820215844-1487e5c4b941 h1:E504VAAKuggnzhTGOFr3X5/beHOKLYS3tqJIIffRpbg=
 github.com/submariner-io/admiral v0.19.0-m2.0.20240820215844-1487e5c4b941/go.mod h1:f4xzFML4SRqETWcyZ32iTy8DH0gLUt2+jrYu6VGXL4Q=
-github.com/submariner-io/shipyard v0.19.0-m2 h1:vOVbz4p+391s6H9lO6JL4t+gNoRdhmbESbx2vzmcGQg=
-github.com/submariner-io/shipyard v0.19.0-m2/go.mod h1:91eQ4sF5XgbJxJUrXvY7u33gGGjaz5ofjLYaZyYXEls=
+github.com/submariner-io/shipyard v0.19.0-m2.0.20240828133900-3d3c2316f606 h1:0C59+84WEc0n8yuFCL4xNKmDhAZ5o/cGLiIzZy1It/s=
+github.com/submariner-io/shipyard v0.19.0-m2.0.20240828133900-3d3c2316f606/go.mod h1:Ith3HTqWhsEMmq26xw66OFYlGWO0p9Id86Cw0MIFbqQ=
 github.com/submariner-io/submariner v0.19.0-m2 h1:qCNV17T55gIYtgDyMGJevrmUlr+nO4YA5GIlnkJTzLg=
 github.com/submariner-io/submariner v0.19.0-m2/go.mod h1:+agj3FglAMfAzOM0d4c/ZTjwBIdvFJjJedMlwJxHboc=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
Specifically, gosec "integer overflow conversion" issues.

Depends on https://github.com/submariner-io/shipyard/pull/1715
