### PR TITLE
Set ServicDiscovery ClusterCIDR from submariner.Status.ClusterCIDR

### DIFF
--- a/internal/controllers/submariner/servicediscovery_resources.go
+++ b/internal/controllers/submariner/servicediscovery_resources.go
@@ -52,7 +52,7 @@ func (r *Reconciler) serviceDiscoveryReconciler(ctx context.Context, submariner 
 					HaltOnCertificateError:   submariner.Spec.HaltOnCertificateError,
 					Debug:                    submariner.Spec.Debug,
 					ClusterID:                submariner.Spec.ClusterID,
-					ClusterCIDR:              submariner.Spec.ClusterCIDR,
+					ClusterCIDR:              submariner.Status.ClusterCIDR,
 					Namespace:                submariner.Spec.Namespace,
 					GlobalnetEnabled:         submariner.Spec.GlobalCIDR != "",
 					ClustersetIPEnabled:      submariner.Spec.ClustersetIPEnabled,

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -343,7 +343,7 @@ func testServiceDiscoveryReconciliation() {
 			Expect(serviceDiscovery.Spec.BrokerK8sApiServer).To(Equal(t.submariner.Spec.BrokerK8sApiServer))
 			Expect(serviceDiscovery.Spec.BrokerK8sSecret).To(Equal(t.submariner.Spec.BrokerK8sSecret))
 			Expect(serviceDiscovery.Spec.ClusterID).To(Equal(t.submariner.Spec.ClusterID))
-			Expect(serviceDiscovery.Spec.ClusterCIDR).To(Equal(t.submariner.Spec.ClusterCIDR))
+			Expect(serviceDiscovery.Spec.ClusterCIDR).To(Equal(testDetectedClusterCIDR))
 			Expect(serviceDiscovery.Spec.Namespace).To(Equal(t.submariner.Spec.Namespace))
 			Expect(serviceDiscovery.Spec.GlobalnetEnabled).To(BeTrue())
 		})


### PR DESCRIPTION
...rather than `submariner.Spec.ClusterCIDR` as the former reflects the actual value.
