### PR TITLE
Automated backport of #3641: Verify the bundle in CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,8 +39,10 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: Create the bundle and validate it
-        run: make bundle
+        run: make bundle LOCAL_BUILD=1
 
   crds:
     name: CRDs up-to-date

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,6 +43,20 @@ jobs:
           fetch-depth: 0
       - name: Create the bundle and validate it
         run: make bundle LOCAL_BUILD=1
+      - name: Verify generated code matches committed code (ignoring hashes)
+        run: >-
+          baseref=${{ github.base_ref }} &&
+          git add -A &&
+          git diff --staged --exit-code
+          -IcreatedAt:
+          -I"value: quay.io/submariner/"
+          -I"image: quay.io/submariner/"
+          -Icontroller-gen.kubebuilder.io/version:
+          -Ioperators.operatorframework.io.metrics.builder:
+          -I"\"version\": \"${baseref}-"
+          -I"\"version\": \"v${baseref/release-/}."
+          -I"newTag: ${baseref}-"
+          -I"newTag: v${baseref/release-/}."
 
   crds:
     name: CRDs up-to-date

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 BASE_BRANCH ?= release-0.19
 # Denotes the default operator image version, exposed as a variable for the automated release
 DEFAULT_IMAGE_VERSION ?= $(BASE_BRANCH)
@@ -41,7 +43,13 @@ else
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
-include $(SHIPYARD_DIR)/Makefile.inc
+-include $(SHIPYARD_DIR)/Makefile.inc
+# Version calculation from Shipyard Makefile.versions
+# These are used by the bundle construction and copied here
+# to allow "make bundle" to run without Shipyard
+override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short=12 HEAD)
+VERSION ?= $(CALCULATED_VERSION)
+export VERSION
 
 override UNIT_TEST_ARGS += test internal/env
 

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: brokers.submariner.io
 spec:
   group: submariner.io
@@ -20,14 +20,19 @@ spec:
         description: Broker is the Schema for the brokers API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,6 +43,9 @@ spec:
                 description: ClustersetIP supernet range for allocating ClustersetIPCIDRs
                   to each cluster.
                 type: string
+              clustersetIPEnabled:
+                description: Enable ClustersetIP default for connecting clusters.
+                type: boolean
               components:
                 description: List of the components to be installed - any of [service-discovery,
                   connectivity].
@@ -59,9 +67,6 @@ spec:
                 type: string
               globalnetEnabled:
                 description: Enable support for Overlapping CIDRs in connecting clusters.
-                type: boolean
-              clustersetIPEnabled:
-                description: Enable ClustersetIP default for connecting clusters.
                 type: boolean
             type: object
           status:

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io
@@ -20,14 +20,19 @@ spec:
         description: ServiceDiscovery is the Schema for the servicediscoveries API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,6 +55,8 @@ spec:
                 type: string
               clustersetIPCIDR:
                 type: string
+              clustersetIPEnabled:
+                type: boolean
               coreDNSCustomConfig:
                 properties:
                   configMapName:
@@ -70,8 +77,6 @@ spec:
                 type: boolean
               haltOnCertificateError:
                 type: boolean
-              clustersetIPEnabled:
-                type: boolean
               imageOverrides:
                 additionalProperties:
                   type: string
@@ -86,40 +91,39 @@ spec:
                 type: string
               tolerations:
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -20,14 +20,19 @@ spec:
         description: Submariner is the Schema for the submariners API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -88,9 +93,13 @@ spec:
                 description: The cluster ID used to identify the tunnels.
                 type: string
               clustersetIPCIDR:
-                description:  ClustersetIP CIDR for allocating ClustersetIPs to exported
+                description: ClustersetIP CIDR for allocating ClustersetIPs to exported
                   services.
                 type: string
+              clustersetIPEnabled:
+                description: Enable ClustersetIP default for services exported on
+                  this cluster.
+                type: boolean
               colorCodes:
                 type: string
               connectionHealthCheck:
