### PR TITLE
Fix CVEs in release-0.21

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -30,3 +30,21 @@ ignore:
   - vulnerability: GHSA-hfvc-g4fc-pqhx
     package:
       name: go.opentelemetry.io/otel/sdk
+
+  # No fix available
+  - vulnerability: GHSA-rg2x-37c3-w2rh
+    fix-state: not-fixed
+    package:
+      name: github.com/docker/docker
+
+  # No fix available
+  - vulnerability: GHSA-x86f-5xw2-fm2r
+    fix-state: not-fixed
+    package:
+      name: github.com/docker/docker
+
+  # No fix available
+  - vulnerability: GHSA-vp62-88p7-qqf5
+    fix-state: not-fixed
+    package:
+      name: github.com/docker/docker

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -168,8 +168,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=


### PR DESCRIPTION
## Summary

- Bump go-git/go-git/v5 to v5.19.1 in tools (GHSA-crhj-59gh-8x96, GHSA-m7cr-m3pv-hgrp)
- Ignore 3 docker/docker CVEs with `fix-state: not-fixed` (auto-expires when fix is published upstream, see https://github.com/moby/moby/issues/52337)

### Remaining: stdlib (11 CVEs)

Build image has Go 1.25.9, fix needs 1.25.10. Requires rebuilding shipyard-dapper-base (Fedora 43 hasn't packaged 1.25.10 yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration with new exception rules for known vulnerabilities
  * Updated an indirect Go module dependency to the latest patch version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner-operator/pull/4075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->