### PR TITLE
Add nftables enabled flag to Submariner

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -168,6 +168,12 @@ type SubmarinerSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HostedCluster bool `json:"hostedCluster,omitempty"`
 
+	// Use nftables for programming IP filter rules.
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Use Nftables"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	// +optional
+	UseNftables bool `json:"useNftables,omitempty"`
+
 	// Enable automatic Load Balancer in front of the gateways.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Load Balancer"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -214,6 +214,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              useNftables:
+                description: Use nftables for programming IP filter rules.
+                type: boolean
               version:
                 description: The image tag.
                 type: string

--- a/internal/controllers/submariner/globalnet_resources.go
+++ b/internal/controllers/submariner/globalnet_resources.go
@@ -20,6 +20,7 @@ package submariner
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/submariner-io/admiral/pkg/names"
@@ -102,6 +103,7 @@ func newGlobalnetDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.DaemonS
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
 								{Name: "SUBMARINER_METRICSPORT", Value: globalnetMetricsServerPort},
+								{Name: "SUBMARINER_USENFTABLES", Value: strconv.FormatBool(cr.Spec.UseNftables)},
 								{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{
 										FieldPath: "spec.nodeName",

--- a/internal/controllers/submariner/route_agent_resources.go
+++ b/internal/controllers/submariner/route_agent_resources.go
@@ -146,6 +146,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 								{Name: "SUBMARINER_SERVICECIDR", Value: cr.Status.ServiceCIDR},
 								{Name: "SUBMARINER_GLOBALCIDR", Value: cr.Spec.GlobalCIDR},
 								{Name: "SUBMARINER_NETWORKPLUGIN", Value: cr.Status.NetworkPlugin},
+								{Name: "SUBMARINER_USENFTABLES", Value: strconv.FormatBool(cr.Spec.UseNftables)},
 								{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{
 										FieldPath: "spec.nodeName",

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -316,6 +316,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              useNftables:
+                description: Use nftables for programming IP filter rules.
+                type: boolean
               version:
                 description: The image tag.
                 type: string


### PR DESCRIPTION
We want to begin testing Submariner with nftables, starting with Kind upstream.
To do this, we need to modify RouteAgent and GlobalNet to dynamically set the required packet filter driver (iptables or nftables), as it is currently hardcoded to iptables.
