### PR TITLE
Update bundle SHAs to latest

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -76,8 +76,8 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:bf688fbafb14d57e521100ae03a0db3ccdf0cd0599b18386a070c2ebc2a598d4
-    createdAt: "2026-04-15 18:03:09"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
+    createdAt: "2026-05-12 11:46:21"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -711,22 +711,22 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:bf688fbafb14d57e521100ae03a0db3ccdf0cd0599b18386a070c2ebc2a598d4
+                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:a9a2ac5d69173ae8f7461dd9275636fe4b2ae195f40f9f8cc157bf244fd7e60f
+                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:555600cd3ad21067a9af4c39efd643ed399e1afc7bf3ccb5ea09caa46270d59b
                 - name: RELATED_IMAGE_submariner-routeagent
-                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:9c201ad110a5bd5dd6caca547aebc5a0b224aa264d58c40de05687f661b933cc
+                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:26dcbee8a483ca73524cc7c43ec531ce0e001e07d0035f77e9355a51a81cf475
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:c5de2e1f38a72ddfab6f300ab87041c73debd4adf10b7608194c1b1fa7fa1141
+                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:144911a1a3aee93e56284d21e6665d3f403f1fe018b5bfa215ade7ea4c2a2de2
                 - name: RELATED_IMAGE_submariner-lighthouse-agent
-                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:6bd83f244a3d2a06151f3917a294326b13234664c60ce2d4b332f9d05c138327
+                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:cc935254131e7ef440b411ea6c6660356308bd961b19f4010c9cc8bb310f830c
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
-                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:15645ebdd6b439d1e601a588441f2d00033023c0ccd25ce4333ace52c3a2795c
+                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:9db81558008c12388ff1332e18d74fd9ea38dbea2636a8ce1b56970a846c7344
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:f096ac9c854bb4b8138d01346df35f2eb2b9f8a2f370f41d54fec4e042bd40cb
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:f096ac9c854bb4b8138d01346df35f2eb2b9f8a2f370f41d54fec4e042bd40cb
-                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:bf688fbafb14d57e521100ae03a0db3ccdf0cd0599b18386a070c2ebc2a598d4
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
+                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -879,19 +879,19 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:bf688fbafb14d57e521100ae03a0db3ccdf0cd0599b18386a070c2ebc2a598d4
+  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
     name: submariner-operator
-  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:a9a2ac5d69173ae8f7461dd9275636fe4b2ae195f40f9f8cc157bf244fd7e60f
+  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:555600cd3ad21067a9af4c39efd643ed399e1afc7bf3ccb5ea09caa46270d59b
     name: submariner-gateway
-  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:9c201ad110a5bd5dd6caca547aebc5a0b224aa264d58c40de05687f661b933cc
+  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:26dcbee8a483ca73524cc7c43ec531ce0e001e07d0035f77e9355a51a81cf475
     name: submariner-routeagent
-  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:c5de2e1f38a72ddfab6f300ab87041c73debd4adf10b7608194c1b1fa7fa1141
+  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:144911a1a3aee93e56284d21e6665d3f403f1fe018b5bfa215ade7ea4c2a2de2
     name: submariner-globalnet
-  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:6bd83f244a3d2a06151f3917a294326b13234664c60ce2d4b332f9d05c138327
+  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:cc935254131e7ef440b411ea6c6660356308bd961b19f4010c9cc8bb310f830c
     name: submariner-lighthouse-agent
-  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:15645ebdd6b439d1e601a588441f2d00033023c0ccd25ce4333ace52c3a2795c
+  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:9db81558008c12388ff1332e18d74fd9ea38dbea2636a8ce1b56970a846c7344
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:f096ac9c854bb4b8138d01346df35f2eb2b9f8a2f370f41d54fec4e042bd40cb
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
     name: ""
   selector:
     matchLabels:

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -9,6 +9,6 @@ patches:
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-04-15 18:03:09"
+  createdAt: "2026-05-12 11:46:21"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -3,42 +3,42 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-operator
-    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:bf688fbafb14d57e521100ae03a0db3ccdf0cd0599b18386a070c2ebc2a598d4
+    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-gateway
-    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:a9a2ac5d69173ae8f7461dd9275636fe4b2ae195f40f9f8cc157bf244fd7e60f
+    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:555600cd3ad21067a9af4c39efd643ed399e1afc7bf3ccb5ea09caa46270d59b
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-routeagent
-    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:9c201ad110a5bd5dd6caca547aebc5a0b224aa264d58c40de05687f661b933cc
+    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:26dcbee8a483ca73524cc7c43ec531ce0e001e07d0035f77e9355a51a81cf475
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-globalnet
-    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:c5de2e1f38a72ddfab6f300ab87041c73debd4adf10b7608194c1b1fa7fa1141
+    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:144911a1a3aee93e56284d21e6665d3f403f1fe018b5bfa215ade7ea4c2a2de2
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-agent
-    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:6bd83f244a3d2a06151f3917a294326b13234664c60ce2d4b332f9d05c138327
+    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:cc935254131e7ef440b411ea6c6660356308bd961b19f4010c9cc8bb310f830c
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-coredns
-    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:15645ebdd6b439d1e601a588441f2d00033023c0ccd25ce4333ace52c3a2795c
+    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:9db81558008c12388ff1332e18d74fd9ea38dbea2636a8ce1b56970a846c7344
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:f096ac9c854bb4b8138d01346df35f2eb2b9f8a2f370f41d54fec4e042bd40cb
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:f096ac9c854bb4b8138d01346df35f2eb2b9f8a2f370f41d54fec4e042bd40cb
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:bf688fbafb14d57e521100ae03a0db3ccdf0cd0599b18386a070c2ebc2a598d4
+  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350


### PR DESCRIPTION
Updates container image SHAs to match Konflux snapshot.

Snapshot: submariner-0-24-20260512-105236-000

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Submariner operator to version 0.24.0 with refreshed container images.
  * Synchronized operator and component image versions including gateway, route agent, globalnet, and lighthouse services.
  * Updated deployment metadata and configuration to reflect the latest image releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner-operator/pull/4062)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->