### PR TITLE
Mount IPsec volumes only for libreswan

### DIFF
--- a/internal/controllers/submariner/cabledriver/cabledriver.go
+++ b/internal/controllers/submariner/cabledriver/cabledriver.go
@@ -1,0 +1,51 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cabledriver customizes gateway DaemonSet construction per cable driver.
+//
+// To add gateway volumes (or other DaemonSet bits) for a new cable driver:
+//  1. Add <driver>.go in this package implementing Driver
+//  2. Register it in the drivers map below
+//
+// Drivers with no operator-side volumes stay unregistered and contribute nothing.
+package cabledriver
+
+import (
+	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Driver customizes gateway DaemonSet construction for a cable driver.
+type Driver interface {
+	Volumes(cr *v1alpha1.Submariner) ([]corev1.VolumeMount, []corev1.Volume)
+}
+
+// drivers is the static registry (same idea as cable.AddDriver / network discoverFunctions).
+var drivers = map[string]Driver{
+	"libreswan": libreswanDriver{},
+	"":          libreswanDriver{}, // omitempty → same as gateway default
+}
+
+// Volumes returns cable-driver-specific volume mounts and volumes for the gateway pod.
+func Volumes(cr *v1alpha1.Submariner) ([]corev1.VolumeMount, []corev1.Volume) {
+	if driver := drivers[cr.Spec.CableDriver]; driver != nil {
+		return driver.Volumes(cr)
+	}
+
+	return nil, nil
+}

--- a/internal/controllers/submariner/cabledriver/cabledriver.go
+++ b/internal/controllers/submariner/cabledriver/cabledriver.go
@@ -20,14 +20,16 @@ limitations under the License.
 //
 // To add gateway volumes (or other DaemonSet bits) for a new cable driver:
 //  1. Add <driver>.go in this package implementing Driver
-//  2. Register it in the drivers map below
+//  2. Register it in init() via AddDriver (see libreswan.go)
 //
 // Drivers with no operator-side volumes stay unregistered and contribute nothing.
 package cabledriver
 
 import (
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Driver customizes gateway DaemonSet construction for a cable driver.
@@ -35,10 +37,18 @@ type Driver interface {
 	Volumes(cr *v1alpha1.Submariner) ([]corev1.VolumeMount, []corev1.Volume)
 }
 
-// drivers is the static registry (same idea as cable.AddDriver / network discoverFunctions).
-var drivers = map[string]Driver{
-	"libreswan": libreswanDriver{},
-	"":          libreswanDriver{}, // omitempty → same as gateway default
+var (
+	drivers = map[string]Driver{}
+	logger  = log.Logger{Logger: logf.Log.WithName("CableDriver")}
+)
+
+// AddDriver registers a cable driver for gateway DaemonSet customization.
+func AddDriver(name string, driver Driver) {
+	if drivers[name] != nil {
+		logger.Fatalf("Multiple gateway cable drivers attempting to register with name %q", name)
+	}
+
+	drivers[name] = driver
 }
 
 // Volumes returns cable-driver-specific volume mounts and volumes for the gateway pod.

--- a/internal/controllers/submariner/cabledriver/libreswan.go
+++ b/internal/controllers/submariner/cabledriver/libreswan.go
@@ -1,0 +1,87 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cabledriver
+
+import (
+	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultIPsecHostPath = "/etc/ipsec.d"
+	defaultNSSHostPath   = "/var/lib/ipsec/nss"
+	defaultPlutoHostPath = "/var/run/pluto"
+
+	ipsecHostPathOptionKey = "ipsecHostPath"
+	nssHostPathOptionKey   = "ipsecNSSHostPath"
+	plutoHostPathOptionKey = "plutoHostPath"
+)
+
+type libreswanDriver struct{}
+
+func (libreswanDriver) Volumes(cr *v1alpha1.Submariner) ([]corev1.VolumeMount, []corev1.Volume) {
+	if cr.Spec.CeIPSecUseOVNCertAuthMode {
+		return libreswanCertModeVolumes(cr)
+	}
+
+	return libreswanPSKModeVolumes()
+}
+
+func libreswanPSKModeVolumes() ([]corev1.VolumeMount, []corev1.Volume) {
+	return []corev1.VolumeMount{
+			{Name: "ipsecd", MountPath: "/etc/ipsec.d", ReadOnly: false},
+			{Name: "ipsecnss", MountPath: "/var/lib/ipsec/nss", ReadOnly: false},
+		},
+		[]corev1.Volume{
+			{Name: "ipsecd", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			{Name: "ipsecnss", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		}
+}
+
+func libreswanCertModeVolumes(cr *v1alpha1.Submariner) ([]corev1.VolumeMount, []corev1.Volume) {
+	hostPathType := corev1.HostPathDirectoryOrCreate
+	ipsecHostPath := hostPathOption(cr, ipsecHostPathOptionKey, defaultIPsecHostPath)
+	nssHostPath := hostPathOption(cr, nssHostPathOptionKey, defaultNSSHostPath)
+	plutoHostPath := hostPathOption(cr, plutoHostPathOptionKey, defaultPlutoHostPath)
+
+	return []corev1.VolumeMount{
+			{Name: "ipsecd", MountPath: "/etc/ipsec.d", ReadOnly: false},
+			{Name: "ipsecnss", MountPath: "/var/lib/ipsec/nss", ReadOnly: false},
+			{Name: "plutosocket", MountPath: "/var/run/pluto", ReadOnly: false},
+		},
+		[]corev1.Volume{
+			{Name: "ipsecd", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+				Path: ipsecHostPath, Type: &hostPathType,
+			}}},
+			{Name: "ipsecnss", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+				Path: nssHostPath, Type: &hostPathType,
+			}}},
+			{Name: "plutosocket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+				Path: plutoHostPath, Type: &hostPathType,
+			}}},
+		}
+}
+
+func hostPathOption(cr *v1alpha1.Submariner, key, defaultPath string) string {
+	if path := cr.Spec.CableDriverOptions[key]; path != "" {
+		return path
+	}
+
+	return defaultPath
+}

