### PR TITLE
Consider preallocating slices with capacity

### DIFF
--- a/pkg/discovery/network/generic.go
+++ b/pkg/discovery/network/generic.go
@@ -82,7 +82,7 @@ func discoverGenericServiceCIDRs(ctx context.Context, client controllerClient.Cl
 
 	err := client.List(ctx, serviceCIDRList, controllerClient.InNamespace(""))
 	if err == nil && len(serviceCIDRList.Items) > 0 {
-		var serviceCIDRs []string
+		serviceCIDRs := make([]string, 0, len(serviceCIDRList.Items))
 
 		for i := range serviceCIDRList.Items {
 			serviceCIDRs = append(serviceCIDRs, serviceCIDRList.Items[i].Spec.CIDRs...)

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -152,7 +152,7 @@ func getCIDRs(ctx context.Context, operatorClient controllerClient.Client, opera
 }
 
 func splitCommaSeparatedCIDRs(cidrs []string) []string {
-	var newCIDRs []string
+	newCIDRs := make([]string, 0, len(cidrs))
 	for _, c := range cidrs {
 		newCIDRs = append(newCIDRs, strings.Split(c, ",")...)
 	}


### PR DESCRIPTION
...flagged by the 'prealloc' linter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Performance optimization to internal network discovery mechanisms through improved memory allocation efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->