### PR TITLE
Prevent duplicate workflow runs from multiple label events

### DIFF
--- a/.github/workflows/e2e-all-k8s.yml
+++ b/.github/workflows/e2e-all-k8s.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     name: E2E All K8s

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     name: E2E


### PR DESCRIPTION
Add concurrency controls to E2E Full and E2E All K8s workflows to automatically cancel previous runs when multiple labels trigger the same workflow for a PR. This prevents wasted CI resources when PRs are labeled with both ready-to-test and e2e-all-k8s simultaneously.

Fixes: #1948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced E2E test workflows with improved concurrency handling to cancel in-progress runs when new changes are pushed, optimizing resource usage and reducing redundant test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->