### PR TITLE
Optimize the logic of finding cluster service/pod ip range

### DIFF
--- a/pkg/discovery/network/generic.go
+++ b/pkg/discovery/network/generic.go
@@ -82,6 +82,11 @@ func findClusterIPRange(ctx context.Context, client controllerClient.Client) (st
 		return clusterIPRange, err
 	}
 
+	clusterIPRange, err = findClusterIPRangeFromKubeController(ctx, client)
+	if err != nil || clusterIPRange != "" {
+		return clusterIPRange, err
+	}
+
 	clusterIPRange, err = findClusterIPRangeFromServiceCreation(ctx, client)
 	if err != nil || clusterIPRange != "" {
 		return clusterIPRange, err
@@ -92,6 +97,10 @@ func findClusterIPRange(ctx context.Context, client controllerClient.Client) (st
 
 func findClusterIPRangeFromApiserver(ctx context.Context, client controllerClient.Client) (string, error) {
 	return FindPodCommandParameter(ctx, client, "component=kube-apiserver", "--service-cluster-ip-range")
+}
+
+func findClusterIPRangeFromKubeController(ctx context.Context, client controllerClient.Client) (string, error) {
+	return FindPodCommandParameter(ctx, client, "component=kube-controller-manager", "--service-cluster-ip-range")
 }
 
 func findClusterIPRangeFromServiceCreation(ctx context.Context, client controllerClient.Client) (string, error) {
@@ -153,12 +162,12 @@ func parseServiceCIDRFrom(msg string) (string, error) {
 }
 
 func findPodIPRange(ctx context.Context, client controllerClient.Client) (string, error) {
-	podIPRange, err := findPodIPRangeKubeController(ctx, client)
+	podIPRange, err := findPodIPRangeFromKubeController(ctx, client)
 	if err != nil || podIPRange != "" {
 		return podIPRange, err
 	}
 
-	podIPRange, err = findPodIPRangeKubeProxy(ctx, client)
+	podIPRange, err = findPodIPRangeFromKubeProxy(ctx, client)
 	if err != nil || podIPRange != "" {
 		return podIPRange, err
 	}
@@ -171,12 +180,12 @@ func findPodIPRange(ctx context.Context, client controllerClient.Client) (string
 	return "", nil
 }
 
-func findPodIPRangeKubeController(ctx context.Context, client controllerClient.Client) (string, error) {
+func findPodIPRangeFromKubeController(ctx context.Context, client controllerClient.Client) (string, error) {
 	return FindPodCommandParameter(ctx, client, "component=kube-controller-manager", "--cluster-cidr")
 }
 
-func findPodIPRangeKubeProxy(ctx context.Context, client controllerClient.Client) (string, error) {
-	return FindPodCommandParameter(ctx, client, "component=kube-proxy", "--cluster-cidr")
+func findPodIPRangeFromKubeProxy(ctx context.Context, client controllerClient.Client) (string, error) {
+	return FindPodCommandParameter(ctx, client, "k8s-app=kube-proxy", "--cluster-cidr")
 }
 
 func findPodIPRangeFromNodeSpec(ctx context.Context, client controllerClient.Client) (string, error) {

--- a/pkg/discovery/network/generic_test.go
+++ b/pkg/discovery/network/generic_test.go
@@ -120,16 +120,13 @@ var _ = Describe("Generic Network", func() {
 			Expect(clusterNet).NotTo(BeNil())
 		})
 
-		It("Should return the ClusterNetwork structure with pod CIDR", func() {
+		It("Should return the ClusterNetwork structure with both CIDR", func() {
 			Expect(clusterNet.PodCIDRs).To(Equal([]string{testPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
 		})
 
 		It("Should identify the networkplugin as generic", func() {
 			Expect(clusterNet.NetworkPlugin).To(BeIdenticalTo(cni.Generic))
-		})
-
-		It("Should return the ClusterNetwork structure with the service CIDR", func() {
-			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDRFromService}))
 		})
 	})
 
@@ -137,13 +134,19 @@ var _ = Describe("Generic Network", func() {
 		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
 				ctx,
-				fakePodWithArg("kube-controller-manager", []string{"kube-controller-manager"}, "--cluster-cidr="+testPodCIDR),
+				fakePodWithArg("kube-controller-manager", []string{"kube-controller-manager"},
+					[]string{"--cluster-cidr=" + testPodCIDR, "--service-cluster-ip-range=" + testServiceCIDR}),
 			)
 			Expect(clusterNet).NotTo(BeNil())
 		})
 
-		It("Should return the ClusterNetwork structure with pod CIDR", func() {
+		It("Should return the ClusterNetwork structure with both CIDR", func() {
 			Expect(clusterNet.PodCIDRs).To(Equal([]string{testPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
+		})
+
+		It("Should identify the networkplugin as generic", func() {
+			Expect(clusterNet.NetworkPlugin).To(BeIdenticalTo(cni.Generic))
 		})
 	})
 
@@ -169,7 +172,7 @@ var _ = Describe("Generic Network", func() {
 		})
 	})
 
-	When("There is a kubeapi pod", func() {
+	When("There is a kube-api pod", func() {
 		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(
 				ctx,
@@ -296,7 +299,7 @@ var _ = Describe("Generic Network", func() {
 		})
 	})
 
-	When("No kube-api pod exists and invalid service creation returns an unexpected error", func() {
+	When("No kube-api and kube-controller pod exists and invalid service creation returns an unexpected error", func() {
 		It("Should return error and nil cluster network", func(ctx SpecContext) {
 			// Inject error for create services to return expectedErr
 			client := fake.NewReactingClient(nil).AddReactor(fake.Create, &corev1.Service{},
@@ -308,7 +311,7 @@ var _ = Describe("Generic Network", func() {
 		})
 	})
 
-	When("No kube-api pod exists and invalid service creation returns the expected error", func() {
+	When("No kube-api and kube-controller pod exists and invalid service creation returns the expected error", func() {
 		BeforeEach(func(ctx SpecContext) {
 			clusterNet = testDiscoverGenericWith(ctx)
 		})

--- a/pkg/discovery/network/network_suite_test.go
+++ b/pkg/discovery/network/network_suite_test.go
@@ -46,9 +46,9 @@ func fakePod(component string, command []string, env []v1.EnvVar) *v1.Pod {
 	return fakePodWithName(component, component, command, env)
 }
 
-func fakePodWithArg(component string, command []string, arg string, env ...v1.EnvVar) *v1.Pod {
+func fakePodWithArg(component string, command, args []string, env ...v1.EnvVar) *v1.Pod {
 	pod := fakePodWithName(component, component, command, env)
-	pod.Spec.Containers[0].Args = []string{arg}
+	pod.Spec.Containers[0].Args = args
 
 	return pod
 }
@@ -62,7 +62,7 @@ func fakePodWithNamespace(namespace, name, component string, command []string, e
 		ObjectMeta: v1meta.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    map[string]string{"component": component, "name": component, "app": component},
+			Labels:    map[string]string{"component": component, "name": component, "app": component, "k8s-app": component},
 		},
 
 		Spec: v1.PodSpec{
@@ -81,7 +81,10 @@ func fakeKubeAPIServerPod() *v1.Pod {
 }
 
 func fakeKubeControllerManagerPod() *v1.Pod {
-	return fakePod("kube-controller-manager", []string{"kube-controller-manager", "--cluster-cidr=" + testPodCIDR}, []v1.EnvVar{})
+	return fakePod("kube-controller-manager", []string{
+		"kube-controller-manager", "--cluster-cidr=" + testPodCIDR,
+		"--service-cluster-ip-range=" + testServiceCIDR,
+	}, []v1.EnvVar{})
 }
 
 func fakeKubeProxyPod() *v1.Pod {


### PR DESCRIPTION
#### What type of PR is this?

Fix or Optimize

#### What this PR does / why we need it:

According to the original logic, do some optimizations:

1. Correct the label selector of kube-proxy from `component=kube-proxy` to `k8s-app=kube-proxy`

2. Similar to `findPodIPRange` function, add the redundant finding from kube-controller-manager.
