### PR TITLE
Add CoreDNS custom ConfigMap key for Corefile merge

### DIFF
--- a/api/v1alpha1/servicediscovery_types.go
+++ b/api/v1alpha1/servicediscovery_types.go
@@ -105,6 +105,11 @@ type CoreDNSCustomConfig struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CoreDNS Custom Config Namespace"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Namespace string `json:"namespace,omitempty"`
+
+	// ConfigMap data key that holds the lighthouse forwarding config.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CoreDNS Custom Config Key"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Key string `json:"key,omitempty"`
 }
 
 func (sd *ServiceDiscovery) UnmarshalJSON(data []byte) error {

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -160,6 +160,11 @@ spec:
         path: coreDNSCustomConfig.namespace
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ConfigMap data key that holds the lighthouse forwarding config.
+        displayName: CoreDNS Custom Config Key
+        path: coreDNSCustomConfig.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
     - description: Submariner is the Schema for the submariners API.
       displayName: Submariner
@@ -302,6 +307,11 @@ spec:
       - description: Namespace of the custom CoreDNS configmap.
         displayName: CoreDNS Custom Config Namespace
         path: coreDNSCustomConfig.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ConfigMap data key that holds the lighthouse forwarding config.
+        displayName: CoreDNS Custom Config Key
+        path: coreDNSCustomConfig.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: List of domains to use for multi-cluster service discovery.

--- a/bundle/manifests/submariner.io_servicediscoveries.yaml
+++ b/bundle/manifests/submariner.io_servicediscoveries.yaml
@@ -64,6 +64,9 @@ spec:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
                     type: string
+                  key:
+                    description: ConfigMap data key that holds the lighthouse forwarding config.
+                    type: string
                   namespace:
                     description: Namespace of the custom CoreDNS configmap.
                     type: string

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -128,6 +128,9 @@ spec:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
                     type: string
+                  key:
+                    description: ConfigMap data key that holds the lighthouse forwarding config.
+                    type: string
                   namespace:
                     description: Namespace of the custom CoreDNS configmap.
                     type: string

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -64,6 +64,9 @@ spec:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
                     type: string
+                  key:
+                    description: ConfigMap data key that holds the lighthouse forwarding config.
+                    type: string
                   namespace:
                     description: Namespace of the custom CoreDNS configmap.
                     type: string

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -128,6 +128,9 @@ spec:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
                     type: string
+                  key:
+                    description: ConfigMap data key that holds the lighthouse forwarding config.
+                    type: string
                   namespace:
                     description: Namespace of the custom CoreDNS configmap.
                     type: string

--- a/config/manifests/bases/submariner.clusterserviceversion.yaml
+++ b/config/manifests/bases/submariner.clusterserviceversion.yaml
@@ -89,6 +89,11 @@ spec:
         path: coreDNSCustomConfig.namespace
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ConfigMap data key that holds the lighthouse forwarding config.
+        displayName: CoreDNS Custom Config Key
+        path: coreDNSCustomConfig.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
     - description: Submariner is the Schema for the submariners API.
       displayName: Submariner
@@ -231,6 +236,11 @@ spec:
       - description: Namespace of the custom CoreDNS configmap.
         displayName: CoreDNS Custom Config Namespace
         path: coreDNSCustomConfig.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ConfigMap data key that holds the lighthouse forwarding config.
+        displayName: CoreDNS Custom Config Key
+        path: coreDNSCustomConfig.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: List of domains to use for multi-cluster service discovery.

--- a/deploy/crds/submariner.io_servicediscoveries.yaml
+++ b/deploy/crds/submariner.io_servicediscoveries.yaml
@@ -64,6 +64,9 @@ spec:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
                     type: string
+                  key:
+                    description: ConfigMap data key that holds the lighthouse forwarding config.
+                    type: string
                   namespace:
                     description: Namespace of the custom CoreDNS configmap.
                     type: string

--- a/deploy/crds/submariner.io_submariners.yaml
+++ b/deploy/crds/submariner.io_submariners.yaml
@@ -128,6 +128,9 @@ spec:
                   configMapName:
                     description: Name of the custom CoreDNS configmap.
                     type: string
+                  key:
+                    description: ConfigMap data key that holds the lighthouse forwarding config.
+                    type: string
                   namespace:
                     description: Namespace of the custom CoreDNS configmap.
                     type: string

--- a/internal/controllers/servicediscovery/cleanup.go
+++ b/internal/controllers/servicediscovery/cleanup.go
@@ -51,7 +51,7 @@ func (r *Reconciler) doCleanup(ctx context.Context, instance *operatorv1alpha1.S
 	var err error
 
 	if instance.Spec.CoreDNSCustomConfig != nil && instance.Spec.CoreDNSCustomConfig.ConfigMapName != "" {
-		err = r.removeLighthouseConfigFromCustomDNSConfigMap(ctx, instance.Spec.CoreDNSCustomConfig)
+		err = r.removeLighthouseConfigFromCustomDNSConfigMap(ctx, instance)
 	} else {
 		err = r.updateLighthouseConfigInConfigMap(ctx, instance, DefaultCoreDNSNamespace, CoreDNSName, "")
 	}
@@ -107,15 +107,25 @@ func (r *Reconciler) removeFinalizer(ctx context.Context, instance *operatorv1al
 }
 
 func (r *Reconciler) removeLighthouseConfigFromCustomDNSConfigMap(ctx context.Context,
-	config *operatorv1alpha1.CoreDNSCustomConfig,
+	instance *operatorv1alpha1.ServiceDiscovery,
 ) error {
+	config := instance.Spec.CoreDNSCustomConfig
 	configMap := newCoreDNSCustomConfigMap(config)
+	configKey := getCustomCoreDNSConfigKey(config)
 
-	log.Info("Removing lighthouse config from custom DNS ConfigMap", "Name", configMap.Name, "Namespace", configMap.Namespace)
+	log.Info("Removing lighthouse config from custom DNS ConfigMap", "Name", configMap.Name, "Namespace", configMap.Namespace,
+		"Key", configKey)
 
 	err := util.Update[*corev1.ConfigMap](ctx, resource.ForControllerClient(r.GeneralClient, configMap.Namespace, configMap), configMap,
 		func(existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-			delete(existing.Data, "lighthouse.server")
+			if configKey == Corefile {
+				// Keep user-managed content; only strip lighthouse markers and managed domain blocks.
+				existing.Data[Corefile] = mergeLighthouseIntoCorefile(existing.Data[Corefile], buildDomains(instance), "")
+				return existing, nil
+			}
+
+			delete(existing.Data, configKey)
+
 			return existing, nil
 		})
 

--- a/internal/controllers/servicediscovery/coredns_merge_internal_test.go
+++ b/internal/controllers/servicediscovery/coredns_merge_internal_test.go
@@ -1,0 +1,55 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicediscovery
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMergeLighthouseIntoCorefile(t *testing.T) {
+	g := NewWithT(t)
+
+	existing := `# User config
+example.com:53 {
+    forward . 1.2.3.4
+}
+clusterset.local:53 {
+    forward . 10.0.0.1
+}
+`
+
+	merged := mergeLighthouseIntoCorefile(existing, []string{"clusterset.local"}, "10.96.1.2")
+	g.Expect(merged).To(ContainSubstring("#lighthouse-start"))
+	g.Expect(merged).To(ContainSubstring("forward . 10.96.1.2"))
+	g.Expect(merged).To(ContainSubstring("example.com:53"))
+	g.Expect(merged).NotTo(ContainSubstring("10.0.0.1"))
+	g.Expect(merged).NotTo(ContainSubstring("forward . 10.0.0.1"))
+
+	updated := mergeLighthouseIntoCorefile(merged, []string{"clusterset.local"}, "10.96.9.9")
+	g.Expect(updated).To(ContainSubstring("forward . 10.96.9.9"))
+	g.Expect(updated).NotTo(ContainSubstring("10.96.1.2"))
+	g.Expect(updated).To(ContainSubstring("example.com:53"))
+
+	cleaned := mergeLighthouseIntoCorefile(updated, []string{"clusterset.local"}, "")
+	g.Expect(cleaned).NotTo(ContainSubstring("lighthouse-start"))
+	g.Expect(cleaned).NotTo(ContainSubstring("clusterset.local"))
+	g.Expect(cleaned).To(ContainSubstring("example.com:53"))
+}

--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -73,6 +73,9 @@ const (
 	MicroshiftDNSNamespace        = "openshift-dns"
 	MicroshiftDNSConfigMap        = "dns-default"
 	coreDNSDefaultPort            = "53"
+	defaultCoreDNSCustomConfigKey = "lighthouse.server"
+	lighthouseStartMarker         = "lighthouse-start"
+	lighthouseEndMarker           = "lighthouse-end"
 )
 
 // Reconciler reconciles a ServiceDiscovery object.
@@ -429,6 +432,7 @@ func (r *Reconciler) updateDNSCustomConfigMap(ctx context.Context, cr *submarine
 	reqLogger logr.Logger,
 ) error {
 	configMap := newCoreDNSCustomConfigMap(cr.Spec.CoreDNSCustomConfig)
+	configKey := getCustomCoreDNSConfigKey(cr.Spec.CoreDNSCustomConfig)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.GeneralClient, configMap, func() error {
 		lighthouseDNSService := &corev1.Service{}
@@ -441,27 +445,43 @@ func (r *Reconciler) updateDNSCustomConfigMap(ctx context.Context, cr *submarine
 		}
 
 		if configMap.Data == nil {
-			reqLogger.Info("Initializing configMap.Data in " + configMap.Name)
+			reqLogger.Info("Initializing configMap.Data", "Name", configMap.Name)
 			configMap.Data = make(map[string]string)
 		}
 
-		if _, ok := configMap.Data["lighthouse.server"]; ok {
-			reqLogger.Info("Overwriting existing lighthouse.server data in " + configMap.Name)
-		}
+		domains := buildDomains(cr)
 
-		coreFile := ""
-		for _, domain := range buildDomains(cr) {
-			coreFile = fmt.Sprintf("%s%s:53 {\n    forward . %s\n}\n",
-				coreFile, domain, lighthouseClusterIP)
-		}
+		if configKey == Corefile {
+			configMap.Data[configKey] = mergeLighthouseIntoCorefile(configMap.Data[configKey], domains, lighthouseClusterIP)
+			reqLogger.Info("Updated custom CoreDNS ConfigMap Corefile key", "Name", configMap.Name,
+				"Namespace", configMap.Namespace)
+		} else {
+			if _, ok := configMap.Data[configKey]; ok {
+				reqLogger.Info("Overwriting existing ConfigMap data", "key", configKey, "Name", configMap.Name)
+			}
 
-		log.Info("Updating coredns-custom ConfigMap for lighthouse.server: " + coreFile)
-		configMap.Data["lighthouse.server"] = coreFile
+			coreFile := ""
+			for _, domain := range domains {
+				coreFile = fmt.Sprintf("%s%s:53 {\n    forward . %s\n}\n",
+					coreFile, domain, lighthouseClusterIP)
+			}
+
+			reqLogger.Info("Updating custom CoreDNS ConfigMap key", "key", configKey, "coreFile", coreFile)
+			configMap.Data[configKey] = coreFile
+		}
 
 		return nil
 	})
 
 	return errors.Wrap(err, "error updating DNS custom ConfigMap")
+}
+
+func getCustomCoreDNSConfigKey(config *submarinerv1alpha1.CoreDNSCustomConfig) string {
+	if config != nil && config.Key != "" {
+		return config.Key
+	}
+
+	return defaultCoreDNSCustomConfigKey
 }
 
 func (r *Reconciler) updateDNSConfig(ctx context.Context, cr *submarinerv1alpha1.ServiceDiscovery) error {
@@ -514,55 +534,127 @@ func (r *Reconciler) updateLighthouseConfigInConfigMap(ctx context.Context, cr *
 	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: configMapNamespace, Name: configMapName}}
 	err := util.MustUpdate[*corev1.ConfigMap](ctx, resource.ForControllerClient(r.GeneralClient, configMap.Namespace, configMap), configMap,
 		func(existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-			coreFile := existing.Data[Corefile]
-			if strings.Contains(coreFile, "lighthouse-start") {
-				// Assume this means we've already set the ConfigMap up, first remove existing lighthouse config
-				newCoreStr := ""
-				skip := false
-
-				log.Infof("Coredns ConfigMap \"%s/%s\" has lighthouse configuration - updating it", configMapNamespace, configMapName)
-
-				for line := range strings.SplitSeq(coreFile, "\n") {
-					if strings.Contains(line, "lighthouse-start") {
-						skip = true
-					} else if strings.Contains(line, "lighthouse-end") {
-						skip = false
-						continue
-					}
-
-					if skip {
-						continue
-					}
-
-					newCoreStr = newCoreStr + line + "\n"
-				}
-
-				coreFile = newCoreStr
-			} else {
-				log.Infof("Coredns ConfigMap \"%s/%s\" does not have lighthouse configuration - adding it",
-					configMapNamespace, configMapName)
-			}
-
-			if clusterIP != "" {
-				coreDNSPort := findCoreDNSListeningPort(coreFile)
-
-				expectedCorefile := "#lighthouse-start AUTO-GENERATED SECTION. DO NOT EDIT\n"
-				for _, domain := range buildDomains(cr) {
-					expectedCorefile = fmt.Sprintf("%s%s:%s {\n    forward . %s\n}\n",
-						expectedCorefile, domain, coreDNSPort, clusterIP)
-				}
-
-				coreFile = expectedCorefile + "#lighthouse-end\n" + coreFile
-			}
-
-			log.Infof("Updated coredns ConfigMap \"%s/%s\": %s", configMapNamespace, configMapName, coreFile)
-
-			existing.Data[Corefile] = coreFile
+			existing.Data[Corefile] = mergeLighthouseIntoCorefile(existing.Data[Corefile], buildDomains(cr), clusterIP)
+			log.Infof("Updated coredns ConfigMap \"%s/%s\": %s", configMapNamespace, configMapName, existing.Data[Corefile])
 
 			return existing, nil
 		})
 
 	return errors.Wrap(err, "error updating DNS ConfigMap")
+}
+
+// mergeLighthouseIntoCorefile injects/updates the lighthouse forward section using markers.
+// When clusterIP is empty the section is removed (cleanup). Existing unmarked server blocks for the
+// managed domains are also removed so re-joins do not leave stale duplicates.
+func mergeLighthouseIntoCorefile(coreFile string, domains []string, clusterIP string) string {
+	if strings.Contains(coreFile, lighthouseStartMarker) {
+		log.Info("Corefile has lighthouse configuration - updating it")
+
+		coreFile = removeLighthouseMarkedSection(coreFile)
+	} else {
+		log.Info("Corefile does not have lighthouse configuration - adding it")
+	}
+
+	coreFile = removeDomainServerBlocks(coreFile, domains)
+
+	if clusterIP == "" {
+		return strings.TrimSpace(coreFile) + "\n"
+	}
+
+	coreDNSPort := findCoreDNSListeningPort(coreFile)
+
+	expectedCorefile := "#lighthouse-start AUTO-GENERATED SECTION. DO NOT EDIT\n"
+	for _, domain := range domains {
+		expectedCorefile = fmt.Sprintf("%s%s:%s {\n    forward . %s\n}\n",
+			expectedCorefile, domain, coreDNSPort, clusterIP)
+	}
+
+	return expectedCorefile + "#lighthouse-end\n" + strings.TrimLeft(coreFile, "\n")
+}
+
+func removeLighthouseMarkedSection(coreFile string) string {
+	newCoreStr := ""
+	skip := false
+
+	for line := range strings.SplitSeq(coreFile, "\n") {
+		if strings.Contains(line, lighthouseStartMarker) {
+			skip = true
+		} else if strings.Contains(line, lighthouseEndMarker) {
+			skip = false
+			continue
+		}
+
+		if skip {
+			continue
+		}
+
+		newCoreStr = newCoreStr + line + "\n"
+	}
+
+	return newCoreStr
+}
+
+// removeDomainServerBlocks strips top-level CoreDNS server blocks whose zone matches a managed domain
+// (with or without an explicit :port), so a previously hand-edited clusterset.local block is replaced.
+func removeDomainServerBlocks(coreFile string, domains []string) string {
+	if coreFile == "" || len(domains) == 0 {
+		return coreFile
+	}
+
+	domainSet := make(map[string]struct{}, len(domains))
+	for _, domain := range domains {
+		domainSet[domain] = struct{}{}
+	}
+
+	lines := strings.Split(coreFile, "\n")
+	var out []string
+	braceDepth := 0
+	skipping := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if !skipping && braceDepth == 0 {
+			zone := serverBlockZone(trimmed)
+			if _, ok := domainSet[zone]; ok {
+				skipping = true
+			}
+		}
+
+		if skipping {
+			braceDepth += strings.Count(line, "{")
+			braceDepth -= strings.Count(line, "}")
+
+			if braceDepth <= 0 {
+				skipping = false
+				braceDepth = 0
+			}
+
+			continue
+		}
+
+		out = append(out, line)
+	}
+
+	return strings.Join(out, "\n")
+}
+
+func serverBlockZone(trimmedLine string) string {
+	if trimmedLine == "" || strings.HasPrefix(trimmedLine, "#") {
+		return ""
+	}
+
+	fields := strings.Fields(trimmedLine)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	zone := fields[0]
+	if idx := strings.Index(zone, ":"); idx >= 0 {
+		zone = zone[:idx]
+	}
+
+	return zone
 }
 
 func findCoreDNSListeningPort(coreFile string) string {

--- a/internal/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -177,6 +177,42 @@ func testReconciliation() {
 			}
 		})
 
