### PR TITLE
Update bundle component SHAs for 0.21.3

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "release-0.21-2d4d8f64ff11"
+            "version": "0.21.3"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "release-0.21-2d4d8f64ff11"
+            "version": "0.21.3"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:2e83a86c99d39a806b974bd81bd193fa523a4438ddc748f9009e702cf94b4902
-    createdAt: "2026-02-05 13:28:42"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:4a9e4a9ebd8c0ded54da68e18c7a0c9a68e75e1e21743d4443cb5ae2901b0060
+    createdAt: "2026-05-31 12:00:55"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -93,7 +93,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/submariner-io/submariner-operator
     support: Submariner
-  name: submariner.v0.21.2
+  name: submariner.v0.21.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -681,22 +681,22 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:2e83a86c99d39a806b974bd81bd193fa523a4438ddc748f9009e702cf94b4902
+                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:4a9e4a9ebd8c0ded54da68e18c7a0c9a68e75e1e21743d4443cb5ae2901b0060
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:86eb47f7db45c51fc334e12a95ccbcc955d36cff55d302e9b835df0198881ed6
+                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:da50c0f4d3ecf250757d51c7ee8a415f55769f92e02ca429103cdb94c34295cf
                 - name: RELATED_IMAGE_submariner-routeagent
-                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:9d57f677f46236a94987223783d88a61101e8eb44bdb72420c1480fa8f39fd67
+                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:0c03e404e2f0f29a49c162e774a15a4e42ff6bf0ec88c647643715f856834fdc
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:f8223f48bca9166c8be441158c8eeffbcf6f4dff55b3bb47c05edfcc001569e8
+                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:d19d0ca6771cd43f61077c11e8c0eaaa4f60fcea6c9839bc8d50bcc01e6f7cdf
                 - name: RELATED_IMAGE_submariner-lighthouse-agent
-                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:b3d220c9f8dd7ce3f4a2a01365ead67d8306a677e4ed292ad075ae81b90939dd
+                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:9238e38fa6418129d207e354ae40d14c7f5c3d489b4f13fb61d8a1f2f7d0c31c
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
-                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:37fb020f4e261f01205d9937375958f9ae679dcbae6d6f44a6a3b037ca37daf5
+                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:5d0cdac8115787153174397171e986fee2718b0af4e4fbee3468c17b4adb5579
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:216411b2b30bcbd993553d1e6e801aee2a8d059ff77a2daf34d7f89e2897a87a
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:e3a7e0f5838ea909fefa9ce2a772bee47264fd1eeeba070014a5f9c8607f8f83
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:216411b2b30bcbd993553d1e6e801aee2a8d059ff77a2daf34d7f89e2897a87a
-                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:2e83a86c99d39a806b974bd81bd193fa523a4438ddc748f9009e702cf94b4902
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:e3a7e0f5838ea909fefa9ce2a772bee47264fd1eeeba070014a5f9c8607f8f83
+                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:4a9e4a9ebd8c0ded54da68e18c7a0c9a68e75e1e21743d4443cb5ae2901b0060
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -849,21 +849,21 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:2e83a86c99d39a806b974bd81bd193fa523a4438ddc748f9009e702cf94b4902
+  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:4a9e4a9ebd8c0ded54da68e18c7a0c9a68e75e1e21743d4443cb5ae2901b0060
     name: submariner-operator
-  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:86eb47f7db45c51fc334e12a95ccbcc955d36cff55d302e9b835df0198881ed6
+  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:da50c0f4d3ecf250757d51c7ee8a415f55769f92e02ca429103cdb94c34295cf
     name: submariner-gateway
-  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:9d57f677f46236a94987223783d88a61101e8eb44bdb72420c1480fa8f39fd67
+  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:0c03e404e2f0f29a49c162e774a15a4e42ff6bf0ec88c647643715f856834fdc
     name: submariner-routeagent
-  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:f8223f48bca9166c8be441158c8eeffbcf6f4dff55b3bb47c05edfcc001569e8
+  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:d19d0ca6771cd43f61077c11e8c0eaaa4f60fcea6c9839bc8d50bcc01e6f7cdf
     name: submariner-globalnet
