### PR TITLE
Fix gateway IPsec HostPath on immutable OS

### DIFF
--- a/internal/controllers/submariner/gateway_resources.go
+++ b/internal/controllers/submariner/gateway_resources.go
@@ -97,7 +97,9 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 	}
 	volumes := []corev1.Volume{
 		{Name: "ipsecd", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-			Path: "/etc/ipsec.d", Type: new(corev1.HostPathDirectoryOrCreate),
+			// Host path under /var (not /etc): Talos and other immutable OS have a read-only
+			// root; kubelet DirectoryOrCreate on /etc/ipsec.d fails with CreateContainerError.
+			Path: "/var/lib/ipsec/ipsec.d", Type: new(corev1.HostPathDirectoryOrCreate),
 		}}},
 		{Name: "ipsecnss", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 			Path: "/var/lib/ipsec/nss", Type: new(corev1.HostPathDirectoryOrCreate),

--- a/internal/controllers/submariner/submariner_suite_test.go
+++ b/internal/controllers/submariner/submariner_suite_test.go
@@ -38,6 +38,7 @@ import (
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -171,7 +172,40 @@ func (t *testDriver) assertGatewayDaemonSet(ctx context.Context) {
 	Expect(daemonSet.Spec.Template.Spec.Containers[0].Image).To(
 		Equal(fmt.Sprintf("%s/%s:%s", t.submariner.Spec.Repository, opnames.GatewayImage, t.submariner.Spec.Version)))
 
+	assertGatewayIPsecHostPaths(daemonSet)
+
 	t.assertGatewayDaemonSetEnv(t.withNetworkDiscovery(), test.EnvMapFrom(daemonSet))
+}
+
+func assertGatewayIPsecHostPaths(daemonSet *appsv1.DaemonSet) {
+	hostPathType := corev1.HostPathDirectoryOrCreate
+	expected := map[string]string{
+		"ipsecd":      "/var/lib/ipsec/ipsec.d",
+		"ipsecnss":    "/var/lib/ipsec/nss",
+		"plutosocket": "/var/run/pluto",
+	}
+
+	for name, path := range expected {
+		var volume *corev1.Volume
+
+		for i := range daemonSet.Spec.Template.Spec.Volumes {
+			if daemonSet.Spec.Template.Spec.Volumes[i].Name == name {
+				volume = &daemonSet.Spec.Template.Spec.Volumes[i]
+				break
+			}
+		}
+
+		Expect(volume).NotTo(BeNil(), "missing volume %q", name)
+		Expect(volume.HostPath).NotTo(BeNil(), "volume %q should be HostPath", name)
+		Expect(volume.HostPath.Path).To(Equal(path))
+		Expect(volume.HostPath.Type).To(Equal(&hostPathType))
+	}
+
+	Expect(daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{
+		Name:      "ipsecd",
+		MountPath: "/etc/ipsec.d",
+		ReadOnly:  false,
+	}))
 }
 
 func (t *testDriver) assertUninstallGatewayDaemonSet(ctx context.Context) *appsv1.DaemonSet {


### PR DESCRIPTION
## What this PR does / why we need it

The gateway pod mounts IPsec config from the node via HostPath.
Previously the host path was `/etc/ipsec.d`.

On Talos (and similar OS where `/etc` is read-only), kubelet cannot create
that directory, so the gateway pod fails to start.

This PR changes only the **host** path to `/var/lib/ipsec/ipsec.d`
(writable, next to the existing NSS mount under `/var/lib/ipsec/`).
Inside the container the path is still `/etc/ipsec.d` — gateway/Libreswan
code does not change.

## How to verify

- On Talos: gateway should start without workarounds
- On normal Linux: existing behavior preserved (DirectoryOrCreate under `/var/lib/ipsec`)
- Unit tests cover HostPath + mount for `ipsecd` / `nssdb` / `nssdir`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the gateway IPsec storage mount to use a writable host path, improving compatibility with immutable operating systems and preventing container startup failures.
* **Tests**
  * Enhanced the gateway DaemonSet test to validate the expected IPsec hostPath volumes (paths and creation mode) and verify the `ipsecd` container volume mount settings, including read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->