### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/bundle.Dockerfile.konflux
+++ b/bundle.Dockerfile.konflux
@@ -34,7 +34,6 @@ LABEL url="https://github.com/submariner-io/submariner-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL version="v0.19.4"
 
-LABEL com.github.commit="25ca7d600c464d14bd60d0e92b414e5824c8a5ee"
 LABEL com.github.url="https://github.com/submariner-io/submariner-operator.git"
 
 LABEL com.redhat.component="submariner-operator-bundle-container"

--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -72,6 +72,5 @@ LABEL com.redhat.component="submariner-operator-container" \
       io.openshift.tags="submariner,submariner-operator,rhel9" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.12::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label was never used by any tooling and contained stale values.