### PR TITLE
Automated backport of #3220: Add TCP port to Lighthouse CoreDNS ClusterIP service

### DIFF
--- a/controllers/servicediscovery/servicediscovery_controller.go
+++ b/controllers/servicediscovery/servicediscovery_controller.go
@@ -385,15 +385,26 @@ func newLighthouseCoreDNSService(cr *submarinerv1alpha1.ServiceDiscovery) *corev
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name:     "udp",
-				Protocol: "UDP",
-				Port:     53,
-				TargetPort: intstr.IntOrString{
-					Type:   intstr.Int,
-					IntVal: 53,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "udp",
+					Protocol: "UDP",
+					Port:     53,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 53,
+					},
 				},
-			}},
+				{
+					Name:     "tcp",
+					Protocol: "TCP",
+					Port:     53,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 53,
+					},
+				},
+			},
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				"app": names.LighthouseCoreDNSComponent,

--- a/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -234,10 +234,13 @@ func (t *testDriver) assertLighthouseCoreDNSService(ctx context.Context) *corev1
 		service)).To(Succeed())
 
 	Expect(service.Labels).To(HaveKeyWithValue("app", lighthouseDNSServiceName))
-	Expect(service.Spec.Ports).To(HaveLen(1))
+	Expect(service.Spec.Ports).To(HaveLen(2))
 	Expect(service.Spec.Ports[0].Protocol).To(Equal(corev1.Protocol("UDP")))
 	Expect(service.Spec.Ports[0].Port).To(Equal(int32(53)))
 	Expect(service.Spec.Ports[0].TargetPort.IntVal).To(Equal(int32(53)))
+	Expect(service.Spec.Ports[1].Protocol).To(Equal(corev1.Protocol("TCP")))
+	Expect(service.Spec.Ports[1].Port).To(Equal(int32(53)))
+	Expect(service.Spec.Ports[1].TargetPort.IntVal).To(Equal(int32(53)))
 
 	return service
 }


### PR DESCRIPTION
Backport of #3220 on release-0.18.

#3220: Add TCP port to Lighthouse CoreDNS ClusterIP service

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.