### PR TITLE
Add loadbalance plugin to submariner-lighthouse-coredns configmap

### DIFF
--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -273,6 +273,7 @@ errors
 health
 ready
 prometheus :9153
+loadbalance
 }`
 	expectedCorefile := ""
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->

The loadbalance will act as a round-robin DNS load balancer by randomizing the order of A, AAAA, and MX records in the answer.

This helps distribute load across pods for headless services DNS.

Fixes https://github.com/submariner-io/submariner-operator/issues/3308 