### PR TITLE
Use IntOrString constructors

### DIFF
--- a/internal/controllers/metrics/metrics.go
+++ b/internal/controllers/metrics/metrics.go
@@ -83,10 +83,7 @@ func newMetricsService(name, namespace, appKey, appName string, port int32) *cor
 	}
 
 	servicePorts := []corev1.ServicePort{
-		{Port: port, Name: "metrics", Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{
-			Type:   intstr.Int,
-			IntVal: port,
-		}},
+		{Port: port, Name: "metrics", Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt32(port)},
 	}
 
 	service := &corev1.Service{

--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -405,24 +405,8 @@ func newLighthouseCoreDNSService(cr *submarinerv1alpha1.ServiceDiscovery) *corev
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{
-					Name:     "udp",
-					Protocol: "UDP",
-					Port:     53,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 53,
-					},
-				},
-				{
-					Name:     "tcp",
-					Protocol: "TCP",
-					Port:     53,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 53,
-					},
-				},
+				{Name: "udp", Protocol: "UDP", Port: 53, TargetPort: intstr.FromInt32(53)},
+				{Name: "tcp", Protocol: "TCP", Port: 53, TargetPort: intstr.FromInt32(53)},
 			},
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{

--- a/internal/controllers/submariner/loadbalancer_resources.go
+++ b/internal/controllers/submariner/loadbalancer_resources.go
@@ -139,13 +139,13 @@ func newLoadBalancerService(instance *v1alpha1.Submariner, platformTypeOCP strin
 				{
 					Name:       encapsPortName,
 					Port:       int32(instance.Spec.CeIPSecNATTPort),
-					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: int32(instance.Spec.CeIPSecNATTPort)},
+					TargetPort: intstr.FromInt32(int32(instance.Spec.CeIPSecNATTPort)),
 					Protocol:   corev1.ProtocolUDP,
 				},
 				{
 					Name:       nattDiscoveryPortName,
 					Port:       int32(port.NATTDiscovery),
-					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: int32(port.NATTDiscovery)},
+					TargetPort: intstr.FromInt32(int32(port.NATTDiscovery)),
 					Protocol:   corev1.ProtocolUDP,
 				},
 			},

--- a/pkg/discovery/network/generic.go
+++ b/pkg/discovery/network/generic.go
@@ -137,14 +137,7 @@ func findClusterIPRangeFromServiceCreation(ctx context.Context, client controlle
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: "1.1.1.1",
-			Ports: []corev1.ServicePort{
-				{
-					Port: 443,
-					TargetPort: intstr.IntOrString{
-						IntVal: 443,
-					},
-				},
-			},
+			Ports:     []corev1.ServicePort{{Port: 443, TargetPort: intstr.FromInt32(443)}},
 		},
 	}
 


### PR DESCRIPTION
This is less verbose and more resilient against future change than constructing the objects manually.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and standardized internal service port declarations across networking, discovery, and load-balancer components.
  * Simplified how port values are constructed for consistency and maintainability.
  * No behavioral or public API changes; no user-visible impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->