### PR TITLE
Fix labels for ACM 2.13 in release-0.20

### DIFF
--- a/bundle.Dockerfile.konflux
+++ b/bundle.Dockerfile.konflux
@@ -22,7 +22,7 @@ COPY bundle/tests/scorecard /tests/scorecard/
 
 ARG SOURCE_DATE_EPOCH
 
-LABEL cpe="cpe:/a:redhat:acm:2.14::el9"
+LABEL cpe="cpe:/a:redhat:acm:2.13::el9"
 LABEL csv-version="0.20.2"
 LABEL description="submariner-operator-bundle"
 LABEL distribution-scope="public"
@@ -50,4 +50,4 @@ LABEL io.openshift.non-scalable="true"
 LABEL io.openshift.tags="submariner,submariner-operator-bundle,rhel9"
 LABEL io.openshift.wants="submariner-operator"
 
-LABEL org.opencontainers.image.created=$SOURCE_DATE_EPOCH
+LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"

--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -73,5 +73,5 @@ LABEL com.redhat.component="submariner-operator-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.14::el9" \
+      cpe="cpe:/a:redhat:acm:2.13::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
Updates cpe from 2.14 to 2.13 for release-0.20 in operator and bundle. Fixes org.opencontainers.image.created variable expansion in bundle.