### PR TITLE
Automated backport of #3778: Handle release-to-tag changes in bundle validation

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -53,10 +53,9 @@ jobs:
           -I"image: quay.io/submariner/"
           -Icontroller-gen.kubebuilder.io/version:
           -Ioperators.operatorframework.io.metrics.builder:
-          -I"\"version\": \"${baseref}-"
-          -I"\"version\": \"v${baseref/release-/}."
-          -I"newTag: ${baseref}-"
-          -I"newTag: v${baseref/release-/}."
+          -I"\"?version\"?: \"?.*${baseref/release-/}."
+          -I"newTag: .*${baseref/release-/}."
+          -I"name: submariner.v${baseref/release-/}"
 
   crds:
     name: CRDs up-to-date


### PR DESCRIPTION
Backport of #3778 on release-0.19.

#3778: Handle release-to-tag changes in bundle validation

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.