### PR TITLE
Update bundle to 0.20.3

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "release-0.20-dfca5c1e80f4"
+            "version": "0.20.3"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "release-0.20-dfca5c1e80f4"
+            "version": "0.20.3"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
-    createdAt: "2026-02-05 13:34:06"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:48d246bc258a533d5e2637655c9f7f6dfb140752824e60bc47f7263f713b51e4
+    createdAt: "2026-07-02 09:44:50"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -93,7 +93,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/submariner-io/submariner-operator
     support: Submariner
-  name: submariner.v0.20.2
+  name: submariner.v0.20.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -684,22 +684,22 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
+                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:48d246bc258a533d5e2637655c9f7f6dfb140752824e60bc47f7263f713b51e4
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:0eef6521c96b29722076c1e220770124c8ed214379abc4654d9567cff8b52d04
+                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:d968ae5d719c9c17d842bba5b2ab0e233369acda02bf88a5e02a02607ac8810d
                 - name: RELATED_IMAGE_submariner-routeagent
-                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:ed521b241da60efabfe2e2b80c51639d1a82a43945945879decbfb192bbc6d23
+                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:a236e5bf851222387e1be10b39be575aede12724f6268d5439e124dd5387be2d
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:4a4ac198e9d0f4a4aaed8f0ec0e1d79bd8fa712b671ee697f7ff9d5616a02d84
+                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:0ffe05f3f98e991ea847b5e5def2130c75b387988a1fb45116b67c00a09c3f63
                 - name: RELATED_IMAGE_submariner-lighthouse-agent
-                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:fd6c46b4a0570b5e7b6457c465e5a1b843ba6f9c209c1856dbebfee1068e35ea
+                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:06246189f2c4aad0bb2dbadf64903bbbb727e5bd45308b654aea9db60e53cd80
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
-                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:70d563a6e6526b9a146a2973210b2abdae09d5acab403fa3f0b465ed5e3c9b11
+                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:c8538712781a26d8faa81ce223f9fa9344eb17b64ed63dcd2d565d336cec0939
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:77e0da2db6d5bb2831e6c51214e08685c9f7f3b8b1e6ac53b4fd1418644ad6a1
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:9c9e0ec55c7a02fcad965795652e3077ab219aa7153e681e726d6c4b870ef866
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:77e0da2db6d5bb2831e6c51214e08685c9f7f3b8b1e6ac53b4fd1418644ad6a1
-                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:9c9e0ec55c7a02fcad965795652e3077ab219aa7153e681e726d6c4b870ef866
+                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:48d246bc258a533d5e2637655c9f7f6dfb140752824e60bc47f7263f713b51e4
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -860,21 +860,21 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
+  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:48d246bc258a533d5e2637655c9f7f6dfb140752824e60bc47f7263f713b51e4
     name: submariner-operator
-  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:0eef6521c96b29722076c1e220770124c8ed214379abc4654d9567cff8b52d04
+  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:d968ae5d719c9c17d842bba5b2ab0e233369acda02bf88a5e02a02607ac8810d
     name: submariner-gateway
-  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:ed521b241da60efabfe2e2b80c51639d1a82a43945945879decbfb192bbc6d23
+  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:a236e5bf851222387e1be10b39be575aede12724f6268d5439e124dd5387be2d
     name: submariner-routeagent
-  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:4a4ac198e9d0f4a4aaed8f0ec0e1d79bd8fa712b671ee697f7ff9d5616a02d84
+  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:0ffe05f3f98e991ea847b5e5def2130c75b387988a1fb45116b67c00a09c3f63
     name: submariner-globalnet
-  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:fd6c46b4a0570b5e7b6457c465e5a1b843ba6f9c209c1856dbebfee1068e35ea
+  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:06246189f2c4aad0bb2dbadf64903bbbb727e5bd45308b654aea9db60e53cd80
     name: submariner-lighthouse-agent
