### PR TITLE
Pin Konflux Dockerfile version labels to v0.22.1

### DIFF
--- a/bundle.Dockerfile.konflux
+++ b/bundle.Dockerfile.konflux
@@ -23,16 +23,16 @@ COPY bundle/tests/scorecard /tests/scorecard/
 ARG SOURCE_DATE_EPOCH
 
 LABEL cpe="cpe:/a:redhat:acm:2.15::el9"
-LABEL csv-version="0.22.0"
+LABEL csv-version="0.22.1"
 LABEL description="submariner-operator-bundle"
 LABEL distribution-scope="public"
 LABEL maintainer="['multi-cluster-networking@redhat.com']"
 LABEL name="rhacm2/submariner-operator-bundle"
-LABEL release="v0.22.0"
+LABEL release="v0.22.1"
 LABEL summary="submariner-operator-bundle"
 LABEL url="https://github.com/submariner-io/submariner-operator"
 LABEL vendor="Red Hat, Inc."
-LABEL version="v0.22.0"
+LABEL version="v0.22.1"
 
 LABEL com.github.commit="25ca7d600c464d14bd60d0e92b414e5824c8a5ee"
 LABEL com.github.url="https://github.com/submariner-io/submariner-operator.git"

--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -63,7 +63,7 @@ USER submariner
 
 LABEL com.redhat.component="submariner-operator-container" \
       name="rhacm2/submariner-rhel9-operator" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="Submariner Operator" \
       description="The Submariner Operator manages the lifecycle of Submariner components." \
       io.k8s.display-name="Submariner Operator" \


### PR DESCRIPTION
Enables dynamic tagging in Konflux releases for 0.22.1 Z-stream.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container and release metadata labels from v0.22.0 to v0.22.1, including the operator image label.
  * This is a metadata-only version bump with no functional or runtime changes; low-risk release housekeeping to align version identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->