### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/bundle.Dockerfile.konflux
+++ b/bundle.Dockerfile.konflux
@@ -34,7 +34,6 @@ LABEL url="https://github.com/submariner-io/submariner-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL version="v0.24.1"
 
-LABEL com.github.commit="25ca7d600c464d14bd60d0e92b414e5824c8a5ee"
 LABEL com.github.url="https://github.com/submariner-io/submariner-operator.git"
 
 LABEL com.redhat.component="submariner-operator-bundle-container"

--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -71,6 +71,5 @@ LABEL com.redhat.component="submariner-operator-container" \
       io.openshift.tags="submariner,submariner-operator,rhel9" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.17::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label contained a stale hardcoded SHA (bundle) or branch name (component), was never updated, and nothing reads it.

Closes #3871

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