-  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:70d563a6e6526b9a146a2973210b2abdae09d5acab403fa3f0b465ed5e3c9b11
+  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:c8538712781a26d8faa81ce223f9fa9344eb17b64ed63dcd2d565d336cec0939
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:77e0da2db6d5bb2831e6c51214e08685c9f7f3b8b1e6ac53b4fd1418644ad6a1
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:9c9e0ec55c7a02fcad965795652e3077ab219aa7153e681e726d6c4b870ef866
     name: submariner-nettest
   selector:
     matchLabels:
       control-plane: submariner-operator
-  version: 0.20.2
+  version: 0.20.3

--- a/bundle/manifests/submariner.io_brokers.yaml
+++ b/bundle/manifests/submariner.io_brokers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: brokers.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_servicediscoveries.yaml
+++ b/bundle/manifests/submariner.io_servicediscoveries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: servicediscoveries.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: submariners.submariner.io
 spec:

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -5,11 +5,11 @@ patches:
   target:
     group: operators.coreos.com
     kind: ClusterServiceVersion
-    name: submariner.v0.20.2
+    name: submariner.v0.20.3
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-02-05 13:34:06"
+  createdAt: "2026-07-02 09:44:50"
   features.operators.openshift.io/disconnected: "true"
   features.operators.openshift.io/fips-compliant: "true"
   features.operators.openshift.io/proxy-aware: "false"

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -3,42 +3,42 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-operator
-    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
+    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:48d246bc258a533d5e2637655c9f7f6dfb140752824e60bc47f7263f713b51e4
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-gateway
-    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:0eef6521c96b29722076c1e220770124c8ed214379abc4654d9567cff8b52d04
+    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:d968ae5d719c9c17d842bba5b2ab0e233369acda02bf88a5e02a02607ac8810d
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-routeagent
-    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:ed521b241da60efabfe2e2b80c51639d1a82a43945945879decbfb192bbc6d23
+    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:a236e5bf851222387e1be10b39be575aede12724f6268d5439e124dd5387be2d
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-globalnet
-    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:4a4ac198e9d0f4a4aaed8f0ec0e1d79bd8fa712b671ee697f7ff9d5616a02d84
+    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:0ffe05f3f98e991ea847b5e5def2130c75b387988a1fb45116b67c00a09c3f63
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-agent
-    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:fd6c46b4a0570b5e7b6457c465e5a1b843ba6f9c209c1856dbebfee1068e35ea
+    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:06246189f2c4aad0bb2dbadf64903bbbb727e5bd45308b654aea9db60e53cd80
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-coredns
-    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:70d563a6e6526b9a146a2973210b2abdae09d5acab403fa3f0b465ed5e3c9b11
+    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:c8538712781a26d8faa81ce223f9fa9344eb17b64ed63dcd2d565d336cec0939
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:77e0da2db6d5bb2831e6c51214e08685c9f7f3b8b1e6ac53b4fd1418644ad6a1
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:9c9e0ec55c7a02fcad965795652e3077ab219aa7153e681e726d6c4b870ef866
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:77e0da2db6d5bb2831e6c51214e08685c9f7f3b8b1e6ac53b4fd1418644ad6a1
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:9c9e0ec55c7a02fcad965795652e3077ab219aa7153e681e726d6c4b870ef866
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:8ea02aba8f9dd901f1f0ccff97ec8d157bebe5a90a6c924affe5e01cf3454e72
+  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:48d246bc258a533d5e2637655c9f7f6dfb140752824e60bc47f7263f713b51e4

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: release-0.20-dfca5c1e80f4
+  newTag: 0.20.3
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
Update component image SHAs from Konflux snapshot
submariner-0-20-20260701-223302-000 and bump bundle version labels to 0.20.3.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the release to **0.20.3** across manifests and bundle metadata.
  * Refreshed container image references for the operator and related components.

* **Bug Fixes**
  * Brought several deployment and related-image references in sync with the new release version.
  * Updated CRD metadata annotations to the latest supported generator version.

* **Chores**
  * Refreshed timestamps and bundle configuration to match the new release packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->