### PR TITLE
Avoid injecting credentials as plaintext env vars

### DIFF
--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -227,7 +227,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 		})
 	}
 
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
 			Name:      name,
@@ -258,9 +258,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 								{Name: "SUBMARINER_GLOBALNET_ENABLED", Value: strconv.FormatBool(cr.Spec.GlobalnetEnabled)},
 								{Name: "SUBMARINER_HALT_ON_CERT_ERROR", Value: strconv.FormatBool(cr.Spec.HaltOnCertificateError)},
 								{Name: broker.EnvironmentVariable("ApiServer"), Value: cr.Spec.BrokerK8sApiServer},
-								{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
 								{Name: broker.EnvironmentVariable("RemoteNamespace"), Value: cr.Spec.BrokerK8sRemoteNamespace},
-								{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA},
 								{Name: broker.EnvironmentVariable("Insecure"), Value: strconv.FormatBool(cr.Spec.BrokerK8sInsecure)},
 								{Name: broker.EnvironmentVariable("Secret"), Value: cr.Spec.BrokerK8sSecret},
 							}),
@@ -277,6 +275,15 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 			},
 		},
 	}
+
+	// Conditionally inject broker token and CA as environment variables for legacy compatibility when BrokerK8sSecret isn't set.
+	if cr.Spec.BrokerK8sSecret == "" {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
+			corev1.EnvVar{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA})
+	}
+
+	return deployment
 }
 
 func newLighthouseDNSConfigMap(cr *submarinerv1alpha1.ServiceDiscovery) *corev1.ConfigMap {

--- a/internal/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -19,13 +19,16 @@ limitations under the License.
 package servicediscovery_test
 
 import (
+	"encoding/base64"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/names"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	submariner_v1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/controllers/servicediscovery"
+	"github.com/submariner-io/submariner-operator/internal/controllers/test"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +60,47 @@ func testReconciliation() {
 			t.AssertReconcileSuccess(ctx)
 			t.assertAgentDeployment(ctx)
 		})
+	})
+
+	When("BrokerK8sSecret is set", func() {
+		BeforeEach(func() {
+			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
+			t.serviceDiscovery.Spec.BrokerK8sSecret = "my-broker-secret"
+			t.serviceDiscovery.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("secret-token"))
+			t.serviceDiscovery.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("secret-ca"))
+		})
+
+		Specify("the lighthouse agent deployment should NOT have broker credentials as env vars",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				deployment := t.AssertDeployment(ctx, names.ServiceDiscoveryComponent)
+				envMap := test.EnvMapFromVars(deployment.Spec.Template.Spec.Containers[0].Env)
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("ApiServerToken")))
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("CA")))
+			})
+	})
+
+	When("BrokerK8sSecret is NOT set", func() {
+		BeforeEach(func() {
+			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
+			t.serviceDiscovery.Spec.BrokerK8sSecret = ""
+			t.serviceDiscovery.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("plaintext-token"))
+			t.serviceDiscovery.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("plaintext-ca"))
+		})
+
+		Specify("the lighthouse agent deployment should have broker credentials as env vars for backwards compatibility",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				deployment := t.AssertDeployment(ctx, names.ServiceDiscoveryComponent)
+				envMap := test.EnvMapFromVars(deployment.Spec.Template.Spec.Containers[0].Env)
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("ApiServerToken"),
+					t.serviceDiscovery.Spec.BrokerK8sApiServerToken))
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("CA"), t.serviceDiscovery.Spec.BrokerK8sCA))
+			})
 	})
 
 	When("the openshift DNS config exists", func() {

--- a/internal/controllers/submariner/gateway_resources.go
+++ b/internal/controllers/submariner/gateway_resources.go
@@ -213,12 +213,9 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 						{Name: "SUBMARINER_BROKER", Value: cr.Spec.Broker},
 						{Name: "SUBMARINER_CABLEDRIVER", Value: cr.Spec.CableDriver},
 						{Name: broker.EnvironmentVariable("ApiServer"), Value: cr.Spec.BrokerK8sApiServer},
-						{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
 						{Name: broker.EnvironmentVariable("RemoteNamespace"), Value: cr.Spec.BrokerK8sRemoteNamespace},
-						{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA},
 						{Name: broker.EnvironmentVariable("Insecure"), Value: strconv.FormatBool(cr.Spec.BrokerK8sInsecure)},
 						{Name: broker.EnvironmentVariable("Secret"), Value: cr.Spec.BrokerK8sSecret},
-						{Name: "CE_IPSEC_PSK", Value: cr.Spec.CeIPSecPSK},
 						{Name: "CE_IPSEC_PSKSECRET", Value: cr.Spec.CeIPSecPSKSecret},
 						{Name: "CE_IPSEC_DEBUG", Value: strconv.FormatBool(cr.Spec.CeIPSecDebug)},
 						{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
@@ -265,6 +262,19 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 		corev1.EnvVar{Name: "CE_IPSEC_PREFERREDSERVER", Value: strconv.FormatBool(cr.Spec.CeIPSecPreferredServer ||
 			cr.Spec.LoadBalancerEnabled)},
 		corev1.EnvVar{Name: "CE_IPSEC_FORCEENCAPS", Value: strconv.FormatBool(cr.Spec.CeIPSecForceUDPEncaps)})
+
+	// Conditionally inject broker token and CA as environment variables for legacy compatibility when BrokerK8sSecret isn't set.
+	if cr.Spec.BrokerK8sSecret == "" {
+		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
+			corev1.EnvVar{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA})
+	}
+
+	// Conditionally inject IPSec PSK as environment variable for legacy compatibility when CeIPSecPSKSecret isn't set.
+	if cr.Spec.CeIPSecPSKSecret == "" {
+		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: "CE_IPSEC_PSK", Value: cr.Spec.CeIPSecPSK})
+	}
 
 	if len(cr.Spec.CableDriverOptions) > 0 {
 		// map[string]string always encodes successfully.

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -20,6 +20,7 @@ package submariner_test
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"reflect"
 	goslices "slices"
@@ -33,6 +34,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	syncertest "github.com/submariner-io/admiral/pkg/syncer/test"
 	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
@@ -170,6 +172,7 @@ func testSubmarinerResourceReconciliation() {
 	})
 }
 
