### PR TITLE
Update bundle to 0.22.1

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "release-0.22-96edb1751559"
+            "version": "v0.22.1"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "release-0.22-96edb1751559"
+            "version": "v0.22.1"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3f71495eab9e2f82f74a21df6143c799bfb8a0038aef4e97b766a498bb535c16
-    createdAt: "2026-02-05 12:27:01"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:01d23e8ab8df7441074c21c4f87d010be6f121114f8ec5ae1ae1abc08e0403cc
+    createdAt: "2026-02-12 14:14:40"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -93,7 +93,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/submariner-io/submariner-operator
     support: Submariner
-  name: submariner.v0.22.0
+  name: submariner.v0.22.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -711,22 +711,22 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3f71495eab9e2f82f74a21df6143c799bfb8a0038aef4e97b766a498bb535c16
+                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:01d23e8ab8df7441074c21c4f87d010be6f121114f8ec5ae1ae1abc08e0403cc
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:1112c506ac82bbd14bf970a859690529b2165945c337b5da04a2e963bb7f6a77
+                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:da7694ab3abff86f89aed2768bab2108f752586350fce3affb0d3f1117dbd9a1
                 - name: RELATED_IMAGE_submariner-routeagent
-                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:096c3fa7333d2cca1984d2852af84ca6735de3ca6fabcdd1aff25fee372acf98
+                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:aaebded4e33e411af66fdb1839a5c7006fcc444c2e4a31109473ddb20f36bb67
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:ef127d44c1bfa39e2e301eca2a1de736df43285b66e3b766860f372fd2cfb591
+                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:1f1b41cdbdd11848c2dad24cdb6c1ec42c3c370c4874fe83d0153a343e9b93d1
                 - name: RELATED_IMAGE_submariner-lighthouse-agent
-                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:5ee9a8aff7bd566cc4633c5191c40d7370349abdbfe19ac6e0588956f879c0c8
+                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:b45bc7cad8a7efb6fd5932d66ae6044b598b99c73e6c1383577e51234e290d42
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
-                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:cd29afa47105e0b49b0f640651c16a73d1190c84fb28aa6feee75d5e89b40b2c
+                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:364d7b5b279791c1a2e914b465274771e5916d0f612c97919a9200a7d8386ddc
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:81fd7584951aaf7bcb86d4038089675e3ec4da3791b2a49fe73ae55f217f4303
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:4af2e26f6f9761c16959f4016a2700240efbf1872a2086c2c69275995be97232
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:81fd7584951aaf7bcb86d4038089675e3ec4da3791b2a49fe73ae55f217f4303
-                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3f71495eab9e2f82f74a21df6143c799bfb8a0038aef4e97b766a498bb535c16
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:4af2e26f6f9761c16959f4016a2700240efbf1872a2086c2c69275995be97232
+                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:01d23e8ab8df7441074c21c4f87d010be6f121114f8ec5ae1ae1abc08e0403cc
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -879,21 +879,21 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3f71495eab9e2f82f74a21df6143c799bfb8a0038aef4e97b766a498bb535c16
+  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:01d23e8ab8df7441074c21c4f87d010be6f121114f8ec5ae1ae1abc08e0403cc
     name: submariner-operator
-  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:1112c506ac82bbd14bf970a859690529b2165945c337b5da04a2e963bb7f6a77
+  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:da7694ab3abff86f89aed2768bab2108f752586350fce3affb0d3f1117dbd9a1
     name: submariner-gateway
-  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:096c3fa7333d2cca1984d2852af84ca6735de3ca6fabcdd1aff25fee372acf98
+  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:aaebded4e33e411af66fdb1839a5c7006fcc444c2e4a31109473ddb20f36bb67
     name: submariner-routeagent
-  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:ef127d44c1bfa39e2e301eca2a1de736df43285b66e3b766860f372fd2cfb591
+  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:1f1b41cdbdd11848c2dad24cdb6c1ec42c3c370c4874fe83d0153a343e9b93d1
     name: submariner-globalnet
-  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:5ee9a8aff7bd566cc4633c5191c40d7370349abdbfe19ac6e0588956f879c0c8
+  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:b45bc7cad8a7efb6fd5932d66ae6044b598b99c73e6c1383577e51234e290d42
     name: submariner-lighthouse-agent
-  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:cd29afa47105e0b49b0f640651c16a73d1190c84fb28aa6feee75d5e89b40b2c
+  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:364d7b5b279791c1a2e914b465274771e5916d0f612c97919a9200a7d8386ddc
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:81fd7584951aaf7bcb86d4038089675e3ec4da3791b2a49fe73ae55f217f4303
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:4af2e26f6f9761c16959f4016a2700240efbf1872a2086c2c69275995be97232
     name: ""
   selector:
     matchLabels:
       control-plane: submariner-operator
-  version: 0.22.0
+  version: 0.22.1

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -5,10 +5,10 @@ patches:
   target:
     group: operators.coreos.com
     kind: ClusterServiceVersion
-    name: submariner.v0.22.0
+    name: submariner.v0.22.1
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-02-05 12:27:01"
+  createdAt: "2026-02-12 14:14:40"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -3,42 +3,42 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-operator
-    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3f71495eab9e2f82f74a21df6143c799bfb8a0038aef4e97b766a498bb535c16
+    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:01d23e8ab8df7441074c21c4f87d010be6f121114f8ec5ae1ae1abc08e0403cc
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-gateway
-    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:1112c506ac82bbd14bf970a859690529b2165945c337b5da04a2e963bb7f6a77
+    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:da7694ab3abff86f89aed2768bab2108f752586350fce3affb0d3f1117dbd9a1
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-routeagent
-    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:096c3fa7333d2cca1984d2852af84ca6735de3ca6fabcdd1aff25fee372acf98
+    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:aaebded4e33e411af66fdb1839a5c7006fcc444c2e4a31109473ddb20f36bb67
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-globalnet
-    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:ef127d44c1bfa39e2e301eca2a1de736df43285b66e3b766860f372fd2cfb591
+    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:1f1b41cdbdd11848c2dad24cdb6c1ec42c3c370c4874fe83d0153a343e9b93d1
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-agent
-    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:5ee9a8aff7bd566cc4633c5191c40d7370349abdbfe19ac6e0588956f879c0c8
+    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:b45bc7cad8a7efb6fd5932d66ae6044b598b99c73e6c1383577e51234e290d42
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-coredns
-    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:cd29afa47105e0b49b0f640651c16a73d1190c84fb28aa6feee75d5e89b40b2c
+    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:364d7b5b279791c1a2e914b465274771e5916d0f612c97919a9200a7d8386ddc
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:81fd7584951aaf7bcb86d4038089675e3ec4da3791b2a49fe73ae55f217f4303
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:4af2e26f6f9761c16959f4016a2700240efbf1872a2086c2c69275995be97232
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:81fd7584951aaf7bcb86d4038089675e3ec4da3791b2a49fe73ae55f217f4303
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:4af2e26f6f9761c16959f4016a2700240efbf1872a2086c2c69275995be97232
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3f71495eab9e2f82f74a21df6143c799bfb8a0038aef4e97b766a498bb535c16
+  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:01d23e8ab8df7441074c21c4f87d010be6f121114f8ec5ae1ae1abc08e0403cc

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: release-0.22-96edb1751559
+  newTag: v0.22.1
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
Updates container image SHAs to match Konflux snapshot submariner-0-22-20260212-181224-000.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released Submariner v0.22.1 patch with updated container images for operator, gateway, route agent, global network, and lighthouse components.
  * Updated deployment configurations and manifests to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->