### PR TITLE
Add clustersetip config to LH deployments

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -238,6 +238,8 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 							Env: httpproxy.AddEnvVars([]corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
+								{Name: "SUBMARINER_CLUSTERSET_IP_CIDR", Value: cr.Spec.ClustersetIPCIDR},
+								{Name: "SUBMARINER_CLUSTERSET_IP_ENABLED", Value: strconv.FormatBool(cr.Spec.ClustersetIPEnabled)},
 								{Name: "SUBMARINER_DEBUG", Value: strconv.FormatBool(cr.Spec.Debug)},
 								{Name: "SUBMARINER_GLOBALNET_ENABLED", Value: strconv.FormatBool(cr.Spec.GlobalnetEnabled)},
 								{Name: "SUBMARINER_HALT_ON_CERT_ERROR", Value: strconv.FormatBool(cr.Spec.HaltOnCertificateError)},

--- a/controllers/submariner/servicediscovery_resources.go
+++ b/controllers/submariner/servicediscovery_resources.go
@@ -54,6 +54,8 @@ func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner 
 					ClusterID:                submariner.Spec.ClusterID,
 					Namespace:                submariner.Spec.Namespace,
 					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
+					ClustersetIPEnabled:      submariner.Spec.ClustersetIPEnabled,
+					ClustersetIPCIDR:         submariner.Spec.ClustersetIPCIDR,
 					ImageOverrides:           submariner.Spec.ImageOverrides,
 					CoreDNSCustomConfig:      submariner.Spec.CoreDNSCustomConfig,
 					NodeSelector:             submariner.Spec.NodeSelector,

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -225,6 +225,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	instance.Status.ColorCodes = instance.Spec.ColorCodes
 	instance.Status.ClusterID = instance.Spec.ClusterID
 	instance.Status.GlobalCIDR = instance.Spec.GlobalCIDR
+	instance.Status.ClustersetIPCIDR = instance.Spec.ClustersetIPCIDR
 	instance.Status.Gateways = &gatewayStatuses
 
 	err = updateDaemonSetStatus(ctx, r.config.ScopedClient, gatewayDaemonSet, &instance.Status.GatewayDaemonSetStatus, request.Namespace)

--- a/controllers/submariner/submariner_suite_test.go
+++ b/controllers/submariner/submariner_suite_test.go
@@ -236,6 +236,7 @@ func (t *testDriver) withNetworkDiscovery() *v1alpha1.Submariner {
 	t.submariner.Status.ClusterCIDR = getClusterCIDR(t.submariner, t.clusterNetwork)
 	t.submariner.Status.ServiceCIDR = getServiceCIDR(t.submariner, t.clusterNetwork)
 	t.submariner.Status.GlobalCIDR = getGlobalCIDR(t.submariner, t.clusterNetwork)
+	t.submariner.Status.ClustersetIPCIDR = getClustersetIPCIDR(t.submariner, t.clusterNetwork)
 	t.submariner.Status.NetworkPlugin = t.clusterNetwork.NetworkPlugin
 
 	return t.submariner
@@ -292,4 +293,12 @@ func getGlobalCIDR(submariner *v1alpha1.Submariner, clusterNetwork *network.Clus
 	}
 
 	return clusterNetwork.GlobalCIDR
+}
+
+func getClustersetIPCIDR(submariner *v1alpha1.Submariner, clusterNetwork *network.ClusterNetwork) string {
+	if submariner.Spec.ClustersetIPCIDR != "" {
+		return submariner.Spec.ClustersetIPCIDR
+	}
+
+	return clusterNetwork.ClustersetIPCIDR
 }

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -314,6 +314,7 @@ var _ = Describe("Generic Network", func() {
 
 	When("the Submariner resource exists", func() {
 		const globalCIDR = "242.112.0.0/24"
+		const clustersetIPCIDR = "243.110.0.0/20"
 
 		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(ctx, &v1alpha1.Submariner{
@@ -321,13 +322,19 @@ var _ = Describe("Generic Network", func() {
 					Name: names.SubmarinerCrName,
 				},
 				Spec: v1alpha1.SubmarinerSpec{
-					GlobalCIDR: globalCIDR,
+					GlobalCIDR:       globalCIDR,
+					ClustersetIPCIDR: clustersetIPCIDR,
 				},
 			})
 		})
 
 		It("should return the ClusterNetwork structure with the global CIDR", func() {
 			Expect(clusterNet.GlobalCIDR).To(Equal(globalCIDR))
+			clusterNet.Show()
+		})
+
+		It("should return the ClusterNetwork structure with the clustersetIP CIDR", func() {
+			Expect(clusterNet.ClustersetIPCIDR).To(Equal(clustersetIPCIDR))
 			clusterNet.Show()
 		})
 	})


### PR DESCRIPTION
Deploy Lighthouse deployments with new ClustersetIP fields in Submariner and ServiceDiscovery specs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