--- a/internal/controllers/submariner/cabledriver/libreswan.go
+++ b/internal/controllers/submariner/cabledriver/libreswan.go
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	cableDriverName = "libreswan"
+
 	defaultIPsecHostPath = "/etc/ipsec.d"
 	defaultNSSHostPath   = "/var/lib/ipsec/nss"
 	defaultPlutoHostPath = "/var/run/pluto"
@@ -32,6 +34,11 @@ const (
 	nssHostPathOptionKey   = "ipsecNSSHostPath"
 	plutoHostPathOptionKey = "plutoHostPath"
 )
+
+func init() {
+	AddDriver(cableDriverName, libreswanDriver{})
+	AddDriver("", libreswanDriver{}) // empty CableDriver is the gateway default
+}
 
 type libreswanDriver struct{}
 

--- a/internal/controllers/submariner/gateway_resources.go
+++ b/internal/controllers/submariner/gateway_resources.go
@@ -30,6 +30,7 @@ import (
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/controllers/apply"
 	"github.com/submariner-io/submariner-operator/internal/controllers/metrics"
+	"github.com/submariner-io/submariner-operator/internal/controllers/submariner/cabledriver"
 	"github.com/submariner-io/submariner-operator/pkg/httpproxy"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
@@ -91,22 +92,7 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 		healthCheckMaxPacketLossCount = cr.Spec.ConnectionHealthCheck.MaxPacketLossCount
 	}
 
