### PR TITLE
Automated backport of #4153: Disable pprof endpoint by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,7 +86,8 @@ func main() {
 	var probeAddr string
 	var pprofAddr string
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&pprofAddr, "pprof-bind-address", ":8082", "The address the profiling endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "",
+		"The address the profiling endpoint binds to. Disabled by default; set e.g. 127.0.0.1:8082 for local debugging.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for the controller manager to ensure there is only one active instance.")
 	flag.BoolVar(&runWebhook, "webhook", false, "Runs the broker validating webhook.")


### PR DESCRIPTION
Backport of #4153 on release-0.24.

#4153: Disable pprof endpoint by default

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled profiling by default unless a profiling address is explicitly configured.

* **Documentation**
  * Updated the flag help text to explain the default behavior and include a local debugging example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->