-  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:b3d220c9f8dd7ce3f4a2a01365ead67d8306a677e4ed292ad075ae81b90939dd
+  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:9238e38fa6418129d207e354ae40d14c7f5c3d489b4f13fb61d8a1f2f7d0c31c
     name: submariner-lighthouse-agent
-  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:37fb020f4e261f01205d9937375958f9ae679dcbae6d6f44a6a3b037ca37daf5
+  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:5d0cdac8115787153174397171e986fee2718b0af4e4fbee3468c17b4adb5579
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:216411b2b30bcbd993553d1e6e801aee2a8d059ff77a2daf34d7f89e2897a87a
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:e3a7e0f5838ea909fefa9ce2a772bee47264fd1eeeba070014a5f9c8607f8f83
     name: submariner-nettest
   selector:
     matchLabels:
       control-plane: submariner-operator
-  version: 0.21.2
+  version: 0.21.3

--- a/bundle/manifests/submariner.io_brokers.yaml
+++ b/bundle/manifests/submariner.io_brokers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: brokers.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_servicediscoveries.yaml
+++ b/bundle/manifests/submariner.io_servicediscoveries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: servicediscoveries.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: submariners.submariner.io
 spec:

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: submariners.submariner.io
 spec:
   group: submariner.io

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -3,42 +3,42 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-operator
-    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:2e83a86c99d39a806b974bd81bd193fa523a4438ddc748f9009e702cf94b4902
+    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:4a9e4a9ebd8c0ded54da68e18c7a0c9a68e75e1e21743d4443cb5ae2901b0060
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-gateway
-    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:86eb47f7db45c51fc334e12a95ccbcc955d36cff55d302e9b835df0198881ed6
+    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:da50c0f4d3ecf250757d51c7ee8a415f55769f92e02ca429103cdb94c34295cf
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-routeagent
-    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:9d57f677f46236a94987223783d88a61101e8eb44bdb72420c1480fa8f39fd67
+    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:0c03e404e2f0f29a49c162e774a15a4e42ff6bf0ec88c647643715f856834fdc
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-globalnet
-    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:f8223f48bca9166c8be441158c8eeffbcf6f4dff55b3bb47c05edfcc001569e8
+    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:d19d0ca6771cd43f61077c11e8c0eaaa4f60fcea6c9839bc8d50bcc01e6f7cdf
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-agent
-    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:b3d220c9f8dd7ce3f4a2a01365ead67d8306a677e4ed292ad075ae81b90939dd
+    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:9238e38fa6418129d207e354ae40d14c7f5c3d489b4f13fb61d8a1f2f7d0c31c
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-coredns
-    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:37fb020f4e261f01205d9937375958f9ae679dcbae6d6f44a6a3b037ca37daf5
+    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:5d0cdac8115787153174397171e986fee2718b0af4e4fbee3468c17b4adb5579
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:216411b2b30bcbd993553d1e6e801aee2a8d059ff77a2daf34d7f89e2897a87a
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:e3a7e0f5838ea909fefa9ce2a772bee47264fd1eeeba070014a5f9c8607f8f83
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:216411b2b30bcbd993553d1e6e801aee2a8d059ff77a2daf34d7f89e2897a87a
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:e3a7e0f5838ea909fefa9ce2a772bee47264fd1eeeba070014a5f9c8607f8f83
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:2e83a86c99d39a806b974bd81bd193fa523a4438ddc748f9009e702cf94b4902
+  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:4a9e4a9ebd8c0ded54da68e18c7a0c9a68e75e1e21743d4443cb5ae2901b0060

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: release-0.21-2d4d8f64ff11
+  newTag: 0.21.3
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
Update 7 component image SHAs from Konflux snapshot
submariner-0-21-20260531-152915-000. Regenerate bundle with make bundle.

All SHAs verified against snapshot. EC passing with 0 violations on latest push snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Submariner operator version to 0.21.3
  * Updated container image digests for operator, gateway, and related Submariner components
  * Updated build tooling dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->