### PR TITLE
Substitute containerImage annotation in bundle 0.20

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,6 +49,7 @@ jobs:
           git add -A &&
           git diff --staged --exit-code
           -IcreatedAt:
+          -IcontainerImage:
           -I"value: quay.io/submariner/"
           -I"image: quay.io/submariner/"
           -Icontroller-gen.kubebuilder.io/version:

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ endif
 FROM_VERSION ?= $(shell (git tag -l --sort=-v:refname v[0-9]*\.[0-9]*\.[0-9]* | awk '/^$(BUNDLE_VERSION)$$/ { seen = 1; next } seen { print; exit } END { exit !seen }' || echo v0.0.0) \
           | head -n1 | cut -d'-' -f1 | cut -c2-)
 SHORT_VERSION := $(shell echo ${BUNDLE_VERSION} | cut -d'.' -f1,2)
+OPERATOR_IMG := $(shell grep -A2 'RELATED_IMAGE_submariner-operator' config/manager/patches/related-images.deployment.config.yaml 2>/dev/null | grep 'value:' | awk '{print $$2}')
 CHANNEL ?= stable-$(SHORT_VERSION)
 CHANNELS ?= $(CHANNEL)
 DEFAULT_CHANNEL ?= $(CHANNEL)
@@ -234,6 +235,7 @@ bundle: $(KUSTOMIZE) $(OPERATOR_SDK) kustomization
 	| $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS))
 	(cd config/bundle && $(KUSTOMIZE) edit add resource ../../bundle/manifests/submariner.clusterserviceversion.yaml)
 	$(KUSTOMIZE) build config/bundle/ --load-restrictor=LoadRestrictionsNone --output bundle/manifests/submariner.clusterserviceversion.yaml
+	sed -i -e 's|$$(SUBMARINER_OPERATOR_IMAGE)|$(OPERATOR_IMG)|g' bundle/manifests/submariner.clusterserviceversion.yaml
 	sed -i -e 's/$$(SHORT_VERSION)/$(SHORT_VERSION)/g' bundle/manifests/submariner.clusterserviceversion.yaml
 	sed -i -e 's/$$(VERSION)/$(VERSION)/g' bundle/manifests/submariner.clusterserviceversion.yaml
 	# The operator-sdk gets bugs when two RELATED_IMAGE_ variables point to the same image, so fix the empty name for the nettest image

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "0.20.2"
+            "version": "release-0.20-dfca5c1e80f4"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "0.20.2"
+            "version": "release-0.20-dfca5c1e80f4"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: $(SUBMARINER_OPERATOR_IMAGE)
-    createdAt: "2025-09-30 14:21:54"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
+    createdAt: "2026-02-05 13:34:06"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/bundle/manifests/submariner.io_brokers.yaml
+++ b/bundle/manifests/submariner.io_brokers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   creationTimestamp: null
   name: brokers.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_servicediscoveries.yaml
+++ b/bundle/manifests/submariner.io_servicediscoveries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   creationTimestamp: null
   name: servicediscoveries.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   creationTimestamp: null
   name: submariners.submariner.io
 spec:

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2025-09-30 14:21:54"
+  createdAt: "2026-02-05 13:34:06"
   features.operators.openshift.io/disconnected: "true"
   features.operators.openshift.io/fips-compliant: "true"
   features.operators.openshift.io/proxy-aware: "false"

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: submariners.submariner.io
 spec:
   group: submariner.io

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: 0.20.2
+  newTag: release-0.20-dfca5c1e80f4
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
The $(SUBMARINER_OPERATOR_IMAGE) placeholder in the CSV containerImage annotation appears raw in OperatorHub instead of showing the actual image.

This worked previously when bundles were built via CPaaS, which used a midstream render_templates script to substitute the placeholder. When Konflux replaced CPaaS for bundle builds, no equivalent substitution was added to the upstream Makefile.

Extract the operator image from related-images config and substitute it during bundle generation, matching the midstream approach.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
