### PR TITLE
Fix bundle Dockerfile labels to match CSV version

### DIFF
--- a/bundle.Dockerfile.konflux
+++ b/bundle.Dockerfile.konflux
@@ -23,16 +23,16 @@ COPY bundle/tests/scorecard /tests/scorecard/
 ARG SOURCE_DATE_EPOCH
 
 LABEL cpe="cpe:/a:redhat:acm:2.15::el9"
-LABEL csv-version="0.22.2"
+LABEL csv-version="0.22.0"
 LABEL description="submariner-operator-bundle"
 LABEL distribution-scope="public"
 LABEL maintainer="['multi-cluster-networking@redhat.com']"
 LABEL name="rhacm2/submariner-operator-bundle"
-LABEL release="v0.22.2"
+LABEL release="v0.22.0"
 LABEL summary="submariner-operator-bundle"
 LABEL url="https://github.com/submariner-io/submariner-operator"
 LABEL vendor="Red Hat, Inc."
-LABEL version="v0.22.2"
+LABEL version="v0.22.0"
 
 LABEL com.github.commit="25ca7d600c464d14bd60d0e92b414e5824c8a5ee"
 LABEL com.github.url="https://github.com/submariner-io/submariner-operator.git"


### PR DESCRIPTION
Labels were incorrectly set to 0.22.2 when bundle CSV is 0.22.0.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
