### PR TITLE
HealthCheckSpec: stop using uint64

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -365,13 +365,13 @@ type HealthCheckSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connection Health Check Interval"
 	//nolint:lll // Markers can't be wrapped
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:fieldDependency:connectionHealthCheck.enabled:true"}
-	IntervalSeconds uint64 `json:"intervalSeconds,omitempty"`
+	IntervalSeconds uint `json:"intervalSeconds,omitempty"`
 
 	// The maximum number of packets lost at which the health checker will mark the connection as down.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Maximum Packet Loss"
 	//nolint:lll // Markers can't be wrapped
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:fieldDependency:connectionHealthCheck.enabled:true"}
-	MaxPacketLossCount uint64 `json:"maxPacketLossCount,omitempty"`
+	MaxPacketLossCount uint `json:"maxPacketLossCount,omitempty"`
 }
 
 type (

--- a/internal/controllers/submariner/gateway_resources.go
+++ b/internal/controllers/submariner/gateway_resources.go
@@ -82,8 +82,8 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 	// Default healthCheck Values
 	healthCheckEnabled := true
 	// The values are in seconds
-	healthCheckInterval := uint64(1)
-	healthCheckMaxPacketLossCount := uint64(5)
+	healthCheckInterval := uint(1)
+	healthCheckMaxPacketLossCount := uint(5)
 
 	if cr.Spec.ConnectionHealthCheck != nil {
 		healthCheckEnabled = cr.Spec.ConnectionHealthCheck.Enabled
@@ -221,8 +221,8 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 						{Name: "CE_IPSEC_PSKSECRET", Value: cr.Spec.CeIPSecPSKSecret},
 						{Name: "CE_IPSEC_DEBUG", Value: strconv.FormatBool(cr.Spec.CeIPSecDebug)},
 						{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
-						{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(healthCheckInterval, 10)},
-						{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(healthCheckMaxPacketLossCount, 10)},
+						{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(uint64(healthCheckInterval), 10)},
+						{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(uint64(healthCheckMaxPacketLossCount), 10)},
 						{Name: "SUBMARINER_METRICSPORT", Value: gatewayMetricsServerPort},
 						{Name: "SUBMARINER_HALT_ON_CERT_ERROR", Value: strconv.FormatBool(cr.Spec.HaltOnCertificateError)},
 						{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{

--- a/internal/controllers/submariner/route_agent_resources.go
+++ b/internal/controllers/submariner/route_agent_resources.go
@@ -48,8 +48,8 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 	// Default healthCheck Values
 	healthCheckEnabled := true
 	// The values are in seconds
-	healthCheckInterval := uint64(1)
-	healthCheckMaxPacketLossCount := uint64(5)
+	healthCheckInterval := uint(1)
+	healthCheckMaxPacketLossCount := uint(5)
 
 	if cr.Spec.ConnectionHealthCheck != nil {
 		healthCheckEnabled = cr.Spec.ConnectionHealthCheck.Enabled
@@ -152,8 +152,8 @@ func newRouteAgentDaemonSet(cr *v1alpha1.Submariner, name string) *appsv1.Daemon
 									},
 								}},
 								{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
-								{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(healthCheckInterval, 10)},
-								{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(healthCheckMaxPacketLossCount, 10)},
+								{Name: "SUBMARINER_HEALTHCHECKINTERVAL", Value: strconv.FormatUint(uint64(healthCheckInterval), 10)},
+								{Name: "SUBMARINER_HEALTHCHECKMAXPACKETLOSSCOUNT", Value: strconv.FormatUint(uint64(healthCheckMaxPacketLossCount), 10)},
 								{Name: "SUBMARINER_INTRAROUTINGDISABLED", Value: strconv.FormatBool(cr.Spec.DisableIntraClusterConnectivity)},
 							}),
 						},


### PR DESCRIPTION
uint64 doesn't always serialise correctly through JSON, and this causes a panic with tests using Kubernetes 1.34 client libraries. The serialised form for serialisable values doesn't change when switching to uint so this should be safe on upgrades.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
