### PR TITLE
Add Amazon VPC CNI network discovery

### DIFF
--- a/config/rbac/submariner-route-agent/cluster_role.yaml
+++ b/config/rbac/submariner-route-agent/cluster_role.yaml
@@ -14,6 +14,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/pkg/discovery/network/awsvpc.go
+++ b/pkg/discovery/network/awsvpc.go
@@ -1,0 +1,96 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	awsNodeName = "aws-node"
+	// amazonVPCCNI matches github.com/submariner-io/submariner/pkg/cni.AmazonVPCCNI.
+	// Inline until that constant is in the operator's released submariner dependency.
+	amazonVPCCNI = "amazon-vpc-cni"
+)
+
+//nolint:nilnil // Intentional as the purpose is to discover.
+func discoverAmazonVPCNetwork(ctx context.Context, client controllerClient.Client) (*ClusterNetwork, error) {
+	found, err := amazonVPCCNIDaemonSetExists(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		found, err = amazonVPCCNIPodExists(ctx, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !found {
+		return nil, nil
+	}
+
+	clusterNetwork, err := discoverNetwork(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	if clusterNetwork != nil {
+		clusterNetwork.NetworkPlugin = amazonVPCCNI
+		return clusterNetwork, nil
+	}
+
+	return nil, nil
+}
+
+func amazonVPCCNIDaemonSetExists(ctx context.Context, client controllerClient.Client) (bool, error) {
+	dsList := &appsv1.DaemonSetList{}
+
+	err := client.List(ctx, dsList, controllerClient.InNamespace(metav1.NamespaceSystem))
+	if err != nil {
+		return false, errors.Wrapf(err, "error listing DaemonSets")
+	}
+
+	for i := range dsList.Items {
+		if dsList.Items[i].Name == awsNodeName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func amazonVPCCNIPodExists(ctx context.Context, client controllerClient.Client) (bool, error) {
+	podList := &corev1.PodList{}
+
+	err := client.List(ctx, podList, controllerClient.InNamespace(metav1.NamespaceSystem),
+		controllerClient.MatchingLabels{"k8s-app": awsNodeName})
+	if err != nil {
+		return false, errors.Wrapf(err, "error listing aws-node pods")
+	}
+
+	return len(podList.Items) > 0, nil
+}

--- a/pkg/discovery/network/awsvpc_test.go
+++ b/pkg/discovery/network/awsvpc_test.go
@@ -1,0 +1,70 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/cni"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Amazon VPC CNI Network", func() {
+	awsNodeDaemonSet := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-node",
+			Namespace: metav1.NamespaceSystem,
+		},
+	}
+
+	awsNodePod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-node-xyz",
+			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{"k8s-app": "aws-node"},
+		},
+	}
+
+	When("the aws-node DaemonSet exists", func() {
+		It("should return a ClusterNetwork with the amazon-vpc-cni plugin", func(ctx SpecContext) {
+			clusterNet := testDiscoverNetworkSuccess(ctx, &awsNodeDaemonSet, newServiceCIDR(testServiceCIDR),
+				fakeKubeAPIServerPod(), fakeKubeControllerManagerPod())
+			Expect(clusterNet.NetworkPlugin).To(Equal("amazon-vpc-cni"))
+			Expect(clusterNet.PodCIDRs).To(Equal([]string{testPodCIDR}))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
+		})
+	})
+
+	When("only aws-node pods exist", func() {
+		It("should return a ClusterNetwork with the amazon-vpc-cni plugin", func(ctx SpecContext) {
+			clusterNet := testDiscoverNetworkSuccess(ctx, &awsNodePod, newServiceCIDR(testServiceCIDR))
+			Expect(clusterNet.NetworkPlugin).To(Equal("amazon-vpc-cni"))
+			Expect(clusterNet.ServiceCIDRs).To(Equal([]string{testServiceCIDR}))
+		})
+	})
+
+	When("aws-node is absent", func() {
+		It("should fall back to the generic plugin", func(ctx SpecContext) {
+			clusterNet := testDiscoverNetworkSuccess(ctx, newServiceCIDR(testServiceCIDR))
+			Expect(clusterNet.NetworkPlugin).To(Equal(cni.Generic))
+		})
+	})
+})

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -116,8 +116,10 @@ var discoverFunctions = []pluginDiscoveryFn{
 	discoverOvnKubernetesNetwork,
 	discoverWeaveNetwork,
 	discoverCanalFlannelNetwork,
-	discoverCalicoNetwork,
+	// Amazon VPC before Calico: discovery stops at the first match, and Calico
+	// probes can false-positive on EKS clusters that also run aws-node.
 	discoverAmazonVPCNetwork,
+	discoverCalicoNetwork,
 	discoverFlannelNetwork,
 	discoverKindNetwork,
 }

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -116,8 +116,10 @@ var discoverFunctions = []pluginDiscoveryFn{
 	discoverOvnKubernetesNetwork,
 	discoverWeaveNetwork,
 	discoverCanalFlannelNetwork,
-	// Amazon VPC before Calico: discovery stops at the first match, and Calico
-	// probes can false-positive on EKS clusters that also run aws-node.
+	// Amazon VPC before Calico: discovery stops at the first match. On EKS it is
+	// common to run amazon-vpc-cni for pod networking together with Calico only
+	// for NetworkPolicy (aws-node plus calico-node / calico-config). In that
+	// setup Calico probes would otherwise win and mis-label the CNI.
 	discoverAmazonVPCNetwork,
 	discoverCalicoNetwork,
 	discoverFlannelNetwork,

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -117,6 +117,7 @@ var discoverFunctions = []pluginDiscoveryFn{
 	discoverWeaveNetwork,
 	discoverCanalFlannelNetwork,
 	discoverCalicoNetwork,
+	discoverAmazonVPCNetwork,
 	discoverFlannelNetwork,
 	discoverKindNetwork,
 }


### PR DESCRIPTION
## What this PR does / why we need it

Detects **Amazon VPC CNI** (`amazon-vpc-cni`) used by EKS (via `aws-node` DaemonSet/pods) so Submariner no longer falls back to `generic` on EKS.

Also grants the route-agent RBAC needed to **watch pods** (required by the companion route-agent handler).

## Related issues

- Related to https://github.com/submariner-io/submariner/issues/3697 (AWS CNI PBR / routing tables)
- Related to https://github.com/submariner-io/submariner/issues/3632 (EKS join / network discovery problems)

## Related PRs

- Companion: submariner `feat/aws-vpc-cni-handler`
- Companion: subctl diagnose recognition of `amazon-vpc-cni`

## Checklist

- [ ] Discovery tests
- [ ] RBAC manifests updated

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Amazon VPC CNI network detection to improve network discovery and select the correct network plugin.
  * Discovery now checks for AWS VPC CNI via existing Kubernetes resources and falls back to the generic plugin when absent.
* **Permissions**
  * Expanded route-agent permissions to watch pods, services, configmaps, and endpoints.
* **Tests**
  * Added coverage for Amazon VPC CNI discovery scenarios (DaemonSet present, pods-only, and absent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->