### PR TITLE
Add clustersetip module to discovery

### DIFF
--- a/pkg/discovery/clustersetip/clustersetip.go
+++ b/pkg/discovery/clustersetip/clustersetip.go
@@ -1,0 +1,223 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustersetip
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/submariner-operator/pkg/cidr"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Info struct {
+	Enabled bool
+	cidr.Info
+}
+
+type Config struct {
+	ClusterID        string
+	ClustersetIPCIDR string
+	AllocationSize   uint
+}
+
+func AllocateClustersetIPCIDR(clustersetIPInfo *Info) (string, error) {
+	return cidr.Allocate(&clustersetIPInfo.Info) //nolint:wrapcheck // No need to wrap
+}
+
+func ValidateClustersetIPConfiguration(clustersetIPInfo *Info, netconfig Config, status reporter.Interface) (string, error) {
+	status.Start("Validating ClustersetIP configuration")
+	defer status.End()
+
+	clustersetIPClusterSize := netconfig.AllocationSize
+	clustersetIPCIDR := netconfig.ClustersetIPCIDR
+
+	if clustersetIPClusterSize != 0 && clustersetIPClusterSize != clustersetIPInfo.AllocationSize {
+		clusterSize, err := cidr.GetValidAllocationSize(clustersetIPInfo.CIDR, clustersetIPClusterSize)
+		if err != nil {
+			return "", status.Error(err, "invalid cluster size")
+		}
+
+		clustersetIPInfo.AllocationSize = clusterSize
+	}
+
+	if clustersetIPCIDR != "" && clustersetIPClusterSize != 0 {
+		status.Failure("Only one of cluster size and clustersetip CIDR can be specified")
+
+		return "", errors.New("only one of cluster size and clustersetip CIDR can be specified")
+	}
+
+	if clustersetIPCIDR != "" {
+		err := cidr.IsValid(clustersetIPCIDR)
+		if err != nil {
+			return "", errors.Wrap(err, "specified clustersetip-cidr is invalid")
+		}
+	}
+
+	return clustersetIPCIDR, nil
+}
+
+func GetClustersetIPNetworks(ctx context.Context, client controllerClient.Client, brokerNamespace string) (*Info, *v1.ConfigMap, error) {
+	configMap, err := GetConfigMap(ctx, client, brokerNamespace)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error retrieving clustersetip ConfigMap")
+	}
+
+	clustersetIPInfo := Info{}
+
+	err = json.Unmarshal([]byte(configMap.Data[clustersetIPEnabledKey]), &clustersetIPInfo.Enabled)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error reading clusersetIPEnabled status")
+	}
+
+	err = json.Unmarshal([]byte(configMap.Data[clustersetIPClusterSize]), &clustersetIPInfo.AllocationSize)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error reading ClustersetIPClusterSize")
+	}
+
+	err = json.Unmarshal([]byte(configMap.Data[clustersetIPCidrRange]), &clustersetIPInfo.CIDR)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error reading ClustersetIPCidrRange")
+	}
+
+	clustersetIPInfo.Clusters, err = cidr.ExtractClusterInfo(configMap)
+
+	return &clustersetIPInfo, configMap, err //nolint:wrapcheck // No need to wrap
+}
+
+func assignClustersetIPs(clustersetIPInfo *Info, netconfig Config, status reporter.Interface) (string, error) {
+	status.Start("Assigning ClustersetIP IPs")
+	defer status.End()
+
+	clustersetIPCIDR := netconfig.ClustersetIPCIDR
+	clusterID := netconfig.ClusterID
+	var err error
+
+	if clustersetIPCIDR == "" {
+		// ClustersetIPCIDR not specified by the user
+		if cidr.IsCIDRPreConfigured(clusterID, clustersetIPInfo.Clusters) {
+			// clustersetipCidr already configured on this cluster
+			clustersetIPCIDR = clustersetIPInfo.Clusters[clusterID].CIDRs[0]
+			status.Success("Using pre-configured clustersetip CIDR %s", clustersetIPCIDR)
+		} else {
+			// no clustersetipCidr configured on this cluster
+			clustersetIPCIDR, err = AllocateClustersetIPCIDR(clustersetIPInfo)
+			if err != nil {
+				return "", status.Error(err, "unable to allocate clustersetip CIDR")
+			}
+
+			status.Success(fmt.Sprintf("Allocated clustersetip CIDR %s", clustersetIPCIDR))
+		}
+	} else {
+		// ClustersetIP enabled, clustersetIPCIDR specified by user
+		if cidr.IsCIDRPreConfigured(clusterID, clustersetIPInfo.Clusters) {
+			// clustersetipCidr pre-configured on this cluster
+			clustersetIPCIDR = clustersetIPInfo.Clusters[clusterID].CIDRs[0]
+			status.Warning("A pre-configured clustersetip CIDR %s was detected - not using the specified CIDR %s",
+				clustersetIPCIDR, netconfig.ClustersetIPCIDR)
+		} else {
+			// clustersetipCidr as specified by the user
+			err := cidr.CheckForOverlappingCIDRs(clustersetIPInfo.Clusters, netconfig.ClustersetIPCIDR, netconfig.ClusterID)
+			if err != nil {
+				return "", status.Error(err, "error validating overlapping clustersetip CIDRs %s", clustersetIPCIDR)
+			}
+
+			status.Success("Using specified clustersetip CIDR %s", clustersetIPCIDR)
+		}
+	}
+
+	return clustersetIPCIDR, nil
+}
+
+func ValidateExistingClustersetIPNetworks(ctx context.Context, client controllerClient.Client, namespace string) error {
+	clustersetIPInfo, _, err := GetClustersetIPNetworks(ctx, client, namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return errors.Wrap(err, "error getting existing clustersetip configmap")
+	}
+
+	if clustersetIPInfo != nil {
+		if err = cidr.IsValid(clustersetIPInfo.CIDR); err != nil {
+			return errors.Wrap(err, "invalid ClustersetIPCidrRange")
+		}
+	}
+
+	return nil
+}
+
+func AllocateCIDRFromConfigMap(ctx context.Context, brokerAdminClient controllerClient.Client, brokerNamespace string,
+	netconfig *Config, status reporter.Interface,
+) error {
+	// Setup default clustersize if nothing specified
+	if netconfig.ClustersetIPCIDR == "" && netconfig.AllocationSize == 0 {
+		netconfig.AllocationSize = DefaultAllocationSize
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		status.Start("Retrieving ClustersetIP information from the Broker")
+		defer status.End()
+
+		clustersetIPInfo, clustersetIPConfigMap, err := GetClustersetIPNetworks(ctx, brokerAdminClient, brokerNamespace)
+		if err != nil {
+			return status.Error(err, "unable to retrieve ClustersetIP information")
+		}
+
+		netconfig.ClustersetIPCIDR, err = ValidateClustersetIPConfiguration(clustersetIPInfo, *netconfig, status)
+		if err != nil {
+			return status.Error(err, "error validating the ClustersetIP configuration")
+		}
+
+		netconfig.ClustersetIPCIDR, err = assignClustersetIPs(clustersetIPInfo, *netconfig, status)
+		if err != nil {
+			return status.Error(err, "error assigning ClustersetIP IPs")
+		}
+
+		if clustersetIPInfo.Clusters[netconfig.ClusterID] == nil ||
+			clustersetIPInfo.Clusters[netconfig.ClusterID].CIDRs[0] != netconfig.ClustersetIPCIDR {
+			newClusterInfo := cidr.ClusterInfo{
+				ClusterID: netconfig.ClusterID,
+				CIDRs:     []string{netconfig.ClustersetIPCIDR},
+			}
+
+			status.Start("Updating the ClustersetIP information on the Broker")
+
+			err = updateConfigMap(ctx, brokerAdminClient, clustersetIPConfigMap, newClusterInfo)
+			if apierrors.IsConflict(err) {
+				status.Warning("Conflict occurred updating the ClustersetIP ConfigMap - retrying")
+			} else {
+				return status.Error(err, "error updating the ClustersetIP ConfigMap")
+			}
+
+			return err
+		}
+
+		return nil
+	})
+
+	return retryErr //nolint:wrapcheck // No need to wrap here
+}

