### PR TITLE
Automated backport of #3273: Add init container to the gateway to wait for node readiness

### DIFF
--- a/controllers/submariner/route_agent_resources.go
+++ b/controllers/submariner/route_agent_resources.go
@@ -110,7 +110,6 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 							Name:            name + "-init",
 							Image:           getImagePath(cr, opnames.RouteAgentImage, names.RouteAgentComponent),
 							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.RouteAgentComponent]),
-							Command:         []string{"submariner-route-agent.sh"},
 							Env: httpproxy.AddEnvVars([]corev1.EnvVar{
 								{Name: "SUBMARINER_WAITFORNODE", Value: "true"},
 								{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Backport of #3273 on release-0.19.

#3273: Add init container to the gateway to wait for node readiness

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.