### PR TITLE
RELATED_IMAGE_* should win over imageOverrides in GetImagePath

### DIFF
--- a/pkg/images/image_parsing_test.go
+++ b/pkg/images/image_parsing_test.go
@@ -41,18 +41,48 @@ var imageTests = []struct {
 	{"submariner-operator", "", apis.DefaultSubmarinerOperatorVersion},
 }
 
-var _ = Describe("image parsing", func() {
-	When("Parsing image", func() {
-		It("Should parse version and repository", func() {
-			_, rep := images.ParseOperatorImage("localhost:5000/submariner-operator:local")
-			Expect(rep).To(Equal("localhost:5000"))
+var _ = Describe("GetImagePath", func() {
+	When("a RELATED_IMAGE_<component> env var is set", func() {
+		It("should ignore supplied imageOverrides for that component", func() {
+			GinkgoT().Setenv("RELATED_IMAGE_submariner-gateway", "registry.redhat.io/rhacm2/gateway@sha256:abc")
 
-			for _, tt := range imageTests {
-				version, repository := images.ParseOperatorImage(tt.image)
-				Expect(repository).To(Equal(tt.repository))
-				Expect(version).To(Equal(tt.version))
-			}
+			path := images.GetImagePath("quay.io/submariner", "0.20.0", "submariner-gateway", "submariner-gateway",
+				map[string]string{"submariner-gateway": "evil.example.com/pwn:latest"})
+			Expect(path).To(Equal("registry.redhat.io/rhacm2/gateway@sha256:abc"))
 		})
+	})
+
+	When("a RELATED_IMAGE_<component> env var is not set", func() {
+		It("should honour supplied imageOverrides", func() {
+			path := images.GetImagePath("quay.io/submariner", "0.20.0", "submariner-gateway", "no-related-image",
+				map[string]string{"no-related-image": "localhost:5000/dev:local"})
+			Expect(path).To(Equal("localhost:5000/dev:local"))
+		})
+	})
+
+	When("no RELATED_IMAGE env var or imageOverride is set", func() {
+		It("should construct path with repository and version", func() {
+			path := images.GetImagePath("quay.io/submariner", "0.20.0", "submariner-gateway", "submariner-gateway", nil)
+			Expect(path).To(Equal("quay.io/submariner/submariner-gateway:0.20.0"))
+		})
+
+		It("should construct path without repository prefix when repo is 'local'", func() {
+			path := images.GetImagePath("local", "dev", "submariner-gateway", "submariner-gateway", nil)
+			Expect(path).To(Equal("submariner-gateway:dev"))
+		})
+	})
+})
+
+var _ = Describe("ParseOperatorImage", func() {
+	It("should parse version and repository", func() {
+		_, rep := images.ParseOperatorImage("localhost:5000/submariner-operator:local")
+		Expect(rep).To(Equal("localhost:5000"))
+
+		for _, tt := range imageTests {
+			version, repository := images.ParseOperatorImage(tt.image)
+			Expect(repository).To(Equal(tt.repository))
+			Expect(version).To(Equal(tt.version))
+		}
 	})
 })
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -30,12 +30,21 @@ import (
 )
 
 func GetImagePath(repo, version, image, component string, imageOverrides map[string]string) string {
-	if override, ok := imageOverrides[component]; ok {
-		return logIfChanged(repo, version, image, component, override, "Image is overridden")
+	// Treat RELATED_IMAGE_* as a trusted source (e.g. set by OLM from the trusted operator bundle) that takes precedence over the
+	// supplied imageOverrides map, which is assumed to be user-supplied (e.g. from the Submariner CR which is namespaced and writable
+	// by lesser-privileged principals). Honouring the latter ahead of the former could let a bad actor pull arbitrary images into
+	// the privileged hostNetwork DaemonSets the operator manages.
+	if relatedImage, present := os.LookupEnv("RELATED_IMAGE_" + component); present {
+		if override, ok := imageOverrides[component]; ok && override != relatedImage {
+			log.Info("Ignoring image override as RELATED_IMAGE_* takes precedence",
+				"component", component, "override", override, "relatedImage", relatedImage)
+		}
+
+		return logIfChanged(repo, version, image, component, relatedImage, "Related image in the environment")
 	}
 
-	if relatedImage, present := os.LookupEnv("RELATED_IMAGE_" + component); present {
-		return logIfChanged(repo, version, image, component, relatedImage, "Related image in the environment")
+	if override, ok := imageOverrides[component]; ok {
+		return logIfChanged(repo, version, image, component, override, "Image is overridden")
 	}
 
 	path := image

--- a/test/e2e/webhook/webhook.go
+++ b/test/e2e/webhook/webhook.go
@@ -286,7 +286,7 @@ var _ = Describe("Broker webhook", func() {
 					Namespace: brokerNamespace,
 					Name:      fmt.Sprintf("%s-%s", serviceName, serviceNamespace),
 				}, serviceImport)).To(Succeed())
-			}).Within(5 * time.Second).To(Succeed())
+			}).Within(time.Minute).To(Succeed())
 
 			impersonatedConfig := rest.CopyConfig(framework.RestConfigs[brokerCluster])
 			impersonatedConfig.Impersonate = rest.ImpersonationConfig{


### PR DESCRIPTION
`GetImagePath()` returned `imageOverrides[component]` verbatim ahead of the _RELATED_IMAGE_<component>_ env var. In production, `imageOverrides` comes from the `Submariner` CR which is namespaced and, as such, should be treated as untrusted. A namespaced CR-writer could therefore obtain root on every node by pointing `imageOverrides` at an attacker image.

Swap the precedence: treat _RELATED_IMAGE_<component>_, when set, as a trusted source (e.g. OLM) and use it ahead of `imageOverrides`[component].



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Related-image environment variables now take precedence over configured image overrides.
  - Conflicting image overrides are logged and ignored.
  - Image overrides are applied only when no related-image environment variable is set.
  - Improved reliability when waiting for aggregated service imports during deployment validation.

- **Tests**
  - Expanded coverage for image path resolution, including environment variables, overrides, default paths, and local repositories.
  - Reorganized operator image parsing tests for clearer coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->