@@ -110,9 +119,9 @@ spec:
                     type: integer
                 type: object
               coreDNSCustomConfig:
-                description: Name of the custom CoreDNS configmap to configure forwarding
-                  to Lighthouse. It should be in <namespace>/<name> format where <namespace>
-                  is optional and defaults to kube-system.
+                description: |-
+                  Name of the custom CoreDNS configmap to configure forwarding to Lighthouse.
+                  It should be in <namespace>/<name> format where <namespace> is optional and defaults to kube-system.
                 properties:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
@@ -138,6 +147,7 @@ spec:
                 description: Halt on certificate error (so the pod gets restarted).
                 type: boolean
               hostedCluster:
+                description: Is the cluster a hosted cluster.
                 type: boolean
               imageOverrides:
                 additionalProperties:
@@ -166,46 +176,41 @@ spec:
               serviceDiscoveryEnabled:
                 description: Enable support for Service Discovery (Lighthouse).
                 type: boolean
-              clustersetIPEnabled:
-                description: Enable ClustersetIP default for services exported on this
-                  cluster.
-                type: boolean
               tolerations:
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -261,9 +266,10 @@ spec:
                     type: boolean
                   nonReadyContainerStates:
                     items:
-                      description: ContainerState holds a possible state of container.
-                        Only one of its members may be specified. If none of them
-                        is specified, the default one is ContainerStateWaiting.
+                      description: |-
+                        ContainerState holds a possible state of container.
+                        Only one of its members may be specified.
+                        If none of them is specified, the default one is ContainerStateWaiting.
                       properties:
                         running:
                           description: Details about a running container
@@ -328,10 +334,10 @@ spec:
                       a daemon set.
                     properties:
                       collisionCount:
-                        description: Count of hash collisions for the DaemonSet. The
-                          DaemonSet controller uses this field as a collision avoidance
-                          mechanism when it needs to create the name for the newest
-                          ControllerRevision.
+                        description: |-
+                          Count of hash collisions for the DaemonSet. The DaemonSet controller
+                          uses this field as a collision avoidance mechanism when it needs to
+                          create the name for the newest ControllerRevision.
                         format: int32
                         type: integer
                       conditions:
@@ -365,38 +371,46 @@ spec:
                           - type
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
                       currentNumberScheduled:
