### PR TITLE
Automated backport of #3641: Verify the bundle in CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,8 +39,10 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: Create the bundle and validate it
-        run: make bundle
+        run: make bundle LOCAL_BUILD=1
 
   check-branch-dependencies:
     name: Check branch dependencies

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,6 +43,20 @@ jobs:
           fetch-depth: 0
       - name: Create the bundle and validate it
         run: make bundle LOCAL_BUILD=1
+      - name: Verify generated code matches committed code (ignoring hashes)
+        run: >-
+          baseref=${{ github.base_ref }} &&
+          git add -A &&
+          git diff --staged --exit-code
+          -IcreatedAt:
+          -I"value: quay.io/submariner/"
+          -I"image: quay.io/submariner/"
+          -Icontroller-gen.kubebuilder.io/version:
+          -Ioperators.operatorframework.io.metrics.builder:
+          -I"\"version\": \"${baseref}-"
+          -I"\"version\": \"v${baseref/release-/}."
+          -I"newTag: ${baseref}-"
+          -I"newTag: v${baseref/release-/}."
 
   check-branch-dependencies:
     name: Check branch dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 BASE_BRANCH ?= release-0.20
 # Denotes the default operator image version, exposed as a variable for the automated release
 DEFAULT_IMAGE_VERSION ?= $(BASE_BRANCH)
@@ -41,7 +43,13 @@ else
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
-include $(SHIPYARD_DIR)/Makefile.inc
+-include $(SHIPYARD_DIR)/Makefile.inc
+# Version calculation from Shipyard Makefile.versions
+# These are used by the bundle construction and copied here
+# to allow "make bundle" to run without Shipyard
+override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short=12 HEAD)
+VERSION ?= $(CALCULATED_VERSION)
+export VERSION
 
 override UNIT_TEST_ARGS += test internal/env
 


### PR DESCRIPTION
Backport of #3641 on release-0.20.

#3641: Allow "make bundle" to run without Shipyard

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.