### PR TITLE
Remove "placeholder" namespace in RBAC yaml

### DIFF
--- a/config/broker/broker-admin/role_binding.yaml
+++ b/config/broker/broker-admin/role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-k8s-broker-admin
-    namespace: placeholder

--- a/config/broker/broker-client/role_binding.yaml
+++ b/config/broker/broker-client/role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-k8s-broker-client
-    namespace: placeholder

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -456,6 +456,8 @@ spec:
                                 minLength: 1
                                 type: string
                               healthCheckIP:
+                                description: 'Deprecated: Get/SetHealthCheckIP() or,
+                                  if necessary, HealthCheckIPs'
                                 type: string
                               healthCheckIPs:
                                 items:
@@ -467,6 +469,8 @@ spec:
                               nat_enabled:
                                 type: boolean
                               private_ip:
+                                description: 'Deprecated: Use Get/SetPrivateIP() or,
+                                  if necessary, PrivateIPs'
                                 type: string
                               privateIPs:
                                 items:
@@ -474,6 +478,8 @@ spec:
                                 maxItems: 2
                                 type: array
                               public_ip:
+                                description: 'Deprecated: Set/SetPublicIP() or, if
+                                  necessary, PublicIPs'
                                 type: string
                               publicIPs:
                                 items:
@@ -539,6 +545,8 @@ spec:
                           minLength: 1
                           type: string
                         healthCheckIP:
+                          description: 'Deprecated: Get/SetHealthCheckIP() or, if
+                            necessary, HealthCheckIPs'
                           type: string
                         healthCheckIPs:
                           items:
@@ -550,6 +558,8 @@ spec:
                         nat_enabled:
                           type: boolean
                         private_ip:
+                          description: 'Deprecated: Use Get/SetPrivateIP() or, if
+                            necessary, PrivateIPs'
                           type: string
                         privateIPs:
                           items:
@@ -557,6 +567,8 @@ spec:
                           maxItems: 2
                           type: array
                         public_ip:
+                          description: 'Deprecated: Set/SetPublicIP() or, if necessary,
+                            PublicIPs'
                           type: string
                         publicIPs:
                           items:
@@ -809,6 +821,8 @@ spec:
                                 Ports is a list of records of service ports
                                 If used, every port defined in the service should have an entry in it
                               items:
+                                description: PortStatus represents the error condition
+                                  of a service port
                                 properties:
                                   error:
                                     description: |-

--- a/config/rbac/lighthouse-agent/cluster_role_binding.yaml
+++ b/config/rbac/lighthouse-agent/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-lighthouse-agent
-    namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: submariner-lighthouse-agent

--- a/config/rbac/lighthouse-agent/ocp_cluster_role_binding.yaml
+++ b/config/rbac/lighthouse-agent/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-lighthouse-agent
-    namespace: placeholder

--- a/config/rbac/lighthouse-coredns/cluster_role_binding.yaml
+++ b/config/rbac/lighthouse-coredns/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-lighthouse-coredns
-    namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: submariner-lighthouse-coredns

--- a/config/rbac/lighthouse-coredns/ocp_cluster_role_binding.yaml
+++ b/config/rbac/lighthouse-coredns/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-lighthouse-coredns
-    namespace: placeholder

--- a/config/rbac/submariner-diagnose/cluster_role_binding.yaml
+++ b/config/rbac/submariner-diagnose/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-diagnose
-    namespace: placeholder
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/rbac/submariner-diagnose/ocp_cluster_role_binding.yaml
+++ b/config/rbac/submariner-diagnose/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-diagnose
-    namespace: placeholder

--- a/config/rbac/submariner-gateway/cluster_role_binding.yaml
+++ b/config/rbac/submariner-gateway/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-gateway
-    namespace: placeholder
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/rbac/submariner-gateway/ocp_cluster_role_binding.yaml
+++ b/config/rbac/submariner-gateway/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-gateway
-    namespace: placeholder

--- a/config/rbac/submariner-gateway/role_binding.yaml
+++ b/config/rbac/submariner-gateway/role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-gateway
-    namespace: placeholder
 roleRef:
   kind: Role
   name: submariner-gateway

--- a/config/rbac/submariner-globalnet/cluster_role_binding.yaml
+++ b/config/rbac/submariner-globalnet/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-globalnet
-    namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: submariner-globalnet

--- a/config/rbac/submariner-globalnet/ocp_cluster_role_binding.yaml
+++ b/config/rbac/submariner-globalnet/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-globalnet
-    namespace: placeholder

--- a/config/rbac/submariner-operator/cluster_role_binding.yaml
+++ b/config/rbac/submariner-operator/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-operator
-    namespace: placeholder
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/rbac/submariner-operator/ocp_cluster_role_binding.yaml
+++ b/config/rbac/submariner-operator/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-operator
-    namespace: placeholder

--- a/config/rbac/submariner-route-agent/cluster_role_binding.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role_binding.yaml
@@ -6,7 +6,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: submariner-routeagent
-    namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: submariner-routeagent

--- a/config/rbac/submariner-route-agent/ocp_cluster_role_binding.yaml
+++ b/config/rbac/submariner-route-agent/ocp_cluster_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submariner-routeagent
-    namespace: placeholder


### PR DESCRIPTION
"placeholder" used to get substituted with actual namespace by `kustomize` when the bundle is built but that's no longer the case. This is a change in behavior with the new `kustomize` version. After removing the "placeholder" line, the actual namespace is added correctly.
