### PR TITLE
Allow custom annotations for LoadBalancer Service

### DIFF
--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -221,6 +221,11 @@ type SubmarinerSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ImageOverrides map[string]string `json:"imageOverrides,omitempty"`
 
+	// Annotations to add to LoadBalancer services, allowing custom configuration for any cloud.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Annotations for Load Balancer Service"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	LoadBalancerServiceAnnotations map[string]string `json:"loadBalancerServiceAnnotations,omitempty"`
+
 	// The gateway connection health check.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connection Health Check"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "devel-690336c20274"
+            "version": "devel-6dae8d695d23"
           }
         },
         {
@@ -69,7 +69,7 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "devel-690336c20274"
+            "version": "devel-6dae8d695d23"
           }
         }
       ]
@@ -77,7 +77,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: $(SUBMARINER_OPERATOR_IMAGE)
-    createdAt: "2025-10-08 12:55:48"
+    createdAt: "2025-10-24 21:35:51"
     description: Creates and manages Submariner deployments.
     operatorframework.io/suggested-namespace: submariner-operator
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
@@ -344,6 +344,12 @@ spec:
         path: loadBalancerEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Annotations to add to LoadBalancer services, allowing custom
+          configuration for any cloud.
+        displayName: Annotations for Load Balancer Service
+        path: loadBalancerServiceAnnotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The namespace in which to deploy the submariner operator.
         displayName: Namespace
         path: namespace
@@ -696,18 +702,18 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: quay.io/submariner/submariner-operator:devel-690336c20274
+                  value: quay.io/submariner/submariner-operator:devel-6dae8d695d23
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: quay.io/submariner/submariner-gateway:devel-690336c20274
+                  value: quay.io/submariner/submariner-gateway:devel-6dae8d695d23
                 - name: RELATED_IMAGE_submariner-route-agent
-                  value: quay.io/submariner/submariner-route-agent:devel-690336c20274
+                  value: quay.io/submariner/submariner-route-agent:devel-6dae8d695d23
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: quay.io/submariner/submariner-globalnet:devel-690336c20274
+                  value: quay.io/submariner/submariner-globalnet:devel-6dae8d695d23
                 - name: RELATED_IMAGE_lighthouse-agent
-                  value: quay.io/submariner/lighthouse-agent:devel-690336c20274
+                  value: quay.io/submariner/lighthouse-agent:devel-6dae8d695d23
                 - name: RELATED_IMAGE_lighthouse-coredns
-                  value: quay.io/submariner/lighthouse-coredns:devel-690336c20274
-                image: quay.io/submariner/submariner-operator:devel-690336c20274
+                  value: quay.io/submariner/lighthouse-coredns:devel-6dae8d695d23
+                image: quay.io/submariner/submariner-operator:devel-6dae8d695d23
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -860,17 +866,17 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: quay.io/submariner/submariner-operator:devel-690336c20274
+  - image: quay.io/submariner/submariner-operator:devel-6dae8d695d23
     name: submariner-operator
-  - image: quay.io/submariner/submariner-gateway:devel-690336c20274
+  - image: quay.io/submariner/submariner-gateway:devel-6dae8d695d23
     name: submariner-gateway
-  - image: quay.io/submariner/submariner-route-agent:devel-690336c20274
+  - image: quay.io/submariner/submariner-route-agent:devel-6dae8d695d23
     name: submariner-route-agent
-  - image: quay.io/submariner/submariner-globalnet:devel-690336c20274
+  - image: quay.io/submariner/submariner-globalnet:devel-6dae8d695d23
     name: submariner-globalnet
-  - image: quay.io/submariner/lighthouse-agent:devel-690336c20274
+  - image: quay.io/submariner/lighthouse-agent:devel-6dae8d695d23
     name: lighthouse-agent
-  - image: quay.io/submariner/lighthouse-coredns:devel-690336c20274
+  - image: quay.io/submariner/lighthouse-coredns:devel-6dae8d695d23
     name: lighthouse-coredns
   selector:
     matchLabels:

--- a/bundle/manifests/submariner.io_brokers.yaml
+++ b/bundle/manifests/submariner.io_brokers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: brokers.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_servicediscoveries.yaml
+++ b/bundle/manifests/submariner.io_servicediscoveries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: servicediscoveries.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: submariners.submariner.io
 spec:
@@ -114,12 +114,10 @@ spec:
                     type: boolean
                   intervalSeconds:
                     description: The interval at which health check pings are sent.
-                    format: int64
                     type: integer
                   maxPacketLossCount:
                     description: The maximum number of packets lost at which the health
                       checker will mark the connection as down.
