### PR TITLE
Upgrade submariner-operator to RHEL 10

### DIFF
--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -1,7 +1,7 @@
 ARG BASE_BRANCH=release-0.23
 ARG SOURCE=/go/src/github.com/submariner-io/submariner-operator
 
-FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi9/go-toolset:latest AS builder
+FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi10/go-toolset:latest AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 ARG BASE_BRANCH
@@ -31,24 +31,24 @@ RUN CGO_ENABLED=1 GOARCH=${TARGETPLATFORM##*/} go build \
     -X github.com/submariner-io/submariner-operator/api/v1alpha1.DefaultSubmarinerOperatorVersion=${BASE_BRANCH} \
     -X github.com/submariner-io/submariner-operator/api/v1alpha1.DefaultSubmarinerVersion=${BASE_BRANCH} \
     -X github.com/submariner-io/submariner-operator/api/v1alpha1.DefaultLighthouseVersion=${BASE_BRANCH} \
-    -X github.com/submariner-io/submariner-operator/pkg/names.GatewayImage=submariner-gateway-rhel9 \
-    -X github.com/submariner-io/submariner-operator/pkg/names.RouteAgentImage=submariner-route-agent-rhel9 \
-    -X github.com/submariner-io/submariner-operator/pkg/names.GlobalnetImage=submariner-globalnet-rhel9 \
-    -X github.com/submariner-io/submariner-operator/pkg/names.ServiceDiscoveryImage=lighthouse-agent-rhel9 \
-    -X github.com/submariner-io/submariner-operator/pkg/names.LighthouseCoreDNSImage=lighthouse-coredns-rhel9 \
-    -X github.com/submariner-io/submariner-operator/pkg/names.OperatorImage=submariner-rhel9-operator \
-    -X github.com/submariner-io/submariner-operator/pkg/names.MetricsProxyImage=nettest-rhel9 \
-    -X github.com/submariner-io/submariner-operator/pkg/names.NettestImage=nettest-rhel9" \
+    -X github.com/submariner-io/submariner-operator/pkg/names.GatewayImage=submariner-gateway-rhel10 \
+    -X github.com/submariner-io/submariner-operator/pkg/names.RouteAgentImage=submariner-route-agent-rhel10 \
+    -X github.com/submariner-io/submariner-operator/pkg/names.GlobalnetImage=submariner-globalnet-rhel10 \
+    -X github.com/submariner-io/submariner-operator/pkg/names.ServiceDiscoveryImage=lighthouse-agent-rhel10 \
+    -X github.com/submariner-io/submariner-operator/pkg/names.LighthouseCoreDNSImage=lighthouse-coredns-rhel10 \
+    -X github.com/submariner-io/submariner-operator/pkg/names.OperatorImage=submariner-rhel10-operator \
+    -X github.com/submariner-io/submariner-operator/pkg/names.MetricsProxyImage=nettest-rhel10 \
+    -X github.com/submariner-io/submariner-operator/pkg/names.NettestImage=nettest-rhel10" \
     -tags "${BUILD_TAGS}" \
     -v -o ${SOURCE}/bin/submariner-operator \
     ${SOURCE}/cmd
 
-FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi9/ubi-minimal:latest
+FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi10:latest
 ARG BASE_BRANCH
 ARG SOURCE
 ARG SOURCE_DATE_EPOCH
 
-RUN adduser -r -l -u 1001 -G root submariner
+RUN useradd -r -l -u 1001 -g root submariner
 
 COPY --from=builder ${SOURCE}/bin/submariner-operator /usr/local/bin/submariner-operator
 
@@ -62,7 +62,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-operator"]
 USER submariner
 
 LABEL com.redhat.component="submariner-operator-container" \
-      name="rhacm2/submariner-rhel9-operator" \
+      name="rhacm2/submariner-rhel10-operator" \
       version="v0.23.0" \
       summary="Submariner Operator" \
       description="The Submariner Operator manages the lifecycle of Submariner components." \
@@ -72,5 +72,5 @@ LABEL com.redhat.component="submariner-operator-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.16::el9" \
+      cpe="cpe:/a:redhat:acm:2.16::el10" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
Changes:
- Update Dockerfile.submariner-operator.konflux to UBI 10 base images
- Update all component image name references from rhel9 to rhel10:
- Update container labels from rhel9 to rhel10
- Update CPE from el9 to el10

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base from RHEL 9 to RHEL 10 and aligned build artifacts and image metadata with RHEL 10.
  * Adjusted runtime user creation and startup behavior to match the new base image.
  * Improved licensing handling and file ownership/permissions for installed binaries and startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->