### PR TITLE
Fix CPE label for ACM 2.12 in release-0.19

### DIFF
--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -73,5 +73,5 @@ LABEL com.redhat.component="submariner-operator-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.14::el9" \
+      cpe="cpe:/a:redhat:acm:2.12::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
Updates cpe from 2.14 to 2.12 for release-0.19.