-                        description: 'The number of nodes that are running at least
-                          1 daemon pod and are supposed to run the daemon pod. More
-                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The number of nodes that are running at least 1
+                          daemon pod and are supposed to run the daemon pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       desiredNumberScheduled:
-                        description: 'The total number of nodes that should be running
-                          the daemon pod (including nodes correctly running the daemon
-                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The total number of nodes that should be running the daemon
+                          pod (including nodes correctly running the daemon pod).
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       numberAvailable:
-                        description: The number of nodes that should be running the
-                          daemon pod and have one or more of the daemon pod running
-                          and available (ready for at least spec.minReadySeconds)
+                        description: |-
+                          The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running and
+                          available (ready for at least spec.minReadySeconds)
                         format: int32
                         type: integer
                       numberMisscheduled:
-                        description: 'The number of nodes that are running the daemon
-                          pod, but are not supposed to run the daemon pod. More info:
-                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The number of nodes that are running the daemon pod, but are
+                          not supposed to run the daemon pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       numberReady:
-                        description: numberReady is the number of nodes that should
-                          be running the daemon pod and have one or more of the daemon
-                          pod running with a Ready Condition.
+                        description: |-
+                          numberReady is the number of nodes that should be running the daemon pod and have one
+                          or more of the daemon pod running with a Ready Condition.
                         format: int32
                         type: integer
                       numberUnavailable:
-                        description: The number of nodes that should be running the
+                        description: |-
+                          The number of nodes that should be running the
                           daemon pod and have none of the daemon pod running and available
                           (ready for at least spec.minReadySeconds)
                         format: int32
@@ -466,9 +480,9 @@ spec:
                             - subnets
                             type: object
                           latencyRTT:
-                            description: LatencySpec describes the round trip time
-                              information for a packet between the gateway pods of
-                              two clusters.
+                            description: |-
+                              LatencySpec describes the round trip time information for a packet
+                              between the gateway pods of two clusters.
                             properties:
                               average:
                                 type: string
@@ -559,9 +573,10 @@ spec:
                     type: boolean
                   nonReadyContainerStates:
                     items:
-                      description: ContainerState holds a possible state of container.
-                        Only one of its members may be specified. If none of them
-                        is specified, the default one is ContainerStateWaiting.
+                      description: |-
+                        ContainerState holds a possible state of container.
+                        Only one of its members may be specified.
+                        If none of them is specified, the default one is ContainerStateWaiting.
                       properties:
                         running:
                           description: Details about a running container
@@ -626,10 +641,10 @@ spec:
                       a daemon set.
                     properties:
                       collisionCount:
-                        description: Count of hash collisions for the DaemonSet. The
-                          DaemonSet controller uses this field as a collision avoidance
-                          mechanism when it needs to create the name for the newest
-                          ControllerRevision.
+                        description: |-
+                          Count of hash collisions for the DaemonSet. The DaemonSet controller
+                          uses this field as a collision avoidance mechanism when it needs to
+                          create the name for the newest ControllerRevision.
                         format: int32
                         type: integer
                       conditions:
@@ -663,38 +678,46 @@ spec:
                           - type
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
                       currentNumberScheduled:
-                        description: 'The number of nodes that are running at least
-                          1 daemon pod and are supposed to run the daemon pod. More
-                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The number of nodes that are running at least 1
+                          daemon pod and are supposed to run the daemon pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       desiredNumberScheduled:
-                        description: 'The total number of nodes that should be running
-                          the daemon pod (including nodes correctly running the daemon
-                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The total number of nodes that should be running the daemon
+                          pod (including nodes correctly running the daemon pod).
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       numberAvailable:
-                        description: The number of nodes that should be running the
-                          daemon pod and have one or more of the daemon pod running
-                          and available (ready for at least spec.minReadySeconds)
+                        description: |-
+                          The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running and
+                          available (ready for at least spec.minReadySeconds)
                         format: int32
                         type: integer
                       numberMisscheduled:
-                        description: 'The number of nodes that are running the daemon
-                          pod, but are not supposed to run the daemon pod. More info:
-                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The number of nodes that are running the daemon pod, but are
+                          not supposed to run the daemon pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       numberReady:
-                        description: numberReady is the number of nodes that should
-                          be running the daemon pod and have one or more of the daemon
-                          pod running with a Ready Condition.
+                        description: |-
+                          numberReady is the number of nodes that should be running the daemon pod and have one
+                          or more of the daemon pod running with a Ready Condition.
                         format: int32
                         type: integer
                       numberUnavailable:
-                        description: The number of nodes that should be running the
+                        description: |-
+                          The number of nodes that should be running the
                           daemon pod and have none of the daemon pod running and available
                           (ready for at least spec.minReadySeconds)
                         format: int32
@@ -718,6 +741,9 @@ spec:
                 required:
                 - mismatchedContainerImages
                 type: object
+              hostedCluster:
+                description: Is the cluster a hosted cluster.
+                type: boolean
               loadBalancerStatus:
                 description: The status of the load balancer DaemonSet.
                 properties:
@@ -725,37 +751,47 @@ spec:
                     description: LoadBalancerStatus represents the status of a load-balancer.
                     properties:
                       ingress:
-                        description: Ingress is a list containing ingress points for
-                          the load-balancer. Traffic intended for the service should
-                          be sent to these ingress points.
+                        description: |-
+                          Ingress is a list containing ingress points for the load-balancer.
+                          Traffic intended for the service should be sent to these ingress points.
                         items:
-                          description: 'LoadBalancerIngress represents the status
-                            of a load-balancer ingress point: traffic intended for
-                            the service should be sent to an ingress point.'
+                          description: |-
+                            LoadBalancerIngress represents the status of a load-balancer ingress point:
+                            traffic intended for the service should be sent to an ingress point.
                           properties:
                             hostname:
-                              description: Hostname is set for load-balancer ingress
-                                points that are DNS based (typically AWS load-balancers)
+                              description: |-
+                                Hostname is set for load-balancer ingress points that are DNS based
+                                (typically AWS load-balancers)
                               type: string
                             ip:
-                              description: IP is set for load-balancer ingress points
-                                that are IP based (typically GCE or OpenStack load-balancers)
+                              description: |-
+                                IP is set for load-balancer ingress points that are IP based
+                                (typically GCE or OpenStack load-balancers)
+                              type: string
+                            ipMode:
+                              description: |-
+                                IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                                Setting this to "VIP" indicates that traffic is delivered to the node with
+                                the destination set to the load-balancer's IP and port.
+                                Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                                the destination set to the node's IP and node port or the pod's IP and port.
+                                Service implementations may use this information to adjust traffic routing.
                               type: string
                             ports:
-                              description: Ports is a list of records of service ports
-                                If used, every port defined in the service should
-                                have an entry in it
+                              description: |-
+                                Ports is a list of records of service ports
+                                If used, every port defined in the service should have an entry in it
                               items:
                                 properties:
                                   error:
-                                    description: 'Error is to record the problem with
-                                      the service port The format of the error shall
-                                      comply with the following rules: - built-in
-                                      error values shall be specified in this file
-                                      and those shall use CamelCase names - cloud
-                                      provider specific error values must have names
-                                      that comply with the format foo.example.com/CamelCase.
-                                      --- The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                    description: |-
+                                      Error is to record the problem with the service port
+                                      The format of the error shall comply with the following rules:
+                                      - built-in error values shall be specified in this file and those shall use
+                                        CamelCase names
+                                      - cloud provider specific error values must have names that comply with the
+                                        format foo.example.com/CamelCase.
                                     maxLength: 316
                                     pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                     type: string
@@ -765,12 +801,12 @@ spec:
                                     format: int32
                                     type: integer
                                   protocol:
-                                    default: TCP
-                                    description: 'Protocol is the protocol of the
-                                      service port of which status is recorded here
-                                      The supported values are: "TCP", "UDP", "SCTP"'
+                                    description: |-
+                                      Protocol is the protocol of the service port of which status is recorded here
+                                      The supported values are: "TCP", "UDP", "SCTP"
                                     type: string
                                 required:
+                                - error
                                 - port
                                 - protocol
                                 type: object
@@ -778,6 +814,7 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 type: object
               natEnabled:
@@ -795,9 +832,10 @@ spec:
                     type: boolean
                   nonReadyContainerStates:
                     items:
-                      description: ContainerState holds a possible state of container.
-                        Only one of its members may be specified. If none of them
-                        is specified, the default one is ContainerStateWaiting.
+                      description: |-
+                        ContainerState holds a possible state of container.
+                        Only one of its members may be specified.
+                        If none of them is specified, the default one is ContainerStateWaiting.
                       properties:
                         running:
                           description: Details about a running container
@@ -862,10 +900,10 @@ spec:
                       a daemon set.
                     properties:
                       collisionCount:
-                        description: Count of hash collisions for the DaemonSet. The
-                          DaemonSet controller uses this field as a collision avoidance
-                          mechanism when it needs to create the name for the newest
-                          ControllerRevision.
+                        description: |-
+                          Count of hash collisions for the DaemonSet. The DaemonSet controller
+                          uses this field as a collision avoidance mechanism when it needs to
+                          create the name for the newest ControllerRevision.
                         format: int32
                         type: integer
                       conditions:
@@ -899,38 +937,46 @@ spec:
                           - type
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
                       currentNumberScheduled:
-                        description: 'The number of nodes that are running at least
-                          1 daemon pod and are supposed to run the daemon pod. More
-                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The number of nodes that are running at least 1
+                          daemon pod and are supposed to run the daemon pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       desiredNumberScheduled:
-                        description: 'The total number of nodes that should be running
-                          the daemon pod (including nodes correctly running the daemon
-                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The total number of nodes that should be running the daemon
+                          pod (including nodes correctly running the daemon pod).
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       numberAvailable:
-                        description: The number of nodes that should be running the
-                          daemon pod and have one or more of the daemon pod running
-                          and available (ready for at least spec.minReadySeconds)
+                        description: |-
+                          The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running and
+                          available (ready for at least spec.minReadySeconds)
                         format: int32
                         type: integer
                       numberMisscheduled:
-                        description: 'The number of nodes that are running the daemon
-                          pod, but are not supposed to run the daemon pod. More info:
-                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        description: |-
+                          The number of nodes that are running the daemon pod, but are
+                          not supposed to run the daemon pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                         format: int32
                         type: integer
                       numberReady:
-                        description: numberReady is the number of nodes that should
-                          be running the daemon pod and have one or more of the daemon
-                          pod running with a Ready Condition.
+                        description: |-
+                          numberReady is the number of nodes that should be running the daemon pod and have one
+                          or more of the daemon pod running with a Ready Condition.
                         format: int32
                         type: integer
                       numberUnavailable:
-                        description: The number of nodes that should be running the
+                        description: |-
+                          The number of nodes that should be running the
                           daemon pod and have none of the daemon pod running and available
                           (ready for at least spec.minReadySeconds)
                         format: int32

--- a/config/manifests/bases/submariner.clusterserviceversion.yaml
+++ b/config/manifests/bases/submariner.clusterserviceversion.yaml
@@ -28,6 +28,18 @@ spec:
         name: submariner-operator
         version: v1
       specDescriptors:
+      - description: ClustersetIP supernet range for allocating ClustersetIPCIDRs
+          to each cluster.
+        displayName: ClustersetIP CIDR Range
+        path: clustersetIPCIDRRange
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Enable ClustersetIP default for connecting clusters.
+        displayName: Enable ClustersetIP
+        path: clustersetIPEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: List of the components to be installed - any of [service-discovery,
           connectivity].
         displayName: Components
@@ -164,6 +176,17 @@ spec:
         path: clusterID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ClustersetIP CIDR for allocating ClustersetIPs to exported services.
+        displayName: ClustersetIP CIDR
+        path: clustersetIPCIDR
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Enable ClustersetIP default for services exported on this cluster.
+        displayName: Enable ClustersetIP default
+        path: clustersetIPEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The gateway connection health check.
         displayName: Connection Health Check
         path: connectionHealthCheck
@@ -187,9 +210,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:connectionHealthCheck.enabled:true
-      - description: Name of the custom CoreDNS configmap to configure forwarding
-          to Lighthouse. It should be in <namespace>/<name> format where <namespace>
-          is optional and defaults to kube-system.
+      - description: |-
+          Name of the custom CoreDNS configmap to configure forwarding to Lighthouse.
+          It should be in <namespace>/<name> format where <namespace> is optional and defaults to kube-system.
         displayName: CoreDNS Custom Config
         path: coreDNSCustomConfig
         x-descriptors:
@@ -281,6 +304,11 @@ spec:
         path: clusterID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The current clustersetIP CIDR.
+        displayName: ClustersetIP CIDR
+        path: clustersetIPCIDR
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Information about the deployment.
         displayName: Deployment Information
         path: deploymentInfo
@@ -298,6 +326,11 @@ spec:
       - description: The status of the Globalnet DaemonSet.
         displayName: Globalnet DaemonSet Status
         path: globalnetDaemonSetStatus
+      - description: Is the cluster a hosted cluster.
+        displayName: Hosted Cluster
+        path: hostedCluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: The status of the load balancer DaemonSet.
         displayName: Load Balancer DaemonSet Status
         path: loadBalancerStatus

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: devel-357dbf060c56
+  newTag: release-0.19-7b95100673b0
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
Backport of #3641 on release-0.19.

#3641: Allow "make bundle" to run without Shipyard

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.