### PR TITLE
Automated backport of #3487: Add node update to routeAgent RBAC

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -39,6 +39,8 @@ rules:
       - get
       - list
       - watch
+      # route agent needs to annotate nodes to prevent OVNK SNAT
+      - update
   - apiGroups:
       - projectcalico.org
     resources:

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -25,7 +25,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: brokers.submariner.io
 spec:
   group: submariner.io
@@ -105,7 +105,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -1164,7 +1164,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io
@@ -1323,7 +1323,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusters.submariner.io
 spec:
   group: submariner.io
@@ -1394,7 +1394,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: endpoints.submariner.io
 spec:
   group: submariner.io
@@ -1493,7 +1493,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: gateways.submariner.io
 spec:
   group: submariner.io
@@ -1704,7 +1704,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: clusterglobalegressips.submariner.io
 spec:
   group: submariner.io
@@ -1830,7 +1830,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: globalegressips.submariner.io
 spec:
   group: submariner.io
@@ -2005,7 +2005,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: globalingressips.submariner.io
 spec:
   group: submariner.io
@@ -2158,7 +2158,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: gatewayroutes.submariner.io
 spec:
   group: submariner.io
@@ -2219,7 +2219,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: nongatewayroutes.submariner.io
 spec:
   group: submariner.io
@@ -2280,7 +2280,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: routeagents.submariner.io
 spec:
   group: submariner.io
@@ -3319,6 +3319,8 @@ rules:
       - get
       - list
       - watch
+      # route agent needs to annotate nodes to prevent OVNK SNAT
+      - update
   - apiGroups:
       - projectcalico.org
     resources:


### PR DESCRIPTION
Backport of #3487 on release-0.20.

#3487: Add node update to routeAgent RBAC

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.