### PR TITLE
Pass POD_NAME env var to route agent Daemonset

### DIFF
--- a/internal/controllers/submariner/route_agent_resources.go
+++ b/internal/controllers/submariner/route_agent_resources.go
@@ -151,6 +151,11 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 										FieldPath: "spec.nodeName",
 									},
 								}},
+								{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.name",
+									},
+								}},
 								{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
 								{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(healthCheckInterval, 10)},
 								{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(healthCheckMaxPacketLossCount, 10)},


### PR DESCRIPTION
...so the route agent can set the Pod as the owner of the `RouteAgent` resource.

Related to https://github.com/submariner-io/submariner/issues/3660

