### PR TITLE
Enhance route-agent DaemonSet unit test verification

### DIFF
--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	goslices "slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -261,6 +262,7 @@ func testDaemonSetReconciliation() {
 
 				daemonSet := t.AssertDaemonSet(ctx, names.RouteAgentComponent)
 				Expect(daemonSet.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("submariner.io/gateway", "true"))
+				Expect(test.EnvMapFrom(daemonSet)).To(HaveKeyWithValue("SUBMARINER_INTRAROUTINGDISABLED", strconv.FormatBool(true)))
 			})
 	})
 

--- a/internal/controllers/submariner/submariner_suite_test.go
+++ b/internal/controllers/submariner/submariner_suite_test.go
@@ -159,6 +159,7 @@ func (t *testDriver) assertRouteAgentDaemonSetEnv(submariner *v1alpha1.Submarine
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_SERVICECIDR", submariner.Status.ServiceCIDR))
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_NETWORKPLUGIN", submariner.Status.NetworkPlugin))
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_DEBUG", strconv.FormatBool(submariner.Spec.Debug)))
+	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_INTRAROUTINGDISABLED", strconv.FormatBool(false)))
 }
 
 func (t *testDriver) assertGatewayDaemonSet(ctx context.Context) {


### PR DESCRIPTION
...for the `DisableIntraClusterConnectivity` case to also verify that the `SUBMARINER_INTRAROUTINGDISABLED` env var is set properly.