+		Context("and the custom key is Corefile", func() {
+			BeforeEach(func() {
+				t.serviceDiscovery.Spec.CoreDNSCustomConfig.Key = servicediscovery.Corefile
+				t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
+						Namespace: t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace,
+					},
+					Data: map[string]string{
+						servicediscovery.Corefile: `# User can put their additional configurations here
+example.com:53 {
+    forward . 1.2.3.4
+}
+clusterset.local:53 {
+    forward . 10.96.209.137
+}
+`,
+					},
+				})
+				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+			})
+
+			It("should merge lighthouse config into Corefile and replace the stale domain block", func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				corefile := t.assertConfigMap(ctx, t.serviceDiscovery.Spec.CoreDNSCustomConfig.ConfigMapName,
+					t.serviceDiscovery.Spec.CoreDNSCustomConfig.Namespace).Data[servicediscovery.Corefile]
+				Expect(corefile).To(ContainSubstring("#lighthouse-start"))
+				Expect(corefile).To(ContainSubstring("forward . " + clusterIP))
+				Expect(corefile).To(ContainSubstring("example.com:53"))
+				Expect(corefile).To(ContainSubstring("forward . 1.2.3.4"))
+				Expect(corefile).NotTo(ContainSubstring("10.96.209.137"))
+				Expect(strings.Count(corefile, "clusterset.local")).To(Equal(1))
+			})
+		})
+
 		Context("and the custom coredns ConfigMap already exists", func() {
 			BeforeEach(func() {
 				t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP), &corev1.ConfigMap{


### PR DESCRIPTION
## What this PR does / why we need it

Extends `spec.coreDNSCustomConfig` with an optional **`key`** field:

- Default / unset → `lighthouse.server` (existing AKS-style behavior)
- `key: Corefile` → merge lighthouse forwards into a full Corefile snippet using `#lighthouse-start` / `#lighthouse-end` markers

This is needed whenever CoreDNS does not pick up AKS-style `*.server` snippet keys
and instead loads a full Corefile from the custom ConfigMap — for example:

```text
import /etc/coredns-user/Corefile
```

In that layout, writing only `lighthouse.server` appears to “succeed” but DNS never
loads the Lighthouse forwards. We hit this on **Yandex Managed Kubernetes**; the same
pattern can appear on other managed / customized CoreDNS setups (see also #3005).

When merging into `Corefile`, existing unmarked `clusterset.local` blocks are replaced so re-joins update a stale Lighthouse ClusterIP without wiping other user zones.

Embedded `deploy/crds` and the OLM bundle (CRDs + CSV `specDescriptors`) are updated so installs from CRDs or bundle both expose `key`.

## Related issues

- Extends the model from https://github.com/submariner-io/submariner-operator/issues/1046 (AKS `coredns-custom` / `lighthouse.server`)
- Related to https://github.com/submariner-io/submariner-operator/issues/3005 (non-default CoreDNS ConfigMap layouts; RKE2 discussion of custom CM naming)

## Related PRs

- Companion subctl: https://github.com/submariner-io/subctl/pull/1832 (`--coredns-custom-configmap-key`)

## Checklist

- [x] API + CRD (`config/crd` **and** `deploy/crds`)
- [x] OLM bundle CRDs + CSV `specDescriptors` include `key`
- [x] Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the ConfigMap data key used for custom CoreDNS forwarding configuration.
  * CoreDNS configuration now safely merges Lighthouse forwarding rules into existing Corefiles while preserving user-managed content.
  * Updated configuration schemas and UI metadata to expose the new key setting.

* **Bug Fixes**
  * Prevented stale or duplicate forwarding rules during configuration updates and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->