### PR TITLE
Ensure CoreDNS ClusterIP service changes are always applied

### DIFF
--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -751,18 +751,8 @@ func (r *Reconciler) ensureLighthouseCoreDNSDeployment(ctx context.Context, inst
 func (r *Reconciler) ensureLighthouseCoreDNSService(ctx context.Context, instance *submarinerv1alpha1.ServiceDiscovery,
 	reqLogger logr.Logger,
 ) error {
-	lighthouseCoreDNSService := &corev1.Service{}
-
-	err := r.ScopedClient.Get(ctx, types.NamespacedName{Name: names.LighthouseCoreDNSComponent, Namespace: instance.Namespace},
-		lighthouseCoreDNSService)
-	if apierrors.IsNotFound(err) {
-		lighthouseCoreDNSService = newLighthouseCoreDNSService(instance)
-		if _, err = apply.Service(ctx, instance, lighthouseCoreDNSService, reqLogger,
-			r.ScopedClient, r.Scheme); err != nil {
-			log.Error(err, "Error creating the lighthouseCoreDNS service")
-
-			return errors.Wrap(err, "error reconciling coredns Service")
-		}
+	if _, err := apply.Service(ctx, instance, newLighthouseCoreDNSService(instance), reqLogger, r.ScopedClient, r.Scheme); err != nil {
+		return errors.Wrap(err, "error reconciling coredns Service")
 	}
 
 	return nil

--- a/internal/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -227,6 +227,7 @@ func newDNSService(clusterIP string) *corev1.Service {
 			Namespace: submarinerNamespace,
 		},
 		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
 			ClusterIP: clusterIP,
 		},
 	}


### PR DESCRIPTION
...by the service discovery controller. Removed the explicit check for existence before applying the service.

Fixes https://github.com/submariner-io/submariner-operator/issues/3377
