### PR TITLE
Automated backport of #3692: Bump the subctl GHA to Go 1.24

### DIFF
--- a/.github/workflows/subctl-unit.yml
+++ b/.github/workflows/subctl-unit.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           check-latest: true
 
       - name: Update the subctl build to use the current submariner-operator


### PR DESCRIPTION
Backport of #3692 on release-0.18.

#3692: Bump the subctl GHA to Go 1.24

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.