### PR TITLE
Automated backport of #4196: Remove kubernetes.io/enforce-mountable-secrets annotation

### DIFF
--- a/config/rbac/submariner-operator/service_account.yaml
+++ b/config/rbac/submariner-operator/service_account.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
-  annotations:
-    kubernetes.io/enforce-mountable-secrets: "true"

--- a/pkg/embeddedyamls/yamls.go
+++ b/pkg/embeddedyamls/yamls.go
@@ -2612,8 +2612,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submariner-operator
-  annotations:
-    kubernetes.io/enforce-mountable-secrets: "true"
 `
 	Config_rbac_submariner_operator_role_yaml = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #4196 on release-0.18.

#4196: Remove kubernetes.io/enforce-mountable-secrets annotation

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.