### PR TITLE
Adjust to golangci-lint v2.7.2

### DIFF
--- a/internal/controllers/submariner/gateway_resources.go
+++ b/internal/controllers/submariner/gateway_resources.go
@@ -185,6 +185,7 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 						// We need to be able to update /var/lib/alternatives (for iptables)
 						ReadOnlyRootFilesystem: ptr.To(false),
 					},
+					//nolint:gosec // Ignore integer overflow conversion int -> int32
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          encapsPortName,

--- a/internal/controllers/submariner/loadbalancer_resources.go
+++ b/internal/controllers/submariner/loadbalancer_resources.go
@@ -135,6 +135,7 @@ func newLoadBalancerService(instance *v1alpha1.Submariner, platformTypeOCP strin
 				appLabel:           names.GatewayComponent,
 				gatewayStatusLabel: string(submv1.HAStatusActive),
 			},
+			//nolint:gosec // Ignore integer overflow conversion int -> int32
 			Ports: []corev1.ServicePort{
 				{
 					Name:       encapsPortName,

--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -278,7 +278,7 @@ func GetValidAllocationSize(cidrRange string, allocationSize uint) (uint, error)
 	}
 
 	ones, totalbits := network.Mask.Size()
-	availableSize := uint(1) << uint(totalbits-ones)
+	availableSize := uint(1) << uint(totalbits-ones) //nolint:gosec // Ignore overflow conversion int -> uint
 	userClusterSize := allocationSize
 	allocationSize = nextPowerOf2(allocationSize)
 


### PR DESCRIPTION
Revert the prior `nolint:gosec` removals due to v2.7.1.

Depends on https://github.com/submariner-io/shipyard/pull/2231