### PR TITLE
Add SUBMARINER_NAMESPACE env var to the LH CoreDNS deployment

### DIFF
--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -350,6 +350,7 @@ func newLighthouseCoreDNSDeployment(cr *submarinerv1alpha1.ServiceDiscovery) *ap
 							Image:           getImagePath(cr, opnames.LighthouseCoreDNSImage, names.LighthouseCoreDNSComponent),
 							ImagePullPolicy: images.GetPullPolicy(cr.Spec.Version, cr.Spec.ImageOverrides[names.LighthouseCoreDNSComponent]),
 							Env: httpproxy.AddEnvVars([]corev1.EnvVar{
+								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
 								{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},
 							}),

--- a/internal/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -276,6 +276,7 @@ func (t *testDriver) assertCoreDNSDeployment(ctx context.Context) {
 
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_CLUSTERID", t.serviceDiscovery.Spec.ClusterID))
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_CLUSTERCIDR", t.serviceDiscovery.Spec.ClusterCIDR))
+	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_NAMESPACE", t.serviceDiscovery.Spec.Namespace))
 }
 
 func assertDNSConfigServers(actual, expected *operatorv1.DNS) {


### PR DESCRIPTION
...so it can access `ConfigMap`(s) in the operator namespace.
