### PR TITLE
Automated backport of #3631: Add networking.k8s.io.servicecidrs RBAC access to submariner

### DIFF
--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -70,3 +70,11 @@ rules:
       - daemonsets
     verbs:
       - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      # Needed for service CIDR discovery
+      - servicecidrs
+    verbs:
+      - get
+      - list

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3116,6 +3116,14 @@ rules:
       - daemonsets
     verbs:
       - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      # Needed for service CIDR discovery
+      - servicecidrs
+    verbs:
+      - get
+      - list
 `
 	Config_rbac_submariner_operator_cluster_role_binding_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #3631 on release-0.21.

#3631: Add networking.k8s.io.servicecidrs RBAC access to submariner

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.