### PR TITLE
Remove the --submariner-namespace parameter

### DIFF
--- a/scripts/test/e2e.sh
+++ b/scripts/test/e2e.sh
@@ -6,8 +6,6 @@
 
 set -em -o pipefail
 
-subm_ns=submariner-operator
-
 ### Main ###
 
 # Run project specific E2E tests (they don't overlap with the generic ones)
@@ -36,6 +34,6 @@ verify="connectivity"
 [[ "${LIGHTHOUSE}" != "true" ]] || verify="service-discovery"
 
 # Run generic E2E tests between the clusters
-subctl verify --only "${verify}" --submariner-namespace="$subm_ns" \
+subctl verify --only "${verify}" \
     --verbose --connection-timeout 20 --connection-attempts 4 \
     --context "${clusters[0]}" --tocontext "${clusters[1]}"


### PR DESCRIPTION
This was dropped from subctl; since its value was always "submariner-operator" anyway it doesn't matter.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