--- a/pkg/discovery/clustersetip/clustersetip_suite_test.go
+++ b/pkg/discovery/clustersetip/clustersetip_suite_test.go
@@ -1,0 +1,30 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clustersetip_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestClsutersetIP(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClustersetIP Suite")
+}

--- a/pkg/discovery/clustersetip/clustersetip_test.go
+++ b/pkg/discovery/clustersetip/clustersetip_test.go
@@ -1,0 +1,140 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustersetip_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/submariner-operator/pkg/cidr"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/clustersetip"
+	"k8s.io/client-go/kubernetes/scheme"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const namespace = "test-ns"
+
+var _ = Describe("AllocateCIDRFromConfigMap", func() {
+	var client controllerClient.Client
+
+	BeforeEach(func(ctx SpecContext) {
+		client = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		Expect(clustersetip.CreateConfigMap(ctx, client, true, "168.254.0.0/16",
+			8192, namespace)).To(Succeed())
+	})
+
+	When("the clustersetip CIDR is not specified", func() {
+		const expClustersetIPCIDR = "168.254.0.0/20"
+
+		It("should allocate a new one", func(ctx SpecContext) {
+			netconfig := &clustersetip.Config{
+				ClusterID: "east",
+			}
+
+			Expect(clustersetip.AllocateCIDRFromConfigMap(ctx, client, namespace,
+				netconfig, reporter.Klog())).To(Succeed())
+			Expect(netconfig.ClustersetIPCIDR).To(Equal(expClustersetIPCIDR))
+
+			clustersetipInfo, _, err := clustersetip.GetClustersetIPNetworks(ctx, client, namespace)
+			Expect(err).To(Succeed())
+			Expect(clustersetipInfo.Clusters).To(HaveKeyWithValue(netconfig.ClusterID, &cidr.ClusterInfo{
+				CIDRs:     []string{expClustersetIPCIDR},
+				ClusterID: netconfig.ClusterID,
+			}))
+
+			netconfig.ClustersetIPCIDR = ""
+			Expect(clustersetip.AllocateCIDRFromConfigMap(ctx, client, namespace,
+				netconfig, reporter.Klog())).To(Succeed())
+			Expect(netconfig.ClustersetIPCIDR).To(Equal(expClustersetIPCIDR))
+		})
+	})
+
+	When("the clustersetip CIDR is specified", func() {
+		const expClustersetIPCIDR = "168.254.0.0/15"
+
+		It("should not allocate a new one", func(ctx SpecContext) {
+			netconfig := &clustersetip.Config{
+				ClusterID:        "east",
+				ClustersetIPCIDR: expClustersetIPCIDR,
+			}
+
+			Expect(clustersetip.AllocateCIDRFromConfigMap(ctx, client, namespace,
+				netconfig, reporter.Klog())).To(Succeed())
+			Expect(netconfig.ClustersetIPCIDR).To(Equal(expClustersetIPCIDR))
+
+			clustersetipInfo, _, err := clustersetip.GetClustersetIPNetworks(ctx, client, namespace)
+			Expect(err).To(Succeed())
+			Expect(clustersetipInfo.Clusters).To(HaveKeyWithValue(netconfig.ClusterID, &cidr.ClusterInfo{
+				CIDRs:     []string{expClustersetIPCIDR},
+				ClusterID: netconfig.ClusterID,
+			}))
+
+			netconfig.ClustersetIPCIDR = ""
+			Expect(clustersetip.AllocateCIDRFromConfigMap(ctx, client, namespace,
+				netconfig, reporter.Klog())).To(Succeed())
+			Expect(netconfig.ClustersetIPCIDR).To(Equal(expClustersetIPCIDR))
+		})
+	})
+
+	When("the clustersetip cluster size is specified", func() {
+		It("should allocate a CIDR", func(ctx SpecContext) {
+			netconfig := &clustersetip.Config{
+				ClusterID:      "east",
+				AllocationSize: 1024,
+			}
+
+			Expect(clustersetip.AllocateCIDRFromConfigMap(ctx, client, namespace,
+				netconfig, reporter.Klog())).To(Succeed())
+			Expect(netconfig.ClustersetIPCIDR).To(Equal("168.254.0.0/22"))
+		})
+	})
+})
+
+var _ = Describe("ValidateExistingClustersetIPNetworks", func() {
+	var client controllerClient.Client
+
+	BeforeEach(func() {
+		client = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	})
+
+	When("the existing clustersetip config is valid", func() {
+		It("should succeed", func(ctx SpecContext) {
+			Expect(clustersetip.CreateConfigMap(ctx, client, true, clustersetip.DefaultCIDR,
+				clustersetip.DefaultAllocationSize, namespace)).To(Succeed())
+
+			Expect(clustersetip.ValidateExistingClustersetIPNetworks(ctx, client, namespace)).To(Succeed())
+		})
+	})
+
+	When("the clustersetip config does not exist", func() {
+		It("should succeed", func(ctx SpecContext) {
+			Expect(clustersetip.ValidateExistingClustersetIPNetworks(ctx, client, namespace)).To(Succeed())
+		})
+	})
+
+	When("the existing clustersetip CIDR is invalid", func() {
+		It("should return an error", func(ctx SpecContext) {
+			Expect(clustersetip.CreateConfigMap(ctx, client, true, "169.254.0.0/16",
+				clustersetip.DefaultAllocationSize, namespace)).To(Succeed())
+
+			Expect(clustersetip.ValidateExistingClustersetIPNetworks(ctx, client, namespace)).ToNot(Succeed())
+		})
+	})
+})

