### PR TITLE
Change loadbalancer type for HCP deployments

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -160,9 +160,13 @@ type SubmarinerSpec struct {
 	// Enable NAT between clusters.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable NAT"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	NatEnabled bool `json:"natEnabled"`
-
+	NatEnabled          bool `json:"natEnabled"`
 	AirGappedDeployment bool `json:"airGappedDeployment,omitempty"`
+
+	// Is the cluster a hosted cluster.
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Hosted Cluster"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HostedCluster bool `json:"hostedCluster,omitempty"`
 
 	// Enable automatic Load Balancer in front of the gateways.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Load Balancer"
@@ -227,6 +231,11 @@ type SubmarinerStatus struct {
 	NatEnabled bool `json:"natEnabled"`
 
 	AirGappedDeployment bool `json:"airGappedDeployment,omitempty"`
+
+	// Is the cluster a hosted cluster.
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Hosted Cluster"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HostedCluster bool `json:"hostedCluster,omitempty"`
 
 	ColorCodes string `json:"colorCodes,omitempty"`
 

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -146,6 +146,8 @@ spec:
               haltOnCertificateError:
                 description: Halt on certificate error (so the pod gets restarted).
                 type: boolean
+              hostedCluster:
+                type: boolean
               imageOverrides:
                 additionalProperties:
                   type: string

--- a/internal/controllers/submariner/submariner_controller.go
+++ b/internal/controllers/submariner/submariner_controller.go
@@ -222,6 +222,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	instance.Status.Version = instance.Spec.Version
 	instance.Status.NatEnabled = instance.Spec.NatEnabled
 	instance.Status.AirGappedDeployment = instance.Spec.AirGappedDeployment
+	instance.Status.HostedCluster = instance.Spec.HostedCluster
 	instance.Status.ColorCodes = instance.Spec.ColorCodes
 	instance.Status.ClusterID = instance.Spec.ClusterID
 	instance.Status.GlobalCIDR = instance.Spec.GlobalCIDR

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -83,6 +83,7 @@ func testSubmarinerResourceReconciliation() {
 		BeforeEach(func() {
 			t.submariner.Spec.NatEnabled = true
 			t.submariner.Spec.AirGappedDeployment = true
+			t.submariner.Spec.HostedCluster = true
 		})
 
 		It("should populate general Submariner resource Status fields from the Spec", func(ctx SpecContext) {
@@ -91,6 +92,7 @@ func testSubmarinerResourceReconciliation() {
 			updated := t.getSubmariner(ctx)
 			Expect(updated.Status.NatEnabled).To(BeTrue())
 			Expect(updated.Status.AirGappedDeployment).To(BeTrue())
+			Expect(updated.Status.HostedCluster).To(BeTrue())
 			Expect(updated.Status.ClusterID).To(Equal(t.submariner.Spec.ClusterID))
 			Expect(updated.Status.GlobalCIDR).To(Equal(t.submariner.Spec.GlobalCIDR))
 			Expect(updated.Status.NetworkPlugin).To(Equal(t.clusterNetwork.NetworkPlugin))

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -248,6 +248,9 @@ spec:
               haltOnCertificateError:
                 description: Halt on certificate error (so the pod gets restarted).
                 type: boolean
+              hostedCluster:
+                description: Is the cluster a hosted cluster.
+                type: boolean
               imageOverrides:
                 additionalProperties:
                   type: string
@@ -840,6 +843,9 @@ spec:
                 required:
                 - mismatchedContainerImages
                 type: object
+              hostedCluster:
+                description: Is the cluster a hosted cluster.
+                type: boolean
               loadBalancerStatus:
                 description: The status of the load balancer DaemonSet.
                 properties:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/submariner-io/submariner-operator/tools
 
-go 1.22.10
+go 1.23.4
+
 require (
 	github.com/operator-framework/operator-sdk v1.39.0
 	github.com/uw-labs/lichen v0.1.7


### PR DESCRIPTION
The Kubevirt(HCP) clusters do not have their loadbalancer installedand rely on the host loadblancer( like netallb) when a loadbalancer is created.So when the Submariner exposes the submariner-gateway loadbalancer service with ServiceExternalTrafficPolicy locally does not work, as the traffic from the remotecluster first lands on the host cluster. Hence the traffic policy is updated to clusterin these deployments.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
