### PR TITLE
Pass cluster CIDRs to lighthouse agent deployment

### DIFF
--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -252,6 +252,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 							Env: httpproxy.AddEnvVars([]corev1.EnvVar{
 								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
+								{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},
 								{Name: "SUBMARINER_CLUSTERSET_IP_CIDR", Value: cr.Spec.ClustersetIPCIDR},
 								{Name: "SUBMARINER_CLUSTERSET_IP_ENABLED", Value: strconv.FormatBool(cr.Spec.ClustersetIPEnabled)},
 								{Name: "SUBMARINER_DEBUG", Value: strconv.FormatBool(cr.Spec.Debug)},

--- a/internal/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -47,6 +47,18 @@ func testReconciliation() {
 		t.awaitFinalizer()
 	})
 
+	Context("", func() {
+		BeforeEach(func() {
+			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
+		})
+
+		It("should create the lighthouse agent deployment", func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
+			t.assertAgentDeployment(ctx)
+		})
+	})
+
 	When("the openshift DNS config exists", func() {
 		Context("and the lighthouse config isn't present", func() {
 			BeforeEach(func() {

--- a/internal/controllers/servicediscovery/servicediscovery_suite_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_suite_test.go
@@ -263,21 +263,29 @@ func (t *testDriver) testServiceDiscoveryDeleted() {
 	})
 }
 
-func (t *testDriver) assertCoreDNSDeployment(ctx context.Context) {
-	d := t.AssertDeployment(ctx, names.LighthouseCoreDNSComponent)
+func (t *testDriver) assertDeployment(ctx context.Context, deploymentName, imageName string, expectedReplicas int) {
+	d := t.AssertDeployment(ctx, deploymentName)
 
 	Expect(d.Spec.Replicas).ToNot(BeNil())
-	Expect(int(*d.Spec.Replicas)).To(Equal(2))
+	Expect(int(*d.Spec.Replicas)).To(Equal(expectedReplicas))
 
 	Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
 	Expect(d.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("%s/%s:%s",
-		t.serviceDiscovery.Spec.Repository, opnames.LighthouseCoreDNSImage, t.serviceDiscovery.Spec.Version)))
+		t.serviceDiscovery.Spec.Repository, imageName, t.serviceDiscovery.Spec.Version)))
 
 	envMap := test.EnvMapFromVars(d.Spec.Template.Spec.Containers[0].Env)
 
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_CLUSTERID", t.serviceDiscovery.Spec.ClusterID))
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_CLUSTERCIDR", t.serviceDiscovery.Spec.ClusterCIDR))
 	Expect(envMap).To(HaveKeyWithValue("SUBMARINER_NAMESPACE", t.serviceDiscovery.Spec.Namespace))
+}
+
+func (t *testDriver) assertCoreDNSDeployment(ctx context.Context) {
+	t.assertDeployment(ctx, names.LighthouseCoreDNSComponent, opnames.LighthouseCoreDNSImage, 2)
+}
+
+func (t *testDriver) assertAgentDeployment(ctx context.Context) {
+	t.assertDeployment(ctx, names.ServiceDiscoveryComponent, opnames.ServiceDiscoveryImage, 1)
 }
 
 func assertDNSConfigServers(actual, expected *operatorv1.DNS) {


### PR DESCRIPTION
Add SUBMARINER_CLUSTERCIDR environment variable to the lighthouse agent deployment pod spec, matching the implementation used by the lighthouse coredns plugin.

Related to https://github.com/submariner-io/lighthouse/issues/1881



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster CIDR configuration to the service discovery agent

* **Tests**
  * Expanded test coverage to validate agent deployment creation
  * Refactored deployment assertion utilities for improved test maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->