-	volumeMounts := []corev1.VolumeMount{
-		{Name: "ipsecd", MountPath: "/etc/ipsec.d", ReadOnly: false},
-		{Name: "ipsecnss", MountPath: "/var/lib/ipsec/nss", ReadOnly: false},
-		{Name: "plutosocket", MountPath: "/var/run/pluto", ReadOnly: false},
-	}
-	volumes := []corev1.Volume{
-		{Name: "ipsecd", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-			Path: "/etc/ipsec.d", Type: new(corev1.HostPathDirectoryOrCreate),
-		}}},
-		{Name: "ipsecnss", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-			Path: "/var/lib/ipsec/nss", Type: new(corev1.HostPathDirectoryOrCreate),
-		}}},
-		{Name: "plutosocket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-			Path: "/var/run/pluto", Type: new(corev1.HostPathDirectoryOrCreate),
-		}}},
-	}
+	volumeMounts, volumes := cabledriver.Volumes(cr)
 
 	if cr.Spec.BrokerK8sSecret != "" {
 		// We've got a secret, mount it where the syncer expects it

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -60,6 +60,7 @@ var _ = Describe("Submariner controller tests", func() {
 	Context("Reconciliation", func() {
 		testSubmarinerResourceReconciliation()
 		testDaemonSetReconciliation()
+		testGatewayIPsecVolumeReconciliation()
 		testServiceDiscoveryReconciliation()
 		testLoadBalancerReconciliation()
 		testBrokerSecretReconciliation()
@@ -398,6 +399,55 @@ func testDaemonSetReconciliation() {
 				Expect(envMap).To(HaveKeyWithValue("HTTP_PROXY", testHTTPProxy))
 				Expect(envMap).To(HaveKeyWithValue("NO_PROXY", testNoProxy))
 			}
+		})
+	})
+}
+
+func testGatewayIPsecVolumeReconciliation() {
+	t := newTestDriver()
+
+	When("CeIPSecUseOVNCertAuthMode is set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CeIPSecUseOVNCertAuthMode = true
+		})
+
+		Specify("the gateway DaemonSet should mount IPsec HostPath volumes", func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
+
+			daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+			assertGatewayIPsecHostPathVolumes(daemonSet, "/etc/ipsec.d", "/var/lib/ipsec/nss", "/var/run/pluto")
+		})
+	})
+
+	When("the cable driver is wireguard", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CableDriver = "wireguard"
+		})
+
+		Specify("the gateway DaemonSet should not mount IPsec volumes", func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
+
+			daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+			assertGatewayNoIPsecVolumes(daemonSet)
+		})
+	})
+
+	When("CeIPSecUseOVNCertAuthMode and IPsec host path cable driver options are set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CeIPSecUseOVNCertAuthMode = true
+			t.submariner.Spec.CableDriverOptions = map[string]string{
+				"ipsecHostPath":    "/var/lib/ipsec/ipsec.d",
+				"ipsecNSSHostPath": "/custom/ipsec/nss",
+				"plutoHostPath":    "/custom/run/pluto",
+			}
+		})
+
+		Specify("the gateway should use the configured host paths", func(ctx SpecContext) {
+			t.AssertReconcileSuccess(ctx)
+
+			daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+			assertGatewayIPsecHostPathVolumes(daemonSet,
+				"/var/lib/ipsec/ipsec.d", "/custom/ipsec/nss", "/custom/run/pluto")
 		})
 	})
 }

