### PR TITLE
Automated backport of #3307: Change loadbalancer type for HCP deployments

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -160,9 +160,13 @@ type SubmarinerSpec struct {
 	// Enable NAT between clusters.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable NAT"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	NatEnabled bool `json:"natEnabled"`
-
+	NatEnabled          bool `json:"natEnabled"`
 	AirGappedDeployment bool `json:"airGappedDeployment,omitempty"`
+
+	// Is the cluster a hosted cluster.
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Hosted Cluster"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HostedCluster bool `json:"hostedCluster,omitempty"`
 
 	// Enable automatic Load Balancer in front of the gateways.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Load Balancer"
@@ -227,6 +231,11 @@ type SubmarinerStatus struct {
 	NatEnabled bool `json:"natEnabled"`
 
 	AirGappedDeployment bool `json:"airGappedDeployment,omitempty"`
+
+	// Is the cluster a hosted cluster.
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Hosted Cluster"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	HostedCluster bool `json:"hostedCluster,omitempty"`
 
 	ColorCodes string `json:"colorCodes,omitempty"`
 

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -137,6 +137,8 @@ spec:
               haltOnCertificateError:
                 description: Halt on certificate error (so the pod gets restarted).
                 type: boolean
+              hostedCluster:
+                type: boolean
               imageOverrides:
                 additionalProperties:
                   type: string

--- a/controllers/submariner/submariner_controller.go
+++ b/controllers/submariner/submariner_controller.go
@@ -222,6 +222,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	instance.Status.Version = instance.Spec.Version
 	instance.Status.NatEnabled = instance.Spec.NatEnabled
 	instance.Status.AirGappedDeployment = instance.Spec.AirGappedDeployment
+	instance.Status.HostedCluster = instance.Spec.HostedCluster
 	instance.Status.ColorCodes = instance.Spec.ColorCodes
 	instance.Status.ClusterID = instance.Spec.ClusterID
 	instance.Status.GlobalCIDR = instance.Spec.GlobalCIDR

--- a/controllers/submariner/submariner_controller_test.go
+++ b/controllers/submariner/submariner_controller_test.go
@@ -78,6 +78,7 @@ func testReconciliation() {
 		BeforeEach(func() {
 			t.submariner.Spec.NatEnabled = true
 			t.submariner.Spec.AirGappedDeployment = true
+			t.submariner.Spec.HostedCluster = true
 		})
 
 		It("should populate general Submariner resource Status fields from the Spec", func(ctx SpecContext) {
@@ -86,6 +87,7 @@ func testReconciliation() {
 			updated := t.getSubmariner(ctx)
 			Expect(updated.Status.NatEnabled).To(BeTrue())
 			Expect(updated.Status.AirGappedDeployment).To(BeTrue())
+			Expect(updated.Status.HostedCluster).To(BeTrue())
 			Expect(updated.Status.ClusterID).To(Equal(t.submariner.Spec.ClusterID))
 			Expect(updated.Status.GlobalCIDR).To(Equal(t.submariner.Spec.GlobalCIDR))
 			Expect(updated.Status.NetworkPlugin).To(Equal(t.clusterNetwork.NetworkPlugin))

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -248,6 +248,9 @@ spec:
               haltOnCertificateError:
                 description: Halt on certificate error (so the pod gets restarted).
                 type: boolean
+              hostedCluster:
+                description: Is the cluster a hosted cluster.
+                type: boolean
               imageOverrides:
                 additionalProperties:
                   type: string
@@ -840,6 +843,9 @@ spec:
                 required:
                 - mismatchedContainerImages
                 type: object
+              hostedCluster:
+                description: Is the cluster a hosted cluster.
+                type: boolean
               loadBalancerStatus:
                 description: The status of the load balancer DaemonSet.
                 properties:


### PR DESCRIPTION
Backport of #3307 on release-0.19.

#3307: Change loadbalancer type for HCP deployments

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.