-                    format: int64
                     type: integer
                 type: object
               coreDNSCustomConfig:
@@ -164,6 +162,12 @@ spec:
               loadBalancerEnabled:
                 description: Enable automatic Load Balancer in front of the gateways.
                 type: boolean
+              loadBalancerServiceAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to LoadBalancer services, allowing
+                  custom configuration for any cloud.
+                type: object
               namespace:
                 description: The namespace in which to deploy the submariner operator.
                 type: string

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -114,12 +114,10 @@ spec:
                     type: boolean
                   intervalSeconds:
                     description: The interval at which health check pings are sent.
-                    format: int64
                     type: integer
                   maxPacketLossCount:
                     description: The maximum number of packets lost at which the health
                       checker will mark the connection as down.
-                    format: int64
                     type: integer
                 type: object
               coreDNSCustomConfig:
@@ -164,6 +162,12 @@ spec:
               loadBalancerEnabled:
                 description: Enable automatic Load Balancer in front of the gateways.
                 type: boolean
+              loadBalancerServiceAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to LoadBalancer services, allowing
+                  custom configuration for any cloud.
+                type: object
               namespace:
                 description: The namespace in which to deploy the submariner operator.
                 type: string

--- a/config/manifests/bases/submariner.clusterserviceversion.yaml
+++ b/config/manifests/bases/submariner.clusterserviceversion.yaml
@@ -273,6 +273,12 @@ spec:
         path: loadBalancerEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Annotations to add to LoadBalancer services, allowing custom
+          configuration for any cloud.
+        displayName: Annotations for Load Balancer Service
+        path: loadBalancerServiceAnnotations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The namespace in which to deploy the submariner operator.
         displayName: Namespace
         path: namespace

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: devel-690336c20274
+  newTag: devel-6dae8d695d23
 - name: repo
   newName: quay.io/submariner

--- a/deploy/crds/submariner.io_brokers.yaml
+++ b/deploy/crds/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/deploy/crds/submariner.io_servicediscoveries.yaml
+++ b/deploy/crds/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/deploy/crds/submariner.io_submariners.yaml
+++ b/deploy/crds/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -114,12 +114,10 @@ spec:
                     type: boolean
                   intervalSeconds:
                     description: The interval at which health check pings are sent.
-                    format: int64
                     type: integer
                   maxPacketLossCount:
                     description: The maximum number of packets lost at which the health
                       checker will mark the connection as down.
-                    format: int64
                     type: integer
                 type: object
               coreDNSCustomConfig:
@@ -164,6 +162,12 @@ spec:
               loadBalancerEnabled:
                 description: Enable automatic Load Balancer in front of the gateways.
                 type: boolean
+              loadBalancerServiceAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to LoadBalancer services, allowing
+                  custom configuration for any cloud.
+                type: object
               namespace:
                 description: The namespace in which to deploy the submariner operator.
                 type: string

--- a/internal/controllers/submariner/loadbalancer_resources.go
+++ b/internal/controllers/submariner/loadbalancer_resources.go
@@ -20,6 +20,7 @@ package submariner
 
 import (
 	"context"
+	"maps"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -110,8 +111,14 @@ func newLoadBalancerService(instance *v1alpha1.Submariner, platformTypeOCP strin
 		if instance.Spec.HostedCluster {
 			externalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
 		}
-	default:
-		svcAnnotations = map[string]string{}
+	}
+
+	if len(instance.Spec.LoadBalancerServiceAnnotations) > 0 {
+		if svcAnnotations == nil {
+			svcAnnotations = make(map[string]string, len(instance.Spec.LoadBalancerServiceAnnotations))
+		}
+
+		maps.Copy(svcAnnotations, instance.Spec.LoadBalancerServiceAnnotations)
 	}
 
 	return &corev1.Service{

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -420,6 +420,19 @@ func testLoadBalancerReconciliation() {
 					"service.kubernetes.io/ibm-load-balancer-cloud-provider-enable-features", "nlb"))
 			})
 		})
+
+		Context("and custom annotations are defined", func() {
+			BeforeEach(func() {
+				t.submariner.Spec.LoadBalancerServiceAnnotations = map[string]string{"submariner.io/annotation": "customvalue"}
+			})
+
+			It("should copy them", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				service := t.assertLoadBalancerService(ctx)
+				Expect(service.Annotations).To(HaveKeyWithValue("submariner.io/annotation", "customvalue"))
+			})
+		})
 	})
 }
 


### PR DESCRIPTION
Allow customer to set custom annotations in LoadBalancer Service with spec.loadBalancerServiceAnnotations

Open more possibility to configure Service

Fix https://github.com/submariner-io/submariner-operator/issues/3695
