### PR TITLE
Combine OCP network discovery CIDRs into comma-separated string

### DIFF
--- a/pkg/discovery/network/openshift4.go
+++ b/pkg/discovery/network/openshift4.go
@@ -21,6 +21,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/resource"
@@ -62,6 +63,9 @@ func parseOS4Network(cr *unstructured.Unstructured) (*ClusterNetwork, error) {
 		return nil, fmt.Errorf("field .spec.clusterNetwork expected, but not found in Network resource: %v", cr.Object)
 	}
 
+	// For Dual-Stack case, store CIDRs as single comma-separated string
+	podCIDRs := []string{}
+
 	for _, clusterNetwork := range clusterNetworks {
 		clusterNetworkMap, _ := clusterNetwork.(map[string]any)
 		cidr, found, err := unstructured.NestedString(clusterNetworkMap, "cidr")
@@ -72,8 +76,10 @@ func parseOS4Network(cr *unstructured.Unstructured) (*ClusterNetwork, error) {
 			return nil, fmt.Errorf("field cidr expected, but not found in clusterNetwork: %v", clusterNetworkMap)
 		}
 
-		result.PodCIDRs = append(result.PodCIDRs, cidr)
+		podCIDRs = append(podCIDRs, cidr)
 	}
+
+	result.PodCIDRs = append(result.PodCIDRs, strings.Join(podCIDRs, ","))
 
 	serviceNetworks, found, err := unstructured.NestedSlice(cr.Object, "spec", "serviceNetwork")
 	if err != nil {
@@ -82,9 +88,12 @@ func parseOS4Network(cr *unstructured.Unstructured) (*ClusterNetwork, error) {
 		return nil, fmt.Errorf("field .spec.serviceNetwork expected, but not found in Network resource: %v", cr.Object)
 	}
 
+	serviceCIDRs := []string{}
 	for _, serviceNetwork := range serviceNetworks {
-		result.ServiceCIDRs = append(result.ServiceCIDRs, serviceNetwork.(string))
+		serviceCIDRs = append(serviceCIDRs, serviceNetwork.(string))
 	}
+
+	result.ServiceCIDRs = append(result.ServiceCIDRs, strings.Join(serviceCIDRs, ","))
 
 	ocpNetworkType, found, err := unstructured.NestedString(cr.Object, "spec", "networkType")
 	if err != nil {

--- a/pkg/discovery/network/openshift4_test.go
+++ b/pkg/discovery/network/openshift4_test.go
@@ -35,9 +35,9 @@ var _ = Describe("OpenShift4 Network", func() {
 		It("Should parse properly pod and service networks", func(ctx SpecContext) {
 			cn, err := testOS4DiscoveryWith(ctx, getNetworkJSON())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cn.PodCIDRs).To(HaveLen(2))
+			Expect(cn.PodCIDRs).To(HaveLen(1))
 			Expect(cn.ServiceCIDRs).To(HaveLen(1))
-			Expect(cn.PodCIDRs).To(Equal([]string{"10.128.0.0/14", "10.132.0.0/14"}))
+			Expect(cn.PodCIDRs).To(Equal([]string{"10.128.0.0/14,10.132.0.0/14"}))
 			Expect(cn.ServiceCIDRs).To(Equal([]string{"172.30.0.0/16"}))
 			Expect(cn.NetworkPlugin).To(Equal(cni.OpenShiftSDN))
 		})


### PR DESCRIPTION
Currently, during OCP network discovery, multiple Pod CIDRs are handled as separate strings.

This fix updates OCP network discovery logic to join all discovered CIDRs into a single comma-separated string to align with the expected format.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
