### PR TITLE
Backport #4166: Grant diagnose Role permission to read Secrets- #4167

### DIFF
--- a/bundle/manifests/submariner-diagnose_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-diagnose_rbac.authorization.k8s.io_v1_role.yaml
@@ -22,6 +22,12 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "0.23.1"
+            "version": "release-0.23-f38d2964b13a"
           }
         },
         {
@@ -69,7 +69,7 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "0.23.1"
+            "version": "release-0.23-f38d2964b13a"
           }
         }
       ]
@@ -77,7 +77,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
-    createdAt: "2026-03-31 15:37:30"
+    createdAt: "2026-08-12 13:32:53"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/bundle/manifests/submariner.io_brokers.yaml
+++ b/bundle/manifests/submariner.io_brokers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   name: brokers.submariner.io
 spec:

--- a/bundle/manifests/submariner.io_servicediscoveries.yaml
+++ b/bundle/manifests/submariner.io_servicediscoveries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   name: servicediscoveries.submariner.io
 spec:
@@ -110,9 +110,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/bundle/manifests/submariner.io_submariners.yaml
+++ b/bundle/manifests/submariner.io_submariners.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   name: submariners.submariner.io
 spec:
@@ -206,9 +206,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -489,8 +490,8 @@ spec:
                                 maxItems: 2
                                 type: array
                               public_ip:
-                                description: 'Deprecated: Set/SetPublicIP() or, if
-                                  necessary, PublicIPs'
+                                description: 'Deprecated: Use Get/SetPublicIP() or,
+                                  if necessary, PublicIPs'
                                 type: string
                               publicIPs:
                                 items:
@@ -511,7 +512,7 @@ spec:
                             type: object
                           latencyRTT:
                             description: |-
-                              LatencySpec describes the round trip time information for a packet
+                              LatencyRTTSpec describes the round trip time information for a packet
                               between the gateway pods of two clusters.
                             properties:
                               average:
@@ -578,7 +579,7 @@ spec:
                           maxItems: 2
                           type: array
                         public_ip:
-                          description: 'Deprecated: Set/SetPublicIP() or, if necessary,
+                          description: 'Deprecated: Use Get/SetPublicIP() or, if necessary,
                             PublicIPs'
                           type: string
                         publicIPs:

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -9,6 +9,6 @@ patches:
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-03-31 15:37:30"
+  createdAt: "2026-08-12 13:32:53"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/crd/bases/submariner.io_brokers.yaml
+++ b/config/crd/bases/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/config/crd/bases/submariner.io_servicediscoveries.yaml
+++ b/config/crd/bases/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io
@@ -110,9 +110,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/config/crd/bases/submariner.io_submariners.yaml
+++ b/config/crd/bases/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -206,9 +206,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -489,8 +490,8 @@ spec:
                                 maxItems: 2
                                 type: array
                               public_ip:
-                                description: 'Deprecated: Set/SetPublicIP() or, if
-                                  necessary, PublicIPs'
+                                description: 'Deprecated: Use Get/SetPublicIP() or,
+                                  if necessary, PublicIPs'
                                 type: string
                               publicIPs:
                                 items:
@@ -511,7 +512,7 @@ spec:
                             type: object
                           latencyRTT:
                             description: |-
-                              LatencySpec describes the round trip time information for a packet
+                              LatencyRTTSpec describes the round trip time information for a packet
                               between the gateway pods of two clusters.
                             properties:
                               average:
@@ -578,7 +579,7 @@ spec:
                           maxItems: 2
                           type: array
                         public_ip:
-                          description: 'Deprecated: Set/SetPublicIP() or, if necessary,
+                          description: 'Deprecated: Use Get/SetPublicIP() or, if necessary,
                             PublicIPs'
                           type: string
                         publicIPs:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: 0.23.1
+  newTag: release-0.23-f38d2964b13a
 - name: repo
   newName: quay.io/submariner

--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -23,6 +23,12 @@ rules:
       - get
       - list
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
       - apps
     resources:
       - daemonsets

--- a/deploy/crds/submariner.io_brokers.yaml
+++ b/deploy/crds/submariner.io_brokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: brokers.submariner.io
 spec:
   group: submariner.io

--- a/deploy/crds/submariner.io_servicediscoveries.yaml
+++ b/deploy/crds/submariner.io_servicediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: servicediscoveries.submariner.io
 spec:
   group: submariner.io
@@ -110,9 +110,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/deploy/crds/submariner.io_submariners.yaml
+++ b/deploy/crds/submariner.io_submariners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: submariners.submariner.io
 spec:
   group: submariner.io
@@ -206,9 +206,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -489,8 +490,8 @@ spec:
                                 maxItems: 2
                                 type: array
                               public_ip:
-                                description: 'Deprecated: Set/SetPublicIP() or, if
-                                  necessary, PublicIPs'
+                                description: 'Deprecated: Use Get/SetPublicIP() or,
+                                  if necessary, PublicIPs'
                                 type: string
                               publicIPs:
                                 items:
@@ -511,7 +512,7 @@ spec:
                             type: object
                           latencyRTT:
                             description: |-
-                              LatencySpec describes the round trip time information for a packet
+                              LatencyRTTSpec describes the round trip time information for a packet
                               between the gateway pods of two clusters.
                             properties:
                               average:
@@ -578,7 +579,7 @@ spec:
                           maxItems: 2
                           type: array
                         public_ip:
-                          description: 'Deprecated: Set/SetPublicIP() or, if necessary,
+                          description: 'Deprecated: Use Get/SetPublicIP() or, if necessary,
                             PublicIPs'
                           type: string
                         publicIPs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Diagnostic tooling can now read Kubernetes Secrets when required for troubleshooting.

- **Documentation**
  - Expanded toleration documentation to cover `Lt` and `Gt` operators and their numeric-comparison requirements.
  - Updated public IP accessor guidance and clarified latency configuration terminology.

- **Updates**
  - Updated controller, Service Discovery, and Submariner example images to newer release builds.
  - Refreshed resource metadata and generated manifest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->