### PR TITLE
Introduce disable intra-cluster connectivity

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -168,6 +168,12 @@ type SubmarinerSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	HostedCluster bool `json:"hostedCluster,omitempty"`
 
+	// Disable intra-cluster connectivity routing.
+	//nolint:lll // Markers can't be wrapped
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable Intra-cluster connectivity"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	DisableIntraClusterConnectivity bool `json:"disableIntraClusterConnectivity,omitempty"`
+
 	// Enable automatic Load Balancer in front of the gateways.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Load Balancer"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -138,6 +138,9 @@ spec:
                 x-kubernetes-list-type: set
               debug:
                 description: Enable operator debugging.
+                type: boolean
+              disableIntraClusterConnectivity:
+                description: Disable intra-cluster connectivity routing.
                 type: boolean
               globalCIDR:
                 description: The Global CIDR super-net range for allocating GlobalCIDRs

--- a/deploy/crds/submariner.io_submariners.yaml
+++ b/deploy/crds/submariner.io_submariners.yaml
@@ -139,6 +139,9 @@ spec:
               debug:
                 description: Enable operator debugging.
                 type: boolean
+              disableIntraClusterConnectivity:
+                description: Disable intra-cluster connectivity routing.
+                type: boolean
               globalCIDR:
                 description: The Global CIDR super-net range for allocating GlobalCIDRs
                   to each cluster.

--- a/internal/controllers/submariner/route_agent_resources.go
+++ b/internal/controllers/submariner/route_agent_resources.go
@@ -154,6 +154,7 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 								{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
 								{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(healthCheckInterval, 10)},
 								{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(healthCheckMaxPacketLossCount, 10)},
+								{Name: "SUBMARINER_INTRAROUTINGDISABLED", Value: strconv.FormatBool(cr.Spec.DisableIntraClusterConnectivity)},
 							}),
 						},
 					},
@@ -165,6 +166,13 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 				},
 			},
 		},
+	}
+
+	// Run pods only on gateway nodes when intra-cluster connectivity is disabled.
+	if cr.Spec.DisableIntraClusterConnectivity {
+		ds.Spec.Template.Spec.NodeSelector = map[string]string{
+			"submariner.io/gateway": "true",
+		}
 	}
 
 	return ds

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -250,6 +250,20 @@ func testDaemonSetReconciliation() {
 		})
 	})
 
+	When("DisableIntraClusterConnectivity is set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.DisableIntraClusterConnectivity = true
+		})
+
+		Specify("the submariner route-agent DaemonSet template NodeSelector should have \"submariner.io/gateway\" set",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.RouteAgentComponent)
+				Expect(daemonSet.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("submariner.io/gateway", "true"))
+			})
+	})
+
 	When("the submariner globalnet DaemonSet doesn't exist", func() {
 		It("should create it", func(ctx SpecContext) {
 			t.AssertReconcileSuccess(ctx)

--- a/internal/controllers/submariner/submariner_suite_test.go
+++ b/internal/controllers/submariner/submariner_suite_test.go
@@ -137,6 +137,7 @@ func (t *testDriver) assertRouteAgentDaemonSet(ctx context.Context) {
 	Expect(daemonSet.Spec.Template.Spec.Containers).To(HaveLen(1))
 	Expect(daemonSet.Spec.Template.Spec.Containers[0].Image).To(
 		Equal(fmt.Sprintf("%s/%s:%s", t.submariner.Spec.Repository, opnames.RouteAgentImage, t.submariner.Spec.Version)))
+	Expect(daemonSet.Spec.Template.Spec.NodeSelector).NotTo(HaveKey("submariner.io/gateway"))
 
 	t.assertRouteAgentDaemonSetEnv(t.withNetworkDiscovery(), test.EnvMapFrom(daemonSet))
 }


### PR DESCRIPTION
This PR adds a configuration flag to Submariner CRD to disable intra-cluster connectivity.  

It also updates RouteAgent scheduling to run pods only on gateway nodes when flag is disabled,  
and sets corresponding environment variable to reflect this setting.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
