### PR TITLE
Propagate Cluster CIDR to LH CoreDNS plugin deployment

### DIFF
--- a/api/v1alpha1/servicediscovery_types.go
+++ b/api/v1alpha1/servicediscovery_types.go
@@ -42,6 +42,8 @@ type ServiceDiscoverySpec struct {
 	Repository               string `json:"repository,omitempty"`
 	Version                  string `json:"version,omitempty"`
 	// +optional
+	ClusterCIDR string `json:"clusterCIDR,omitempty"`
+	// +optional
 	ClustersetIPCIDR       string `json:"clustersetIPCIDR,omitempty"`
 	Debug                  bool   `json:"debug"`
 	GlobalnetEnabled       bool   `json:"globalnetEnabled,omitempty"`

--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -335,6 +335,7 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSComponent]),
 							Env: httpproxy.AddEnvVars([]corev1.EnvVar{
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
+								{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},
 							}),
 							Args: []string{
 								"-conf",

--- a/internal/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -58,6 +58,7 @@ func testReconciliation() {
 				t.AssertReconcileSuccess(ctx)
 
 				assertDNSConfigServers(t.assertDNSConfig(ctx), newDNSConfig(clusterIP))
+				t.assertCoreDNSDeployment(ctx)
 			})
 		})
 

--- a/internal/controllers/submariner/servicediscovery_resources.go
+++ b/internal/controllers/submariner/servicediscovery_resources.go
@@ -52,6 +52,7 @@ func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner 
 					HaltOnCertificateError:   submariner.Spec.HaltOnCertificateError,
 					Debug:                    submariner.Spec.Debug,
 					ClusterID:                submariner.Spec.ClusterID,
+					ClusterCIDR:              submariner.Spec.ClusterCIDR,
 					Namespace:                submariner.Spec.Namespace,
 					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
 					ClustersetIPEnabled:      submariner.Spec.ClustersetIPEnabled,

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -343,6 +343,7 @@ func testServiceDiscoveryReconciliation() {
 			Expect(serviceDiscovery.Spec.BrokerK8sApiServer).To(Equal(t.submariner.Spec.BrokerK8sApiServer))
 			Expect(serviceDiscovery.Spec.BrokerK8sSecret).To(Equal(t.submariner.Spec.BrokerK8sSecret))
 			Expect(serviceDiscovery.Spec.ClusterID).To(Equal(t.submariner.Spec.ClusterID))
+			Expect(serviceDiscovery.Spec.ClusterCIDR).To(Equal(t.submariner.Spec.ClusterCIDR))
 			Expect(serviceDiscovery.Spec.Namespace).To(Equal(t.submariner.Spec.Namespace))
 			Expect(serviceDiscovery.Spec.GlobalnetEnabled).To(BeTrue())
 		})

--- a/internal/controllers/test/driver.go
+++ b/internal/controllers/test/driver.go
@@ -147,8 +147,6 @@ func (d *Driver) AssertDeployment(ctx context.Context, name string) *appsv1.Depl
 
 	Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue("app", name))
 	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", name))
-	Expect(deployment.Spec.Replicas).ToNot(BeNil())
-	Expect(int(*deployment.Spec.Replicas)).To(Equal(1))
 
 	return deployment
 }

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -1212,6 +1212,8 @@ spec:
                 type: string
               brokerK8sSecret:
                 type: string
+              clusterCIDR:
+                type: string
               clusterID:
                 type: string
               clustersetIPCIDR:


### PR DESCRIPTION
...as it needs knowledge of the supported IP families.
