### PR TITLE
Remove kubernetes.io/enforce-mountable-secrets annotation

### DIFF
--- a/config/rbac/submariner-operator/service_account.yaml
+++ b/config/rbac/submariner-operator/service_account.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
-  annotations:
-    kubernetes.io/enforce-mountable-secrets: "true"

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2924,8 +2924,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
-  annotations:
-    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_operator_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
...from operator SA so it can access the webhook secret.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `submariner-operator` ServiceAccount configuration to remove an obsolete secret-mount restriction.
  * Applied the same update to the packaged deployment manifest for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->