### PR TITLE
Align bundle validation with release branches

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,6 +45,7 @@ jobs:
         run: make bundle LOCAL_BUILD=1
       - name: Verify generated code matches committed code (ignoring hashes)
         run: >-
+          baseref=${{ github.base_ref }} &&
           git add -A &&
           git diff --staged --exit-code
           -IcreatedAt:
@@ -52,8 +53,10 @@ jobs:
           -I"image: quay.io/submariner/"
           -Icontroller-gen.kubebuilder.io/version:
           -Ioperators.operatorframework.io.metrics.builder:
-          -I"\"version\": \"${{ github.base_ref }}-"
-          -I"newTag: ${{ github.base_ref }}-"
+          -I"\"version\": \"${baseref}-"
+          -I"\"version\": \"v${baseref/release-/}."
+          -I"newTag: ${baseref}-"
+          -I"newTag: v${baseref/release-/}."
 
   check-branch-dependencies:
     name: Check branch dependencies


### PR DESCRIPTION
The bundle validation on release branches was changed to account for tagged bundles; this updates the devel bundle validation to match, to ensure that future release branches start off with a correct bundle validation workflow.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
