### PR TITLE
Allow "make bundle" to run without Shipyard

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,8 +39,10 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: Create the bundle and validate it
-        run: make bundle
+        run: make bundle LOCAL_BUILD=1
 
   check-branch-dependencies:
     name: Check branch dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 BASE_BRANCH ?= devel
 # Denotes the default operator image version, exposed as a variable for the automated release
 DEFAULT_IMAGE_VERSION ?= $(BASE_BRANCH)
@@ -42,7 +44,13 @@ else
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
-include $(SHIPYARD_DIR)/Makefile.inc
+-include $(SHIPYARD_DIR)/Makefile.inc
+# Version calculation from Shipyard Makefile.versions
+# These are used by the bundle construction and copied here
+# to allow "make bundle" to run without Shipyard
+override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short=12 HEAD)
+VERSION ?= $(CALCULATED_VERSION)
+export VERSION
 
 override UNIT_TEST_ARGS += test internal/env
 


### PR DESCRIPTION
Bundle construction is supposed to work without Shipyard, but a couple of fixes are required:

* don't fail the build if Shipyard's Makefile.inc isn't available;
* provide the version information without Shipyard.

The bundle GHA is changed to skip Shipyard, to ensure this isn't broken again in future. Since this involves shell constructs that rely on bash, the Makefile is configured to use bash as its shell (GHAs use Ubuntu which defaults to dash). The bundle build also needs at least the last two tags tied to the base branch in the repository, so the corresponding checkout operation is changed to fetch the repository in its entirety.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