--- a/internal/controllers/submariner/submariner_suite_test.go
+++ b/internal/controllers/submariner/submariner_suite_test.go
@@ -38,6 +38,7 @@ import (
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -171,7 +172,48 @@ func (t *testDriver) assertGatewayDaemonSet(ctx context.Context) {
 	Expect(daemonSet.Spec.Template.Spec.Containers[0].Image).To(
 		Equal(fmt.Sprintf("%s/%s:%s", t.submariner.Spec.Repository, opnames.GatewayImage, t.submariner.Spec.Version)))
 
+	assertGatewayIPsecEmptyDirVolumes(daemonSet)
+
 	t.assertGatewayDaemonSetEnv(t.withNetworkDiscovery(), test.EnvMapFrom(daemonSet))
+}
+
+func assertGatewayIPsecEmptyDirVolumes(daemonSet *appsv1.DaemonSet) {
+	volumes := daemonSet.Spec.Template.Spec.Volumes
+
+	Expect(findVolume(volumes, "ipsecd").EmptyDir).NotTo(BeNil())
+	Expect(findVolume(volumes, "ipsecnss").EmptyDir).NotTo(BeNil())
+	Expect(findVolume(volumes, "plutosocket")).To(BeNil())
+}
+
+func assertGatewayIPsecHostPathVolumes(daemonSet *appsv1.DaemonSet, ipsecHostPath, nssHostPath, plutoHostPath string) {
+	hostPathType := corev1.HostPathDirectoryOrCreate
+	volumes := daemonSet.Spec.Template.Spec.Volumes
+
+	ipsecd := findVolume(volumes, "ipsecd")
+	Expect(ipsecd.HostPath).NotTo(BeNil())
+	Expect(ipsecd.HostPath.Path).To(Equal(ipsecHostPath))
+	Expect(ipsecd.HostPath.Type).To(Equal(&hostPathType))
+
+	Expect(findVolume(volumes, "ipsecnss").HostPath.Path).To(Equal(nssHostPath))
+	Expect(findVolume(volumes, "plutosocket").HostPath.Path).To(Equal(plutoHostPath))
+}
+
+func assertGatewayNoIPsecVolumes(daemonSet *appsv1.DaemonSet) {
+	volumes := daemonSet.Spec.Template.Spec.Volumes
+
+	Expect(findVolume(volumes, "ipsecd")).To(BeNil())
+	Expect(findVolume(volumes, "ipsecnss")).To(BeNil())
+	Expect(findVolume(volumes, "plutosocket")).To(BeNil())
+}
+
+func findVolume(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+
+	return nil
 }
 
 func (t *testDriver) assertUninstallGatewayDaemonSet(ctx context.Context) *appsv1.DaemonSet {


### PR DESCRIPTION
## What this PR does / why we need it

The gateway DaemonSet always mounted IPsec HostPath volumes
(`/etc/ipsec.d`, `/var/lib/ipsec/nss`, `/var/run/pluto`) for **every**
cable driver. On immutable OS roots (e.g. Talos), kubelet
`DirectoryOrCreate` under `/etc` fails and the gateway pod never starts.

Those host mounts exist to **share state with host OVN IPsec** (cert
mode). They are not needed for WireGuard / VXLAN / AmneziaWG, and for
default libreswan PSK the gateway runs its own pluto in the pod.

This PR:

1. **Cable-driver registry** (`internal/controllers/submariner/cabledriver/`):
   only **libreswan** contributes IPsec volumes; other drivers get none.
2. **Volume type by existing cert flag** (`ceIPSecUseOVNCertAuthMode`,
   set by `subctl join --use-ipsec-cert-auth-mode`):
   - PSK (default, flag unset): `EmptyDir` for `ipsecd` / `ipsecnss`
     (pre-OVN behavior)
   - OVN cert mode (flag set): `HostPath` to share with host pluto
3. **Optional HostPath overrides** via `spec.cableDriverOptions` (no new
   API fields), for immutable OS / non-standard layouts when cert mode
   is required (`--use-ipsec-cert-auth-mode`). Path options do **not**
   switch volume type - only the cert flag does:
   - `ipsecHostPath` (default `/etc/ipsec.d`)
   - `ipsecNSSHostPath` (default `/var/lib/ipsec/nss`)
   - `plutoHostPath` (default `/var/run/pluto`)

Container mount paths are unchanged (libreswan still expects
`/etc/ipsec.d`, `/var/lib/ipsec/nss`, `/var/run/pluto` in the pod).

`SUBMARINER_CABLEDRIVEROPTIONS` is still the full map from the CR
(including operator-consumed keys); libreswan ignores unknown options.

Empty `spec.cableDriver` is treated like libreswan (same as the gateway
binary default).

### Why this design

**Why EmptyDir vs HostPath follows `--use-ipsec-cert-auth-mode`?**  
That flag already means "use host OVN IPsec / do not start pluto in the
pod". HostPath is required only then. For default PSK, the gateway
starts its own pluto and only needs writable dirs **inside** the pod -
`EmptyDir` (same idea as before OVN cert support), with no host `/etc`
dependency. Reusing the existing join flag avoids a second
"volume type" knob that would have to stay in sync with auth mode.

**Why path overrides via `cableDriverOptions`, not new Spec fields?**  
Overrides are rare (immutable OS + cert mode, or non-default OVN
layout). `cableDriverOptions` + `subctl join --cable-driver-option`
already exist; no CRD churn. Keys apply only when building HostPath in
cert mode - omitting them keeps OCP defaults. They do not select
EmptyDir/HostPath.

### Extensibility

WireGuard, VXLAN, and AmneziaWG stay out of the registry (no host
volumes). A new entry belongs here only if a future cable driver must
**share persistent state with the host** (same class as OVN + libreswan
cert mode), for example:

- another host IPsec stack (e.g. strongSwan/charon coexisting with a CNI)
- hardware / SmartNIC offload that needs host device or vendor paths
- a host-managed userspace VPN with state under a node directory

Plain in-pod tunnels (kernel/userspace WireGuard variants, GENEVE/GRE-like
overlays, OpenVPN entirely inside the gateway pod) would not need
operator HostPath mounts. Add `<driver>.go` under `cabledriver/` and
register it in the map when such a case appears.

## How to verify

- Unit: `go test ./internal/controllers/submariner/...`
- libreswan PSK (default join, no cert flag): EmptyDir IPsec volumes, no HostPath
- libreswan + `subctl join --use-ipsec-cert-auth-mode`: HostPath defaults
- libreswan cert + `--cable-driver-option ipsecHostPath=...` (and optional
  `ipsecNSSHostPath` / `plutoHostPath`): HostPath uses overrides
  (still requires `--use-ipsec-cert-auth-mode`)
- `cableDriver=wireguard` (or vxlan / amneziawg): no IPsec volumes
- Talos + libreswan PSK: gateway starts without `/etc` HostPath

## Related

- Supersedes approach in #4145 (hardcoded `/var/lib/ipsec/ipsec.d` for all)
- Review feedback: configurable host path and/or volume type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cable-driver-specific gateway volume configuration.
  * Added support for certificate-based and pre-shared-key IPsec volume setups.
  * Added configurable host paths for certificate-based IPsec components.
  * WireGuard gateways now omit unnecessary IPsec volumes.

* **Bug Fixes**
  * Improved gateway pod volume handling across supported cable drivers.
  * Ensured gateway workloads use the appropriate storage type for each IPsec configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->