### PR TITLE
Skip JSON error checking when unnecessary

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,13 @@ version: "2"
 linters:
   default: none
   settings:
+    errcheck:
+      exclude-functions:
+        - encoding/json.Marshal
+        - encoding/json.MarshalIndent
+    errchkjson:
+      check-error-free-encoding: true
+      report-no-exported: true
     gocritic:
       disabled-checks:
         - ifElseChain

--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -99,10 +99,8 @@ func AddClusterInfoData(toConfigMap *corev1.ConfigMap, newCluster ClusterInfo) e
 		existingInfo = append(existingInfo, newCluster)
 	}
 
-	data, err := json.MarshalIndent(existingInfo, "", "\t")
-	if err != nil {
-		return errors.Wrapf(err, "error marshalling ClusterInfo")
-	}
+	// The definition of ClusterInfo ensures it can be encoded, no need to check for errors
+	data, _ := json.MarshalIndent(existingInfo, "", "\t")
 
 	toConfigMap.Data[ClusterInfoKey] = string(data)
 

--- a/pkg/discovery/clustersetip/config_map.go
+++ b/pkg/discovery/clustersetip/config_map.go
@@ -61,10 +61,8 @@ func CreateConfigMap(ctx context.Context, client controllerClient.Client, cluste
 func NewClustersetIPConfigMap(clustersetIPEnabled bool, defaultClusteretIPCidrRange string,
 	defaultClustersetIPClusterSize uint, namespace string,
 ) (*corev1.ConfigMap, error) {
-	cidrRange, err := json.Marshal(defaultClusteretIPCidrRange)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error marshalling clustersetIP CIDR range")
-	}
+	// Strings can always be encoded, no need to check for errors
+	cidrRange, _ := json.Marshal(defaultClusteretIPCidrRange)
 
 	data := map[string]string{
 		clustersetIPEnabledKey:  strconv.FormatBool(clustersetIPEnabled),

--- a/pkg/discovery/globalnet/config_map.go
+++ b/pkg/discovery/globalnet/config_map.go
@@ -64,10 +64,8 @@ func NewGlobalnetConfigMap(globalnetEnabled bool, defaultGlobalCidrRange string,
 		"component": "submariner-globalnet",
 	}
 
-	cidrRange, err := json.Marshal(defaultGlobalCidrRange)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error marshalling CIDR range")
-	}
+	// Strings can always be encoded, no need to check for errors
+	cidrRange, _ := json.Marshal(defaultGlobalCidrRange)
 
 	var data map[string]string
 	if globalnetEnabled {


### PR DESCRIPTION
It is possible to determine statically that the argument to json.Marshal or json.MarshalIndent is safe to encode, and can't produce an error. In such cases there is no point in checking the returned error. As a side benefit, removing the "if err" blocks reduces measured cyclomatic complexity and increases code coverage.

errchkjson can detect this, but even when enabled, its checks default to disabled. This enables the checks and configures errcheck to ignore json.Marshal and json.MarshalIndent (this is safe because they are checked by errchkjson).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
