### PR TITLE
Substitute containerImage annotation in bundle

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,6 +49,7 @@ jobs:
           git add -A &&
           git diff --staged --exit-code
           -IcreatedAt:
+          -IcontainerImage:
           -I"value: quay.io/submariner/"
           -I"image: quay.io/submariner/"
           -Icontroller-gen.kubebuilder.io/version:

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ endif
 FROM_VERSION ?= $(shell (git tag -l --sort=-v:refname v[0-9]*\.[0-9]*\.[0-9]* | awk '/^$(BUNDLE_VERSION)$$/ { seen = 1; next } seen { print; exit } END { exit !seen }' || echo v0.0.0) \
           | head -n1 | cut -d'-' -f1 | cut -c2-)
 SHORT_VERSION := $(shell echo ${BUNDLE_VERSION} | cut -d'.' -f1,2)
+OPERATOR_IMG := $(shell grep -A2 'RELATED_IMAGE_submariner-operator' config/manager/patches/related-images.deployment.config.yaml 2>/dev/null | grep 'value:' | awk '{print $$2}')
 CHANNEL ?= alpha-$(SHORT_VERSION)
 CHANNELS ?= $(CHANNEL)
 DEFAULT_CHANNEL ?= $(CHANNEL)
@@ -198,6 +199,7 @@ bundle: kustomization | $(KUSTOMIZE) $(OPERATOR_SDK)
 	| $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS))
 	(cd config/bundle && $(KUSTOMIZE) edit add resource ../../bundle/manifests/submariner.clusterserviceversion.yaml)
 	$(KUSTOMIZE) build config/bundle/ --load-restrictor=LoadRestrictionsNone --output bundle/manifests/submariner.clusterserviceversion.yaml
+	sed -i -e 's|$$(SUBMARINER_OPERATOR_IMAGE)|$(OPERATOR_IMG)|g' bundle/manifests/submariner.clusterserviceversion.yaml
 	sed -i -e 's/$$(SHORT_VERSION)/$(SHORT_VERSION)/g' bundle/manifests/submariner.clusterserviceversion.yaml
 	sed -i -e 's/$$(VERSION)/$(VERSION)/g' bundle/manifests/submariner.clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate --select-optional suite=operatorframework ./bundle

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "devel-e1cfcc0f6d67"
+            "version": "devel-c17ac5a484b8"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "devel-e1cfcc0f6d67"
+            "version": "devel-c17ac5a484b8"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: $(SUBMARINER_OPERATOR_IMAGE)
-    createdAt: "2026-01-04 17:26:44"
+    containerImage: quay.io/submariner/submariner-operator:devel-c17ac5a484b8
+    createdAt: "2026-02-04 19:36:02"
     description: Creates and manages Submariner deployments.
     operatorframework.io/suggested-namespace: submariner-operator
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
@@ -702,18 +702,18 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: quay.io/submariner/submariner-operator:devel-e1cfcc0f6d67
+                  value: quay.io/submariner/submariner-operator:devel-c17ac5a484b8
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: quay.io/submariner/submariner-gateway:devel-e1cfcc0f6d67
+                  value: quay.io/submariner/submariner-gateway:devel-c17ac5a484b8
                 - name: RELATED_IMAGE_submariner-route-agent
-                  value: quay.io/submariner/submariner-route-agent:devel-e1cfcc0f6d67
+                  value: quay.io/submariner/submariner-route-agent:devel-c17ac5a484b8
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: quay.io/submariner/submariner-globalnet:devel-e1cfcc0f6d67
+                  value: quay.io/submariner/submariner-globalnet:devel-c17ac5a484b8
                 - name: RELATED_IMAGE_lighthouse-agent
-                  value: quay.io/submariner/lighthouse-agent:devel-e1cfcc0f6d67
+                  value: quay.io/submariner/lighthouse-agent:devel-c17ac5a484b8
                 - name: RELATED_IMAGE_lighthouse-coredns
-                  value: quay.io/submariner/lighthouse-coredns:devel-e1cfcc0f6d67
-                image: quay.io/submariner/submariner-operator:devel-e1cfcc0f6d67
+                  value: quay.io/submariner/lighthouse-coredns:devel-c17ac5a484b8
+                image: quay.io/submariner/submariner-operator:devel-c17ac5a484b8
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -866,17 +866,17 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: quay.io/submariner/submariner-operator:devel-e1cfcc0f6d67
+  - image: quay.io/submariner/submariner-operator:devel-c17ac5a484b8
     name: submariner-operator
-  - image: quay.io/submariner/submariner-gateway:devel-e1cfcc0f6d67
+  - image: quay.io/submariner/submariner-gateway:devel-c17ac5a484b8
     name: submariner-gateway
-  - image: quay.io/submariner/submariner-route-agent:devel-e1cfcc0f6d67
+  - image: quay.io/submariner/submariner-route-agent:devel-c17ac5a484b8
     name: submariner-route-agent
-  - image: quay.io/submariner/submariner-globalnet:devel-e1cfcc0f6d67
+  - image: quay.io/submariner/submariner-globalnet:devel-c17ac5a484b8
     name: submariner-globalnet
-  - image: quay.io/submariner/lighthouse-agent:devel-e1cfcc0f6d67
+  - image: quay.io/submariner/lighthouse-agent:devel-c17ac5a484b8
     name: lighthouse-agent
-  - image: quay.io/submariner/lighthouse-coredns:devel-e1cfcc0f6d67
+  - image: quay.io/submariner/lighthouse-coredns:devel-c17ac5a484b8
     name: lighthouse-coredns
   selector:
     matchLabels:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: devel-e1cfcc0f6d67
+  newTag: devel-c17ac5a484b8
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
The $(SUBMARINER_OPERATOR_IMAGE) placeholder in the CSV containerImage annotation appears raw in OperatorHub instead of showing the actual image.

This worked previously when bundles were built via CPaaS, which used a midstream render_templates script to substitute the placeholder. When Konflux replaced CPaaS for bundle builds, no equivalent substitution was added to the upstream Makefile.

Extract the operator image from related-images config and substitute it during bundle generation, matching the midstream approach.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bundle generation now replaces operator image placeholders with the actual operator image so generated bundles reference a real operator image for deployment.
  * Development image tags for the operator and related components were updated to a new devel tag to ensure bundle manifests reference the latest build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->