### PR TITLE
Use go -C instead of explicit cd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ licensecheck: $(BINARIES) | bin/lichen
 
 bin/lichen:
 	mkdir -p $(@D)
-	cd tools && $(GO) build -o $(CURDIR)/$@ github.com/uw-labs/lichen
+	$(GO) -C tools build -o $(CURDIR)/$@ github.com/uw-labs/lichen
 
 # Generate deep-copy code
 CONTROLLER_DEEPCOPY := api/v1alpha1/zz_generated.deepcopy.go
@@ -154,7 +154,7 @@ ci: $(EMBEDDED_YAMLS) golangci-lint markdownlint unit build images
 # Download controller-gen locally if not already downloaded.
 $(CONTROLLER_GEN):
 	mkdir -p $(@D)
-	cd tools && $(GO) build -o $@ sigs.k8s.io/controller-tools/cmd/controller-gen
+	$(GO) -C tools build -o $@ sigs.k8s.io/controller-tools/cmd/controller-gen
 
 controller-gen: $(CONTROLLER_GEN)
 
@@ -185,7 +185,7 @@ is-semantic-version:
 # Download kustomize locally if not already downloaded.
 # We clear GITHUB_TOKEN to ensure that the installation script won't try to use it (and fail)
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-KUSTOMIZE_VERSION := $(shell cd tools && $(GO) list -m -f {{.Version}} sigs.k8s.io/kustomize/kustomize/v5)
+KUSTOMIZE_VERSION := $(shell $(GO) -C tools list -m -f {{.Version}} sigs.k8s.io/kustomize/kustomize/v5)
 $(KUSTOMIZE):
 	mkdir -p $(@D)
 	{ curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | GITHUB_TOKEN= bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(@D); }
@@ -237,7 +237,7 @@ unit: $(EMBEDDED_YAMLS)
 #     gpg --no-options -q --batch --no-default-keyring \
 #     --output scripts/operator-sdk-signing-keyring.gpg \
 #     --dearmor scripts/operator-sdk-signing-key.asc
-OPERATOR_SDK_VERSION := $(shell cd tools && $(GO) list -m -f {{.Version}} github.com/operator-framework/operator-sdk)
+OPERATOR_SDK_VERSION := $(shell $(GO) -C tools list -m -f {{.Version}} github.com/operator-framework/operator-sdk)
 OPERATOR_SDK_REPO := github.com/operator-framework/operator-sdk
 $(OPERATOR_SDK):
 	mkdir -p $(@D) && \


### PR DESCRIPTION
This doesn't make a huge difference here but it's a good practice since it avoids having to handle returning to the previous directory.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
