### PR TITLE
Disable pprof endpoint by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,7 +81,8 @@ func main() {
 	var probeAddr string
 	var pprofAddr string
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&pprofAddr, "pprof-bind-address", ":8082", "The address the profiling endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "",
+		"The address the profiling endpoint binds to. Disabled by default; set e.g. 127.0.0.1:8082 for local debugging.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for the controller manager to ensure there is only one active instance.")
 


### PR DESCRIPTION
The --pprof-bind-address flag defaulted to ':8082', so controller-runtime served unauthenticated net/http/pprof on 0.0.0.0:8082 in every shipped deployment (config/manager/manager.yaml passes only --leader-elect; no NetworkPolicy ships). Any pod on the cluster pod network could read /debug/pprof/cmdline, goroutine stacks, and trigger CPU/heap profiling overhead.

Default the flag to '' (disabled) and document the loopback debug address in the help text. Operators who need profiling can opt in explicitly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Disabled the pprof profiling endpoint by default.
  * Profiling can be enabled explicitly by configuring a bind address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->