### PR TITLE
Backport #4166: Grant diagnose Role permission to read Secrets- #4167

### DIFF
--- a/bundle/manifests/submariner-diagnose_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/submariner-diagnose_rbac.authorization.k8s.io_v1_role.yaml
@@ -22,6 +22,12 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/config/rbac/submariner-diagnose/role.yaml
+++ b/config/rbac/submariner-diagnose/role.yaml
@@ -23,6 +23,12 @@ rules:
       - get
       - list
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
       - apps
     resources:
       - daemonsets

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -3433,6 +3433,12 @@ rules:
       - get
       - list
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
       - apps
     resources:
       - daemonsets


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated diagnostic permissions to allow reading Kubernetes Secrets.
  - This enables diagnostic workflows to access the Secret information required for more complete troubleshooting.
  - No changes were made to endpoint configuration schemas or IP address validation in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->