### PR TITLE
Substitute containerImage annotation in bundle 0.19

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,6 +49,7 @@ jobs:
           git add -A &&
           git diff --staged --exit-code
           -IcreatedAt:
+          -IcontainerImage:
           -I"value: quay.io/submariner/"
           -I"image: quay.io/submariner/"
           -Icontroller-gen.kubebuilder.io/version:

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ endif
 FROM_VERSION ?= $(shell (git tag -l --sort=-v:refname v[0-9]*\.[0-9]*\.[0-9]* | awk '/^$(BUNDLE_VERSION)$$/ { seen = 1; next } seen { print; exit } END { exit !seen }' || echo v0.0.0) \
           | head -n1 | cut -d'-' -f1 | cut -c2-)
 SHORT_VERSION := $(shell echo ${BUNDLE_VERSION} | cut -d'.' -f1,2)
+OPERATOR_IMG := $(shell grep -A2 'RELATED_IMAGE_submariner-operator' config/manager/patches/related-images.deployment.config.yaml 2>/dev/null | grep 'value:' | awk '{print $$2}')
 CHANNEL ?= stable-$(SHORT_VERSION)
 CHANNELS ?= $(CHANNEL)
 DEFAULT_CHANNEL ?= $(CHANNEL)
@@ -217,6 +218,7 @@ bundle: $(KUSTOMIZE) $(OPERATOR_SDK) kustomization
 	| $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS))
 	(cd config/bundle && $(KUSTOMIZE) edit add resource ../../bundle/manifests/submariner.clusterserviceversion.yaml)
 	$(KUSTOMIZE) build config/bundle/ --load_restrictor=LoadRestrictionsNone --output bundle/manifests/submariner.clusterserviceversion.yaml
+	sed -i -e 's|$$(SUBMARINER_OPERATOR_IMAGE)|$(OPERATOR_IMG)|g' bundle/manifests/submariner.clusterserviceversion.yaml
 	sed -i -e 's/$$(SHORT_VERSION)/$(SHORT_VERSION)/g' bundle/manifests/submariner.clusterserviceversion.yaml
 	sed -i -e 's/$$(VERSION)/$(VERSION)/g' bundle/manifests/submariner.clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate --select-optional suite=operatorframework ./bundle

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "v0.19.4"
+            "version": "release-0.19-47a20cd423c1"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "v0.19.4"
+            "version": "release-0.19-47a20cd423c1"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: $(SUBMARINER_OPERATOR_IMAGE)
-    createdAt: "2026-01-06 16:39:21"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:dd83b4947e3cb5317f7115dbdd4f0c9693c3e845db67a527e32fef416e16d439
+    createdAt: "2026-02-05 12:13:50"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-01-06 16:39:21"
+  createdAt: "2026-02-05 12:13:50"
   features.operators.openshift.io/disconnected: "true"
   features.operators.openshift.io/fips-compliant: "true"
   features.operators.openshift.io/proxy-aware: "false"

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: v0.19.4
+  newTag: release-0.19-47a20cd423c1
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
The $(SUBMARINER_OPERATOR_IMAGE) placeholder in the CSV containerImage annotation appears raw in OperatorHub instead of showing the actual image.

This worked previously when bundles were built via CPaaS, which used a midstream render_templates script to substitute the placeholder. When Konflux replaced CPaaS for bundle builds, no equivalent substitution was added to the upstream Makefile.

Extract the operator image from related-images config and substitute it during bundle generation, matching the midstream approach.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline task bundle image references with new digests
  * Updated build configuration and image tags to new versions
  * Updated manifest version references and build metadata
  * Enhanced workflow exclusion patterns for bundle validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->