--- a/pkg/discovery/clustersetip/config_map.go
+++ b/pkg/discovery/clustersetip/config_map.go
@@ -1,0 +1,111 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustersetip
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner-operator/pkg/cidr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clustersetIPConfigMapName = "submariner-clustersetip-info"
+	clustersetIPEnabledKey    = "clustersetIPEnabled"
+	clustersetIPCidrRange     = "clustersetIPCidrRange"
+	clustersetIPClusterSize   = "clustersetIPClusterSize"
+	DefaultCIDR               = "243.0.0.0/8"
+	DefaultAllocationSize     = 4096 // i.e., x.x.x.x/20 subnet mask
+)
+
+func CreateConfigMap(ctx context.Context, client controllerClient.Client, clustersetIPEnabled bool,
+	defaultClustersetIPCidrRange string, defaultClustersetIPClusterSize uint, namespace string,
+) error {
+	gnConfigMap, err := NewClustersetIPConfigMap(clustersetIPEnabled, defaultClustersetIPCidrRange,
+		defaultClustersetIPClusterSize, namespace)
+	if err != nil {
+		return errors.Wrap(err, "error creating clustersetip config map")
+	}
+
+	err = client.Create(ctx, gnConfigMap)
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return errors.Wrapf(err, "error creating clustersetip ConfigMap")
+}
+
+func NewClustersetIPConfigMap(clustersetIPEnabled bool, defaultClusteretIPCidrRange string,
+	defaultClustersetIPClusterSize uint, namespace string,
+) (*corev1.ConfigMap, error) {
+	cidrRange, err := json.Marshal(defaultClusteretIPCidrRange)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error marshalling clustersetIP CIDR range")
+	}
+
+	data := map[string]string{
+		clustersetIPEnabledKey:  strconv.FormatBool(clustersetIPEnabled),
+		clustersetIPCidrRange:   string(cidrRange),
+		clustersetIPClusterSize: fmt.Sprint(defaultClustersetIPClusterSize),
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clustersetIPConfigMapName,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+
+	return cm, nil
+}
+
+func updateConfigMap(ctx context.Context, client controllerClient.Client, configMap *corev1.ConfigMap, newCluster cidr.ClusterInfo,
+) error {
+	err := cidr.AddClusterInfoData(configMap, newCluster)
+	if err != nil {
+		return errors.Wrapf(err, "error adding ClusterInfo")
+	}
+
+	err = client.Update(ctx, configMap)
+
+	return errors.Wrapf(err, "error updating clustersetip ConfigMap")
+}
+
+//nolint:wrapcheck // No need to wrap here
+func GetConfigMap(ctx context.Context, client controllerClient.Client, namespace string) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	return cm, client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: clustersetIPConfigMapName}, cm)
+}
+
+//nolint:wrapcheck // No need to wrap here
+func DeleteConfigMap(ctx context.Context, client controllerClient.Client, namespace string) error {
+	return client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      clustersetIPConfigMapName,
+		Namespace: namespace,
+	}})
+}


### PR DESCRIPTION
...to allow subctl to allocate clustersetIP cidrs during join

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