+//nolint:maintidx // Ignore for unit tests.
 func testDaemonSetReconciliation() {
 	t := newTestDriver()
 
@@ -228,6 +231,79 @@ func testDaemonSetReconciliation() {
 				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
 				Expect(test.EnvMapFrom(daemonSet)).To(HaveKeyWithValue("SUBMARINER_CABLEDRIVEROPTIONS",
 					`{"h1":"10-20","jc":"3"}`))
+			})
+	})
+
+	When("BrokerK8sSecret is set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.BrokerK8sSecret = "my-broker-secret"
+			t.submariner.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("secret-token"))
+			t.submariner.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("secret-ca"))
+
+			t.getAuthorizedBrokerClientFor = func(_ context.Context, _ *v1alpha1.SubmarinerSpec, brokerToken, brokerCA string,
+				_ schema.GroupVersionResource,
+			) (dynamic.Interface, error) {
+				return t.dynClient, nil
+			}
+		})
+
+		Specify("the submariner gateway DaemonSet should NOT have broker credentials as env vars",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				envMap := test.EnvMapFrom(daemonSet)
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("ApiServerToken")))
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("CA")))
+			})
+	})
+
+	When("BrokerK8sSecret is not set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.BrokerK8sSecret = ""
+			t.submariner.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("plaintext-token"))
+			t.submariner.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("plaintext-ca"))
+		})
+
+		Specify("the submariner gateway DaemonSet should have broker credentials as env vars for backwards compatibility",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				envMap := test.EnvMapFrom(daemonSet)
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("ApiServerToken"),
+					t.submariner.Spec.BrokerK8sApiServerToken))
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("CA"), t.submariner.Spec.BrokerK8sCA))
+			})
+	})
+
+	When("CeIPSecPSKSecret is set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CeIPSecPSKSecret = "my-psk-secret"
+			t.submariner.Spec.CeIPSecPSK = "secret-psk"
+		})
+
+		Specify("the submariner gateway DaemonSet should NOT have PSK as env var",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				Expect(test.EnvMapFrom(daemonSet)).NotTo(HaveKey("CE_IPSEC_PSK"))
+			})
+	})
+
+	When("CeIPSecPSKSecret is not set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CeIPSecPSKSecret = ""
+			t.submariner.Spec.CeIPSecPSK = "plaintext-psk"
+		})
+
+		Specify("the submariner gateway DaemonSet should have PSK as env var for backwards compatibility",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				Expect(test.EnvMapFrom(daemonSet)).To(HaveKeyWithValue("CE_IPSEC_PSK", "plaintext-psk"))
 			})
 	})
 

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -189,9 +189,6 @@ function verify_subm_cr() {
   validate_equals '.kind' 'Submariner'
   validate_equals '.metadata.name' "$deployment_name"
   validate_equals '.spec.brokerK8sApiServer' "$SUBMARINER_BROKER_URL"
-  # TODO: every cluster must have it's own token / SA (not working when using bundle/acm)
-  # validate_not_equals '.spec.brokerK8sApiServerToken' $SUBMARINER_BROKER_TOKEN
-  validate_equals '.spec.brokerK8sCA' "$SUBMARINER_BROKER_CA"
   validate_equals '.spec.brokerK8sRemoteNamespace' "$SUBMARINER_BROKER_NS"
   validate_equals '.spec.ceIPSecDebug' "$ce_ipsec_debug"
   validate_equals '.spec.ceIPSecNATTPort' "$ce_ipsec_nattport"
@@ -266,7 +263,6 @@ function verify_subm_gateway_pod() {
   validate_pod_container_env 'SUBMARINER_NATENABLED' "$natEnabled"
   validate_pod_container_env 'BROKER_K8S_APISERVER' "$SUBMARINER_BROKER_URL"
   validate_pod_container_env 'BROKER_K8S_REMOTENAMESPACE' "$SUBMARINER_BROKER_NS"
-  validate_pod_container_env 'BROKER_K8S_CA' "$SUBMARINER_BROKER_CA"
   validate_pod_container_env 'CE_IPSEC_DEBUG' "$ce_ipsec_debug"
   validate_pod_container_env 'CE_IPSEC_NATTPORT' "$ce_ipsec_nattport"
 
@@ -345,7 +341,6 @@ function verify_subm_gateway_container() {
   # Verify SubM Gateway pod environment variables
   grep "BROKER_K8S_APISERVER=$SUBMARINER_BROKER_URL" "$env_file"
   grep "SUBMARINER_NAMESPACE=$subm_ns" "$env_file"
-  grep "BROKER_K8S_CA=$SUBMARINER_BROKER_CA" "$env_file"
   grep "CE_IPSEC_DEBUG=$ce_ipsec_debug" "$env_file"
   grep "SUBMARINER_DEBUG=$subm_debug" "$env_file"
   grep "BROKER_K8S_REMOTENAMESPACE=$SUBMARINER_BROKER_NS" "$env_file"


### PR DESCRIPTION
When `BrokerK8sSecret` or `CeIPSecPSKSecret` are set, the credentials are available via mounted `Secret` volumes. In this case, we no longer inject them as plaintext environment variables to reduce the attack surface for credential exposure via `kubectl describe`, /proc/PID/environ, child process inheritance, crash dumps, and accidental logging.

When these `Secret` fields are empty, we continue to inject credentials as environment variables for compatibility with deployments that use the plaintext fields (i.e. helm).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential handling for service discovery and gateway components.
  * Configured Kubernetes secrets are now used without duplicating credentials in deployment or gateway environment variables.
  * Existing plaintext credential behavior remains supported when Kubernetes secrets are not configured.
  * Removed unnecessary broker CA credential exposure from gateway validation and runtime checks.
* **Tests**
  * Added coverage for broker credentials and IPSec PSK handling across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->