### PR TITLE
Fix wsl_v5 linter warnings reported in golangci-lint 2.9.0

### DIFF
--- a/internal/controllers/submariner/broker_controller_test.go
+++ b/internal/controllers/submariner/broker_controller_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Broker controller", func() {
 
 	BeforeEach(func() {
 		t.BeforeEach()
+
 		brokerObject = &v1alpha1.Broker{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      brokerName,

--- a/pkg/cidr/cidr_test.go
+++ b/pkg/cidr/cidr_test.go
@@ -40,7 +40,6 @@ var _ = Describe("Allocate", func() {
 	When("no CIDRs are already allocated", func() {
 		It("should allocate the next CIDR in sequence", func() {
 			// First
-
 			result, err := cidr.Allocate(&cidrInfo)
 			Expect(err).To(Succeed())
 			Expect(result).To(Equal("169.254.0.0/19"))


### PR DESCRIPTION
Add blank lines before return and go statements to satisfy wsl_v5 whitespace requirements.
