### PR TITLE
Grant diagnose Role permission to read Secrets

### DIFF
--- a/bundle/manifests/submariner-diagnose_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-diagnose_rbac.authorization.k8s.io_v1_role.yaml
@@ -22,6 +22,12 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "devel-30c9e48f194d"
+            "version": "devel-6116295a498b"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "devel-30c9e48f194d"
+            "version": "devel-6116295a498b"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/submariner/submariner-operator:devel-30c9e48f194d
-    createdAt: "2026-02-12 10:10:20"
+    containerImage: quay.io/submariner/submariner-operator:devel-6116295a498b
+    createdAt: "2026-08-10 22:41:25"
     description: Creates and manages Submariner deployments.
     operatorframework.io/suggested-namespace: submariner-operator
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
@@ -709,18 +709,18 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: quay.io/submariner/submariner-operator:devel-30c9e48f194d
+                  value: quay.io/submariner/submariner-operator:devel-6116295a498b
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: quay.io/submariner/submariner-gateway:devel-30c9e48f194d
+                  value: quay.io/submariner/submariner-gateway:devel-6116295a498b
                 - name: RELATED_IMAGE_submariner-route-agent
-                  value: quay.io/submariner/submariner-route-agent:devel-30c9e48f194d
+                  value: quay.io/submariner/submariner-route-agent:devel-6116295a498b
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: quay.io/submariner/submariner-globalnet:devel-30c9e48f194d
+                  value: quay.io/submariner/submariner-globalnet:devel-6116295a498b
                 - name: RELATED_IMAGE_lighthouse-agent
-                  value: quay.io/submariner/lighthouse-agent:devel-30c9e48f194d
+                  value: quay.io/submariner/lighthouse-agent:devel-6116295a498b
                 - name: RELATED_IMAGE_lighthouse-coredns
-                  value: quay.io/submariner/lighthouse-coredns:devel-30c9e48f194d
-                image: quay.io/submariner/submariner-operator:devel-30c9e48f194d
+                  value: quay.io/submariner/lighthouse-coredns:devel-6116295a498b
+                image: quay.io/submariner/submariner-operator:devel-6116295a498b
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -873,17 +873,17 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: quay.io/submariner/submariner-operator:devel-30c9e48f194d
+  - image: quay.io/submariner/submariner-operator:devel-6116295a498b
     name: submariner-operator
-  - image: quay.io/submariner/submariner-gateway:devel-30c9e48f194d
+  - image: quay.io/submariner/submariner-gateway:devel-6116295a498b
     name: submariner-gateway
-  - image: quay.io/submariner/submariner-route-agent:devel-30c9e48f194d
+  - image: quay.io/submariner/submariner-route-agent:devel-6116295a498b
     name: submariner-route-agent
-  - image: quay.io/submariner/submariner-globalnet:devel-30c9e48f194d
+  - image: quay.io/submariner/submariner-globalnet:devel-6116295a498b
     name: submariner-globalnet
-  - image: quay.io/submariner/lighthouse-agent:devel-30c9e48f194d
+  - image: quay.io/submariner/lighthouse-agent:devel-6116295a498b
     name: lighthouse-agent
-  - image: quay.io/submariner/lighthouse-coredns:devel-30c9e48f194d
+  - image: quay.io/submariner/lighthouse-coredns:devel-6116295a498b
     name: lighthouse-coredns
   selector:
     matchLabels:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: devel-30c9e48f194d
+  newTag: devel-6116295a498b
 - name: repo
   newName: quay.io/submariner

--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -23,6 +23,12 @@ rules:
       - get
       - list
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
       - apps
     resources:
       - daemonsets


### PR DESCRIPTION
Add 'get' permission for secrets resource to the submariner-diagnose Role. This allows the diagnose ServiceAccount to read broker credentials and IPSec PSK from Secrets in the submariner-operator namespace.

**Note**: this is needed for https://github.com/submariner-io/subctl/pull/1846

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics by allowing access to the secrets needed for troubleshooting.
  * Updated the operator components and related images to the latest development build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->