### PR TITLE
Automated backport of #4200: Add validating webhook for broker resource isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ else
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
+override export PLUGIN = $(DAPPER_SOURCE)/scripts/test/deploy-plugin.sh
+
 -include $(SHIPYARD_DIR)/Makefile.inc
 # Version calculation from Shipyard Makefile.versions
 # These are used by the bundle construction and copied here

--- a/config/webhook/certificate.yaml
+++ b/config/webhook/certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: submariner-operator-serving-cert
+  namespace: submariner-operator
+spec:
+  dnsNames:
+    - submariner-operator-webhook.submariner-operator.svc
+    - submariner-operator-webhook.submariner-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: submariner-operator-selfsigned-issuer
+  secretName: submariner-operator-webhook-cert

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: submariner-operator-webhook
+  namespace: submariner-operator
+  labels:
+    control-plane: submariner-operator-webhook
+spec:
+  selector:
+    matchLabels:
+      control-plane: submariner-operator-webhook
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: submariner-operator-webhook
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: submariner-operator
+      volumes:
+        - name: cert
+          secret:
+            secretName: submariner-operator-webhook-cert
+            defaultMode: 420
+      containers:
+        - name: submariner-operator
+          # Replace this with the built image name
+          image: quay.io/submariner/submariner-operator:dev
+          command:
+            - submariner-operator
+          args:
+            - --webhook
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: cert
+              mountPath: /var/run/webhook-certs
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 9443
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"

--- a/config/webhook/embed.go
+++ b/config/webhook/embed.go
@@ -15,21 +15,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package e2e_test
 
-import (
-	"testing"
+// Package webhook embeds the webhook YAML files
+package webhook
 
-	"github.com/submariner-io/shipyard/test/e2e"
-	"github.com/submariner-io/shipyard/test/e2e/framework"
-	_ "github.com/submariner-io/submariner-operator/test/e2e/cleanup"
-	"github.com/submariner-io/submariner-operator/test/e2e/webhook"
+import _ "embed"
+
+var (
+	//go:embed certificate.yaml
+	Certificate []byte
+
+	//go:embed deployment.yaml
+	Deployment []byte
+
+	//go:embed service.yaml
+	Service []byte
+
+	//go:embed self_signed_issuer.yaml
+	SelfSignedIssuer []byte
+
+	//go:embed validating_webhook_config.yaml
+	ValidatingWebhookConfig []byte
 )
-
-func init() {
-	framework.AddBeforeSuite(webhook.Deploy)
-}
-
-func TestE2E(t *testing.T) {
-	e2e.RunE2ETests(t)
-}

--- a/config/webhook/self_signed_issuer.yaml
+++ b/config/webhook/self_signed_issuer.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: submariner-operator-selfsigned-issuer
+  namespace: submariner-operator
+spec:
+  selfSigned: {}

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: submariner-operator-webhook
+  namespace: submariner-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: submariner-operator-webhook-cert
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: submariner-operator-webhook

--- a/config/webhook/validating_webhook_config.yaml
+++ b/config/webhook/validating_webhook_config.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: submariner-broker-validator
+  annotations:
+    cert-manager.io/inject-ca-from: submariner-operator/submariner-operator-serving-cert
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+  - name: broker-validator.submariner.io
+    clientConfig:
+      service:
+        name: submariner-operator-webhook
+        namespace: submariner-operator
+        path: /validate
+    rules:
+      - operations: ["CREATE", "UPDATE", "DELETE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["secrets"]
+        scope: "Namespaced"
+      - operations: ["CREATE", "UPDATE", "DELETE"]
+        apiGroups: ["submariner.io"]
+        apiVersions: ["v1"]
+        resources: ["endpoints"]
+        scope: "Namespaced"
+      - operations: ["CREATE", "UPDATE", "DELETE"]
+        apiGroups: ["submariner.io"]
+        apiVersions: ["v1"]
+        resources: ["clusters"]
+        scope: "Namespaced"
+      - operations: ["CREATE", "UPDATE", "DELETE"]
+        apiGroups: ["discovery.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["endpointslices"]
+        scope: "Namespaced"
+      - operations: ["CREATE", "UPDATE", "DELETE"]
+        apiGroups: ["multicluster.x-k8s.io"]
+        apiVersions: ["v1alpha1", "v1beta1"]
+        resources: ["serviceimports"]
+        scope: "Namespaced"
+      - operations: ["UPDATE"]
+        apiGroups: ["multicluster.x-k8s.io"]
+        apiVersions: ["v1alpha1", "v1beta1"]
+        resources: ["serviceimports/status"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - submariner-k8s-broker
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10

--- a/config/webhook/validating_webhook_config.yaml
+++ b/config/webhook/validating_webhook_config.yaml
@@ -36,12 +36,12 @@ webhooks:
         scope: "Namespaced"
       - operations: ["CREATE", "UPDATE", "DELETE"]
         apiGroups: ["multicluster.x-k8s.io"]
-        apiVersions: ["v1alpha1", "v1beta1"]
+        apiVersions: ["v1alpha1"]
         resources: ["serviceimports"]
         scope: "Namespaced"
       - operations: ["UPDATE"]
         apiGroups: ["multicluster.x-k8s.io"]
-        apiVersions: ["v1alpha1", "v1beta1"]
+        apiVersions: ["v1alpha1"]
         resources: ["serviceimports/status"]
         scope: "Namespaced"
     namespaceSelector:

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/gateway"
 	"github.com/submariner-io/submariner-operator/pkg/lighthouse"
+	opwebhook "github.com/submariner-io/submariner-operator/pkg/webhook"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +55,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -81,14 +84,15 @@ func init() {
 
 //nolint:gocyclo // No further refactors necessary
 func main() {
+	var runWebhook bool
 	var enableLeaderElection bool
 	var probeAddr string
 	var pprofAddr string
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&pprofAddr, "pprof-bind-address", ":8082", "The address the profiling endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+		"Enable leader election for the controller manager to ensure there is only one active instance.")
+	flag.BoolVar(&runWebhook, "webhook", false, "Runs the broker validating webhook.")
 
 	kzerolog.AddFlags(nil)
 	flag.Parse()
@@ -120,6 +124,15 @@ func main() {
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)
+	}
+	
+	if runWebhook {
+	    if err := runBrokerWebhook(signals.SetupSignalHandler(), cfg); err != nil {
+		    log.Error(err, "")
+			os.Exit(1)
+		}
+
+		return
 	}
 
 	ctx := context.TODO()
@@ -270,4 +283,31 @@ func getWatchNamespace() (string, error) {
 	}
 
 	return ns, nil
+}
+
+func runBrokerWebhook(ctx context.Context, cfg *rest.Config) error {
+	log.Info("Starting the broker webhook server")
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: opwebhook.NewScheme(),
+		Metrics: server.Options{
+			BindAddress: "0",
+		},
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port:    9443,
+			CertDir: "/var/run/webhook-certs",
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create manager: %w", err)
+	}
+
+	brokerValidator := opwebhook.NewBrokerValidator()
+	brokerValidator.SetupWithManager(mgr)
+
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("webhook manager failed: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -18,13 +18,12 @@ limitations under the License.
 
 package names
 
-import "fmt"
-
 /* CR names and other constants. */
 const (
 	ServiceDiscoveryCrName = "service-discovery"
 	SubmarinerCrName       = "submariner"
 	CleanupFinalizer       = "controllers.submariner.io/cleanup"
+	ClusterSAPrefix        = "cluster-"
 )
 
 /* These values are used by downstream distributions to override the component default image name. */
@@ -45,5 +44,5 @@ func AppendUninstall(name string) string {
 }
 
 func ForClusterSA(clusterID string) string {
-	return fmt.Sprintf("cluster-%s", clusterID)
+	return ClusterSAPrefix + clusterID
 }

--- a/pkg/webhook/broker_validator.go
+++ b/pkg/webhook/broker_validator.go
@@ -1,0 +1,375 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+const (
+	// SigningRequestLabelKey matches admiral's certificate package constant.
+	SigningRequestLabelKey   = "submariner.io/csr-request"
+	NotBrokerClientSAMessage = "not a broker-client service account"
+)
+
+var webhookLog = logf.Log.WithName("broker-validator")
+
+// BrokerValidator validates secret operations in the broker namespace
+// to ensure spoke clusters only access their own certificate secrets.
+type BrokerValidator struct {
+	decoder admission.Decoder
+}
+
+func NewBrokerValidator() *BrokerValidator {
+	return &BrokerValidator{
+		decoder: admission.NewDecoder(NewScheme()),
+	}
+}
+
+// SetupWithManager registers the webhook with the manager.
+func (v *BrokerValidator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/validate", &admission.Webhook{Handler: v})
+}
+
+//nolint:gocritic // Ignore hugeParam - interface method
+func (v *BrokerValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	// Extract cluster ID from the ServiceAccount
+	clusterID, err := v.extractClusterID(req.UserInfo.Username, req.Namespace)
+	if err != nil {
+		webhookLog.V(log.DEBUG).Info("Request not from broker-client SA, allowing", "username",
+			req.UserInfo.Username, "kind", req.Kind.Kind)
+
+		// Not a broker-client SA, allow (e.g., broker-admin, system:serviceaccount:kube-system:*)
+		return admission.Allowed(NotBrokerClientSAMessage)
+	}
+
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update && req.Operation != admissionv1.Delete {
+		return admission.Allowed("operation not restricted")
+	}
+
+	switch req.Kind.Kind {
+	case "Secret":
+		return v.handleSecret(&req, clusterID)
+	case "Cluster":
+		return v.handleCluster(&req, clusterID)
+	case "Endpoint":
+		return v.handleEndpoint(&req, clusterID)
+	case "EndpointSlice":
+		return v.handleEndpointSlice(&req, clusterID)
+	case "ServiceImport":
+		return v.handleServiceImport(&req, clusterID)
+	default:
+		webhookLog.Info("Unexpected resource kind, allowing", "kind", req.Kind.Kind)
+		return admission.Allowed("resource kind not validated")
+	}
+}
+
+// handleSecret validates secret admission requests.
+func (v *BrokerValidator) handleSecret(req *admission.Request, clusterID string) admission.Response {
+	secret := &corev1.Secret{}
+
+	if err := v.decode(req, secret); err != nil {
+		webhookLog.Error(err, "Failed to decode Secret")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Allow access to secrets that belong to this cluster (certificate secrets)
+	// These are labeled with submariner.io/csr-request: <cluster-id>
+	if labelValue, ok := secret.Labels[SigningRequestLabelKey]; ok {
+		if labelValue == clusterID {
+			webhookLog.V(log.DEBUG).Info("Allowing certificate Secret access", "cluster", clusterID,
+				"secret", secret.Name, "operation", req.Operation)
+
+			return admission.Allowed(fmt.Sprintf("cluster %s accessing own certificate Secret", clusterID))
+		}
+
+		// Attempting to access another cluster's certificate secret
+		msg := fmt.Sprintf("cluster %s cannot access certificate Secret belonging to cluster %s",
+			clusterID, labelValue)
+		webhookLog.Info("Denying cross-cluster secret access", "requesting-cluster", clusterID,
+			"secret-owner", labelValue, "secret", secret.Name, "operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	// Deny access to unlabeled secrets (e.g., submariner-ipsec-psk, token secrets)
+	// These should only be accessed by broker-admin
+	msg := fmt.Sprintf("cluster %s cannot access shared secret %s (no cluster label)", clusterID, secret.Name)
+	webhookLog.Info("Denying access to unlabeled secret", "cluster", clusterID, "secret", secret.Name,
+		"operation", req.Operation)
+
+	return admission.Denied(msg)
+}
+
+// handleCluster validates Cluster admission requests.
+func (v *BrokerValidator) handleCluster(req *admission.Request, clusterID string) admission.Response {
+	// Validate that the Cluster's name matches the requesting cluster's ID
+	if req.Name != clusterID {
+		msg := fmt.Sprintf("cluster %s cannot %s Cluster for cluster %s", clusterID, req.Operation, req.Name)
+		webhookLog.Info("Denying cross-cluster Cluster access", "requesting-cluster", clusterID,
+			"remote-cluster", req.Name, "operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	webhookLog.V(log.DEBUG).Info("Allowing Cluster access", "cluster", clusterID, "operation", req.Operation)
+
+	return admission.Allowed(fmt.Sprintf("cluster %s accessing own Cluster", clusterID))
+}
+
+// handleEndpoint validates endpoint admission requests.
+func (v *BrokerValidator) handleEndpoint(req *admission.Request, clusterID string) admission.Response {
+	endpoint := &submarinerv1.Endpoint{}
+
+	if err := v.decode(req, endpoint); err != nil {
+		webhookLog.Error(err, "Failed to decode Endpoint")
+
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Validate that the endpoint's ClusterID matches the requesting cluster's ID
+	if endpoint.Spec.ClusterID != clusterID {
+		msg := fmt.Sprintf("cluster %s cannot %s Endpoint for cluster %s", clusterID, req.Operation, endpoint.Spec.ClusterID)
+		webhookLog.Info("Denying cross-cluster Endpoint access", "requesting-cluster", clusterID,
+			"endpoint-cluster", endpoint.Spec.ClusterID, "endpoint", endpoint.Name, "operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	webhookLog.V(log.DEBUG).Info("Allowing Endpoint access", "cluster", clusterID, "endpoint", endpoint.Name, "operation", req.Operation)
+
+	return admission.Allowed(fmt.Sprintf("cluster %s accessing own Endpoint", clusterID))
+}
+
+// handleEndpointSlice validates EndpointSlice admission requests.
+// EndpointSlices are synced by lighthouse to the broker namespace.
+func (v *BrokerValidator) handleEndpointSlice(req *admission.Request, clusterID string) admission.Response {
+	endpointSlice := &discoveryv1.EndpointSlice{}
+
+	if err := v.decode(req, endpointSlice); err != nil {
+		webhookLog.Error(err, "Failed to decode EndpointSlice")
+
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Validate that the EndpointSlice's source cluster label matches the requesting cluster's ID
+	sourceCluster, ok := endpointSlice.Labels[mcsv1a1.LabelSourceCluster]
+	if !ok {
+		msg := fmt.Sprintf("EndpointSlice %s missing %s label", endpointSlice.Name, mcsv1a1.LabelSourceCluster)
+		webhookLog.Info("Denying EndpointSlice without source cluster label", "endpointslice", endpointSlice.Name,
+			"operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	if sourceCluster != clusterID {
+		msg := fmt.Sprintf("cluster %s cannot %s EndpointSlice for cluster %s",
+			clusterID, req.Operation, sourceCluster)
+		webhookLog.Info("Denying cross-cluster EndpointSlice access", "requesting-cluster", clusterID,
+			"source-cluster", sourceCluster, "endpointslice", endpointSlice.Name, "operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	webhookLog.V(log.DEBUG).Info("Allowing EndpointSlice access", "cluster", clusterID,
+		"endpointslice", endpointSlice.Name, "operation", req.Operation)
+
+	return admission.Allowed(fmt.Sprintf("cluster %s accessing own EndpointSlice", clusterID))
+}
+
+// handleServiceImport validates ServiceImport admission requests.
+// ServiceImports are synced by lighthouse to the broker namespace.
+// Aggregated ServiceImports (created by lighthouse aggregation) have LabelServiceName in annotations
+// and should be ignored. Local ServiceImports have LabelServiceName in labels.
+func (v *BrokerValidator) handleServiceImport(req *admission.Request, clusterID string) admission.Response {
+	serviceImport := &mcsv1a1.ServiceImport{}
+
+	if err := v.decode(req, serviceImport); err != nil {
+		webhookLog.Error(err, "Failed to decode ServiceImport")
+
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Ignore aggregated ServiceImports - they have LabelServiceName in annotations instead of labels
+	if serviceImport.Annotations[mcsv1a1.LabelServiceName] != "" {
+		return v.handleAggregatedServiceImport(req, serviceImport, clusterID)
+	}
+
+	// Validate that the ServiceImport's source cluster label matches the requesting cluster's ID
+	sourceCluster, ok := serviceImport.Labels[mcsv1a1.LabelSourceCluster]
+	if !ok {
+		msg := fmt.Sprintf("ServiceImport %s missing %s label", serviceImport.Name, mcsv1a1.LabelSourceCluster)
+		webhookLog.Info("Denying ServiceImport without source cluster label", "serviceimport", serviceImport.Name,
+			"operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	if sourceCluster != clusterID {
+		msg := fmt.Sprintf("cluster %s cannot %s ServiceImport for cluster %s", clusterID, req.Operation, sourceCluster)
+		webhookLog.Info("Denying cross-cluster ServiceImport access", "requesting-cluster", clusterID,
+			"source-cluster", sourceCluster, "serviceimport", serviceImport.Name, "operation", req.Operation)
+
+		return admission.Denied(msg)
+	}
+
+	webhookLog.V(log.DEBUG).Info("Allowing ServiceImport access", "cluster", clusterID, "serviceimport", serviceImport.Name,
+		"operation", req.Operation)
+
+	return admission.Allowed(fmt.Sprintf("cluster %s accessing own ServiceImport", clusterID))
+}
+
+func (v *BrokerValidator) handleAggregatedServiceImport(req *admission.Request, serviceImport *mcsv1a1.ServiceImport, clusterID string,
+) admission.Response {
+	if req.Operation == admissionv1.Update {
+		old := &mcsv1a1.ServiceImport{}
+		if err := v.decoder.DecodeRaw(req.OldObject, old); err != nil {
+			webhookLog.Error(err, "Failed to decode old ServiceImport")
+
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if !reflect.DeepEqual(old.Status.Clusters, serviceImport.Status.Clusters) {
+			return v.handleServiceImportClustersUpdated(old.Status.Clusters, serviceImport.Status.Clusters, serviceImport.Name, clusterID)
+		}
+	}
+
+	ownClusterPresent := slices.ContainsFunc(serviceImport.Status.Clusters, func(c mcsv1a1.ClusterStatus) bool {
+		return c.Cluster == clusterID
+	})
+
+	if !ownClusterPresent {
+		if (req.Operation == admissionv1.Create || req.Operation == admissionv1.Delete) && len(serviceImport.Status.Clusters) == 0 {
+			// Because Status is a subresource, the resource must first be created w/o Status.
+			return admission.Allowed("")
+		}
+
+		webhookLog.Info("Denying aggregated ServiceImport with only other clusters present", "serviceimport", serviceImport.Name,
+			"operation", req.Operation)
+
+		return admission.Denied(fmt.Sprintf("Aggregated ServiceImport %s missing own cluster", serviceImport.Name))
+	}
+
+	otherClusterPresent := len(serviceImport.Status.Clusters) > 1
+	if otherClusterPresent && (req.Operation == admissionv1.Create || req.Operation == admissionv1.Delete) {
+		webhookLog.Info("Denying aggregated ServiceImport with other clusters present", "serviceimport", serviceImport.Name,
+			"operation", req.Operation)
+
+		return admission.Denied(fmt.Sprintf("Aggregated ServiceImport %s contains other clusters", serviceImport.Name))
+	}
+
+	return admission.Allowed("")
+}
+
+func (v *BrokerValidator) handleServiceImportClustersUpdated(old, updated []mcsv1a1.ClusterStatus, name, clusterID string,
+) admission.Response {
+	otherClusterNames := func(clusters []mcsv1a1.ClusterStatus) []string {
+		names := make([]string, 0, len(clusters))
+		for _, c := range clusters {
+			if c.Cluster != clusterID {
+				names = append(names, c.Cluster)
+			}
+		}
+
+		slices.Sort(names)
+
+		return names
+	}
+
+	if !slices.Equal(otherClusterNames(updated), otherClusterNames(old)) {
+		webhookLog.Info("Denying aggregated ServiceImport - modifying other clusters", "serviceimport", name,
+			"updated", fmt.Sprintf("%v", updated), "old", fmt.Sprintf("%v", old))
+
+		return admission.Denied(fmt.Sprintf("Aggregated ServiceImport %s attempting to modify other clusters", name))
+	}
+
+	return admission.Allowed("")
+}
+
+// extractClusterID extracts the cluster ID from a broker-client ServiceAccount username.
+// Expected format: system:serviceaccount:<namespace>:cluster-<id>
+// This matches the format created by subctl via names.ForClusterSA(clusterID).
+// Returns cluster ID and nil on success, empty string and error if not a broker-client SA.
+func (v *BrokerValidator) extractClusterID(username, brokerNamespace string) (string, error) {
+	// Format: system:serviceaccount:<namespace>:<sa-name>
+	parts := strings.Split(username, ":")
+	if len(parts) != 4 || parts[0] != "system" || parts[1] != "serviceaccount" {
+		return "", errors.New("not a service account")
+	}
+
+	// Validate that the ServiceAccount is from the broker namespace
+	// to prevent a SA from another namespace claiming to be a cluster
+	if parts[2] != brokerNamespace {
+		return "", errors.New("service account is outside the broker namespace")
+	}
+
+	saName := parts[3]
+
+	// Check if it matches cluster-<id> pattern (subctl creates SAs via names.ForClusterSA)
+	if !strings.HasPrefix(saName, names.ClusterSAPrefix) {
+		return "", errors.New("not a broker-client service account")
+	}
+
+	// Extract cluster ID from cluster-<id>
+	clusterID := strings.TrimPrefix(saName, names.ClusterSAPrefix)
+
+	if clusterID == "" {
+		return "", errors.New("empty cluster ID")
+	}
+
+	return clusterID, nil
+}
+
+//nolint:wrapcheck //  No need to wrap
+func (v *BrokerValidator) decode(req *admission.Request, into runtime.Object) error {
+	if req.Operation == admissionv1.Delete {
+		return v.decoder.DecodeRaw(req.OldObject, into)
+	}
+
+	return v.decoder.Decode(*req, into)
+}
+
+func NewScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(discoveryv1.AddToScheme(scheme))
+	utilruntime.Must(mcsv1a1.Install(scheme))
+	utilruntime.Must(submarinerv1.AddToScheme(scheme))
+
+	return scheme
+}

--- a/pkg/webhook/broker_validator.go
+++ b/pkg/webhook/broker_validator.go
@@ -108,6 +108,35 @@ func (v *BrokerValidator) handleSecret(req *admission.Request, clusterID string)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	// For Update operations, validate that the old owner also matches to prevent ownership takeover
+	if req.Operation == admissionv1.Update {
+		oldSecret := &corev1.Secret{}
+		if err := v.decoder.DecodeRaw(req.OldObject, oldSecret); err != nil {
+			webhookLog.Error(err, "Failed to decode old Secret")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		oldOwner, oldHasLabel := oldSecret.Labels[SigningRequestLabelKey]
+		newOwner, newHasLabel := secret.Labels[SigningRequestLabelKey]
+
+		// Both old and new must match clusterID to prevent ownership changes
+		if oldHasLabel && oldOwner != clusterID {
+			msg := fmt.Sprintf("cluster %s cannot update Secret belonging to cluster %s", clusterID, oldOwner)
+			webhookLog.Info("Denying update of other cluster's Secret", "requesting-cluster", clusterID,
+				"secret-owner", oldOwner, "secret", secret.Name)
+
+			return admission.Denied(msg)
+		}
+
+		if newHasLabel && newOwner != clusterID {
+			msg := fmt.Sprintf("cluster %s cannot change Secret ownership to cluster %s", clusterID, newOwner)
+			webhookLog.Info("Denying Secret ownership change", "requesting-cluster", clusterID,
+				"new-owner", newOwner, "secret", secret.Name)
+
+			return admission.Denied(msg)
+		}
+	}
+
 	// Allow access to secrets that belong to this cluster (certificate secrets)
 	// These are labeled with submariner.io/csr-request: <cluster-id>
 	if labelValue, ok := secret.Labels[SigningRequestLabelKey]; ok {
@@ -162,6 +191,24 @@ func (v *BrokerValidator) handleEndpoint(req *admission.Request, clusterID strin
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	// For Update operations, validate that the old ClusterID also matches to prevent ownership takeover
+	if req.Operation == admissionv1.Update {
+		oldEndpoint := &submarinerv1.Endpoint{}
+		if err := v.decoder.DecodeRaw(req.OldObject, oldEndpoint); err != nil {
+			webhookLog.Error(err, "Failed to decode old Endpoint")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if oldEndpoint.Spec.ClusterID != clusterID {
+			msg := fmt.Sprintf("cluster %s cannot update Endpoint belonging to cluster %s",
+				clusterID, oldEndpoint.Spec.ClusterID)
+			webhookLog.Info("Denying update of other cluster's Endpoint", "requesting-cluster", clusterID,
+				"endpoint-cluster", oldEndpoint.Spec.ClusterID, "endpoint", endpoint.Name)
+
+			return admission.Denied(msg)
+		}
+	}
+
 	// Validate that the endpoint's ClusterID matches the requesting cluster's ID
 	if endpoint.Spec.ClusterID != clusterID {
 		msg := fmt.Sprintf("cluster %s cannot %s Endpoint for cluster %s", clusterID, req.Operation, endpoint.Spec.ClusterID)
@@ -185,6 +232,25 @@ func (v *BrokerValidator) handleEndpointSlice(req *admission.Request, clusterID 
 		webhookLog.Error(err, "Failed to decode EndpointSlice")
 
 		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// For Update operations, validate that the old source cluster label also matches to prevent ownership takeover
+	if req.Operation == admissionv1.Update {
+		oldEndpointSlice := &discoveryv1.EndpointSlice{}
+		if err := v.decoder.DecodeRaw(req.OldObject, oldEndpointSlice); err != nil {
+			webhookLog.Error(err, "Failed to decode old EndpointSlice")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		oldSourceCluster, oldHasLabel := oldEndpointSlice.Labels[mcsv1a1.LabelSourceCluster]
+		if oldHasLabel && oldSourceCluster != clusterID {
+			msg := fmt.Sprintf("cluster %s cannot update EndpointSlice belonging to cluster %s",
+				clusterID, oldSourceCluster)
+			webhookLog.Info("Denying update of other cluster's EndpointSlice", "requesting-cluster", clusterID,
+				"source-cluster", oldSourceCluster, "endpointslice", endpointSlice.Name)
+
+			return admission.Denied(msg)
+		}
 	}
 
 	// Validate that the EndpointSlice's source cluster label matches the requesting cluster's ID
@@ -225,9 +291,45 @@ func (v *BrokerValidator) handleServiceImport(req *admission.Request, clusterID 
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	// Ignore aggregated ServiceImports - they have LabelServiceName in annotations instead of labels
+	var oldServiceImport *mcsv1a1.ServiceImport
+
+	// For Update operations, validate that the old classification and ownership match to prevent takeover
+	if req.Operation == admissionv1.Update {
+		oldServiceImport = &mcsv1a1.ServiceImport{}
+		if err := v.decoder.DecodeRaw(req.OldObject, oldServiceImport); err != nil {
+			webhookLog.Error(err, "Failed to decode old ServiceImport")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Check if classification changed (local <-> aggregated)
+		oldIsAggregated := oldServiceImport.Annotations[mcsv1a1.LabelServiceName] != ""
+		newIsAggregated := serviceImport.Annotations[mcsv1a1.LabelServiceName] != ""
+
+		if oldIsAggregated != newIsAggregated {
+			msg := fmt.Sprintf("cluster %s cannot change ServiceImport classification", clusterID)
+			webhookLog.Info("Denying ServiceImport classification change", "requesting-cluster", clusterID,
+				"serviceimport", serviceImport.Name, "old-aggregated", oldIsAggregated, "new-aggregated", newIsAggregated)
+
+			return admission.Denied(msg)
+		}
+
+		// For local ServiceImports, validate old ownership
+		if !oldIsAggregated {
+			oldSourceCluster, oldHasLabel := oldServiceImport.Labels[mcsv1a1.LabelSourceCluster]
+			if oldHasLabel && oldSourceCluster != clusterID {
+				msg := fmt.Sprintf("cluster %s cannot update ServiceImport belonging to cluster %s",
+					clusterID, oldSourceCluster)
+				webhookLog.Info("Denying update of other cluster's ServiceImport", "requesting-cluster", clusterID,
+					"source-cluster", oldSourceCluster, "serviceimport", serviceImport.Name)
+
+				return admission.Denied(msg)
+			}
+		}
+	}
+
+	// Aggregated ServiceImports have LabelServiceName in annotations instead of labels.
 	if serviceImport.Annotations[mcsv1a1.LabelServiceName] != "" {
-		return v.handleAggregatedServiceImport(req, serviceImport, clusterID)
+		return v.handleAggregatedServiceImport(req, serviceImport, oldServiceImport, clusterID)
 	}
 
 	// Validate that the ServiceImport's source cluster label matches the requesting cluster's ID
@@ -254,16 +356,9 @@ func (v *BrokerValidator) handleServiceImport(req *admission.Request, clusterID 
 	return admission.Allowed(fmt.Sprintf("cluster %s accessing own ServiceImport", clusterID))
 }
 
-func (v *BrokerValidator) handleAggregatedServiceImport(req *admission.Request, serviceImport *mcsv1a1.ServiceImport, clusterID string,
+func (v *BrokerValidator) handleAggregatedServiceImport(req *admission.Request, serviceImport, old *mcsv1a1.ServiceImport, clusterID string,
 ) admission.Response {
 	if req.Operation == admissionv1.Update {
-		old := &mcsv1a1.ServiceImport{}
-		if err := v.decoder.DecodeRaw(req.OldObject, old); err != nil {
-			webhookLog.Error(err, "Failed to decode old ServiceImport")
-
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-
 		if !reflect.DeepEqual(old.Status.Clusters, serviceImport.Status.Clusters) {
 			return v.handleServiceImportClustersUpdated(old.Status.Clusters, serviceImport.Status.Clusters, serviceImport.Name, clusterID)
 		}

--- a/pkg/webhook/broker_validator.go
+++ b/pkg/webhook/broker_validator.go
@@ -45,6 +45,7 @@ const (
 	// SigningRequestLabelKey matches admiral's certificate package constant.
 	SigningRequestLabelKey   = "submariner.io/csr-request"
 	NotBrokerClientSAMessage = "not a broker-client service account"
+	LabelSourceCluster       = "multicluster.kubernetes.io/source-cluster"
 )
 
 var webhookLog = logf.Log.WithName("broker-validator")
@@ -119,8 +120,17 @@ func (v *BrokerValidator) handleSecret(req *admission.Request, clusterID string)
 		oldOwner, oldHasLabel := oldSecret.Labels[SigningRequestLabelKey]
 		newOwner, newHasLabel := secret.Labels[SigningRequestLabelKey]
 
-		// Both old and new must match clusterID to prevent ownership changes
-		if oldHasLabel && oldOwner != clusterID {
+		// Deny updates to unlabeled secrets (shared resources like submariner-ipsec-psk)
+		if !oldHasLabel {
+			msg := fmt.Sprintf("cluster %s cannot update unlabeled Secret %s", clusterID, secret.Name)
+			webhookLog.Info("Denying update of unlabeled Secret", "requesting-cluster", clusterID,
+				"secret", secret.Name)
+
+			return admission.Denied(msg)
+		}
+
+		// Old label exists - require it to match clusterID
+		if oldOwner != clusterID {
 			msg := fmt.Sprintf("cluster %s cannot update Secret belonging to cluster %s", clusterID, oldOwner)
 			webhookLog.Info("Denying update of other cluster's Secret", "requesting-cluster", clusterID,
 				"secret-owner", oldOwner, "secret", secret.Name)
@@ -128,6 +138,7 @@ func (v *BrokerValidator) handleSecret(req *admission.Request, clusterID string)
 			return admission.Denied(msg)
 		}
 
+		// Prevent changing ownership to another cluster
 		if newHasLabel && newOwner != clusterID {
 			msg := fmt.Sprintf("cluster %s cannot change Secret ownership to cluster %s", clusterID, newOwner)
 			webhookLog.Info("Denying Secret ownership change", "requesting-cluster", clusterID,
@@ -242,8 +253,19 @@ func (v *BrokerValidator) handleEndpointSlice(req *admission.Request, clusterID 
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		oldSourceCluster, oldHasLabel := oldEndpointSlice.Labels[mcsv1a1.LabelSourceCluster]
-		if oldHasLabel && oldSourceCluster != clusterID {
+		oldSourceCluster, oldHasLabel := oldEndpointSlice.Labels[LabelSourceCluster]
+
+		// Deny updates to unlabeled EndpointSlices
+		if !oldHasLabel {
+			msg := fmt.Sprintf("cluster %s cannot update unlabeled EndpointSlice %s", clusterID, endpointSlice.Name)
+			webhookLog.Info("Denying update of unlabeled EndpointSlice", "requesting-cluster", clusterID,
+				"endpointslice", endpointSlice.Name)
+
+			return admission.Denied(msg)
+		}
+
+		// Old label exists - require it to match clusterID
+		if oldSourceCluster != clusterID {
 			msg := fmt.Sprintf("cluster %s cannot update EndpointSlice belonging to cluster %s",
 				clusterID, oldSourceCluster)
 			webhookLog.Info("Denying update of other cluster's EndpointSlice", "requesting-cluster", clusterID,
@@ -254,9 +276,9 @@ func (v *BrokerValidator) handleEndpointSlice(req *admission.Request, clusterID 
 	}
 
 	// Validate that the EndpointSlice's source cluster label matches the requesting cluster's ID
-	sourceCluster, ok := endpointSlice.Labels[mcsv1a1.LabelSourceCluster]
+	sourceCluster, ok := endpointSlice.Labels[LabelSourceCluster]
 	if !ok {
-		msg := fmt.Sprintf("EndpointSlice %s missing %s label", endpointSlice.Name, mcsv1a1.LabelSourceCluster)
+		msg := fmt.Sprintf("EndpointSlice %s missing %s label", endpointSlice.Name, LabelSourceCluster)
 		webhookLog.Info("Denying EndpointSlice without source cluster label", "endpointslice", endpointSlice.Name,
 			"operation", req.Operation)
 
@@ -315,8 +337,19 @@ func (v *BrokerValidator) handleServiceImport(req *admission.Request, clusterID 
 
 		// For local ServiceImports, validate old ownership
 		if !oldIsAggregated {
-			oldSourceCluster, oldHasLabel := oldServiceImport.Labels[mcsv1a1.LabelSourceCluster]
-			if oldHasLabel && oldSourceCluster != clusterID {
+			oldSourceCluster, oldHasLabel := oldServiceImport.Labels[LabelSourceCluster]
+
+			// Deny updates to unlabeled local ServiceImports
+			if !oldHasLabel {
+				msg := fmt.Sprintf("cluster %s cannot update unlabeled ServiceImport %s", clusterID, serviceImport.Name)
+				webhookLog.Info("Denying update of unlabeled ServiceImport", "requesting-cluster", clusterID,
+					"serviceimport", serviceImport.Name)
+
+				return admission.Denied(msg)
+			}
+
+			// Old label exists - require it to match clusterID
+			if oldSourceCluster != clusterID {
 				msg := fmt.Sprintf("cluster %s cannot update ServiceImport belonging to cluster %s",
 					clusterID, oldSourceCluster)
 				webhookLog.Info("Denying update of other cluster's ServiceImport", "requesting-cluster", clusterID,
@@ -333,9 +366,9 @@ func (v *BrokerValidator) handleServiceImport(req *admission.Request, clusterID 
 	}
 
 	// Validate that the ServiceImport's source cluster label matches the requesting cluster's ID
-	sourceCluster, ok := serviceImport.Labels[mcsv1a1.LabelSourceCluster]
+	sourceCluster, ok := serviceImport.Labels[LabelSourceCluster]
 	if !ok {
-		msg := fmt.Sprintf("ServiceImport %s missing %s label", serviceImport.Name, mcsv1a1.LabelSourceCluster)
+		msg := fmt.Sprintf("ServiceImport %s missing %s label", serviceImport.Name, LabelSourceCluster)
 		webhookLog.Info("Denying ServiceImport without source cluster label", "serviceimport", serviceImport.Name,
 			"operation", req.Operation)
 

--- a/pkg/webhook/broker_validator_test.go
+++ b/pkg/webhook/broker_validator_test.go
@@ -76,6 +76,15 @@ var _ = Describe("BrokerValidator", func() {
 		})
 	})
 
+	Context("attempting to claim an unlabeled Secret via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldSecret := newSecret("")
+			newSecret := newSecret(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newSecret, oldSecret, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
+
 	t.testAccess("own Endpoint", newEndpoint(testClusterID), AllowOwn)
 	t.testAccess("another cluster's Endpoint", newEndpoint("cluster-b"), Deny)
 
@@ -104,6 +113,15 @@ var _ = Describe("BrokerValidator", func() {
 		})
 	})
 
+	Context("attempting to claim an unlabeled EndpointSlice via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldEPS := newEndpointSlice("")
+			newEPS := newEndpointSlice(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newEPS, oldEPS, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
+
 	t.testAccess("own ServiceImport", newServiceImport(testClusterID), AllowOwn)
 	t.testAccess("another cluster's ServiceImport", newServiceImport("cluster-b"), Deny)
 	t.testAccess("unlabeled ServiceImport", newServiceImport(""), Deny)
@@ -111,6 +129,15 @@ var _ = Describe("BrokerValidator", func() {
 	Context("attempting to take over another cluster's ServiceImport via Update", func() {
 		It("should deny", func(ctx context.Context) {
 			oldSI := newServiceImport(otherClusterID)
+			newSI := newServiceImport(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newSI, oldSI, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
+
+	Context("attempting to claim an unlabeled ServiceImport via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldSI := newServiceImport("")
 			newSI := newServiceImport(testClusterID)
 			resp := t.validator.Handle(ctx, t.createRequest(newSI, oldSI, admissionv1.Update))
 			Expect(resp.Allowed).To(BeFalse())
@@ -368,7 +395,7 @@ func newEndpointSlice(clusterID string) *discoveryv1.EndpointSlice {
 	}
 
 	if clusterID != "" {
-		s.Labels = map[string]string{mcsv1a1.LabelSourceCluster: clusterID}
+		s.Labels = map[string]string{webhook.LabelSourceCluster: clusterID}
 	}
 
 	return s
@@ -387,7 +414,7 @@ func newServiceImport(clusterID string) *mcsv1a1.ServiceImport {
 	}
 
 	if clusterID != "" {
-		s.Labels[mcsv1a1.LabelSourceCluster] = clusterID
+		s.Labels[webhook.LabelSourceCluster] = clusterID
 	}
 
 	return s

--- a/pkg/webhook/broker_validator_test.go
+++ b/pkg/webhook/broker_validator_test.go
@@ -1,0 +1,361 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/submariner-operator/pkg/webhook"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+const (
+	testClusterID   = "cluster-a"
+	otherClusterID  = "other-cluster"
+	brokerNamespace = "submariner-k8s-broker"
+)
+
+var _ = Describe("BrokerValidator", func() {
+	t := newTestDriver()
+
+	DescribeTableSubtree("when the request user name is",
+		func(username string) {
+			It("should allow", func(ctx context.Context) {
+				t.username = username
+
+				resp := t.validator.Handle(ctx, t.createRequest(newSecret(""), nil, admissionv1.Create))
+				Expect(resp.Allowed).To(BeTrue())
+				Expect(resp.Result.Message).To(Equal(webhook.NotBrokerClientSAMessage))
+			})
+		},
+		Entry("not a broker-client SA", fmt.Sprintf("system:serviceaccount:%s:submariner-k8s-broker-admin", brokerNamespace)),
+		Entry("not a SA", "system:user:foo:bar"),
+		Entry("a user", "admin"),
+		Entry("a SA from another namespace", "system:serviceaccount:attacker-namespace:cluster-malicious"),
+	)
+
+	t.testAccess("own certificate Secret", newSecret(testClusterID), AllowOwn)
+	t.testAccess("another cluster's certificate Secret", newSecret("cluster-b"), Deny)
+	t.testAccess("unlabeled Secret", newSecret(""), Deny)
+
+	t.testAccess("own Endpoint", newEndpoint(testClusterID), AllowOwn)
+	t.testAccess("another cluster's Endpoint", newEndpoint("cluster-b"), Deny)
+
+	t.testAccess("own Cluster", newCluster(testClusterID), AllowOwn)
+	t.testAccess("another cluster's Cluster", newCluster("cluster-b"), Deny)
+
+	t.testAccess("own EndpointSlice", newEndpointSlice(testClusterID), AllowOwn)
+	t.testAccess("another cluster's EndpointSlice", newEndpointSlice("cluster-b"), Deny)
+	t.testAccess("unlabeled EndpointSlice", newEndpointSlice(""), Deny)
+
+	t.testAccess("own ServiceImport", newServiceImport(testClusterID), AllowOwn)
+	t.testAccess("another cluster's ServiceImport", newServiceImport("cluster-b"), Deny)
+	t.testAccess("unlabeled ServiceImport", newServiceImport(""), Deny)
+
+	t.testAccess("an aggregate ServiceImport with only other clusters present", newAggregatedServiceImport(otherClusterID), Deny)
+
+	DescribeTableSubtree("an aggregate ServiceImport with no clusters present",
+		func(op admissionv1.Operation, access Access) {
+			t.testHandle(op, newAggregatedServiceImport(), access)
+		},
+		Entry("", admissionv1.Create, Allow),
+		Entry("", admissionv1.Update, Deny),
+		Entry("", admissionv1.Delete, Allow),
+	)
+
+	Context("an aggregate ServiceImport with own cluster present", func() {
+		DescribeTableSubtree("and other clusters present",
+			func(op admissionv1.Operation, access Access) {
+				t.testHandle(op, newAggregatedServiceImport(otherClusterID, testClusterID), access)
+			},
+			Entry("", admissionv1.Create, Deny),
+			Entry("", admissionv1.Update, Allow),
+			Entry("", admissionv1.Delete, Deny),
+		)
+
+		DescribeTableSubtree("and no other clusters present",
+			func(op admissionv1.Operation) {
+				t.testHandle(op, newAggregatedServiceImport(testClusterID), Allow)
+			},
+			Entry("", admissionv1.Create),
+			Entry("", admissionv1.Update),
+			Entry("", admissionv1.Delete),
+		)
+
+		Context("and attempting to add/remove other clusters", func() {
+			It("should deny access", func(ctx context.Context) {
+				old := newAggregatedServiceImport(testClusterID, otherClusterID)
+
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport(testClusterID), old,
+					admissionv1.Update)).Allowed).To(BeFalse())
+
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport("third", testClusterID, otherClusterID),
+					old, admissionv1.Update)).Allowed).To(BeFalse())
+			})
+		})
+
+		Context("and attempting to replace another cluster's ID", func() {
+			It("should deny access", func(ctx context.Context) {
+				old := newAggregatedServiceImport(testClusterID, otherClusterID)
+
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport(testClusterID, "different-cluster"),
+					old, admissionv1.Update)).Allowed).To(BeFalse())
+			})
+		})
+
+		Context("and attempting to add/remove own cluster", func() {
+			It("should allow access", func(ctx context.Context) {
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport(testClusterID),
+					newAggregatedServiceImport(), admissionv1.Update)).Allowed).To(BeTrue())
+
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport(),
+					newAggregatedServiceImport(testClusterID), admissionv1.Update)).Allowed).To(BeTrue())
+
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport(otherClusterID, testClusterID),
+					newAggregatedServiceImport(otherClusterID), admissionv1.Update)).Allowed).To(BeTrue())
+
+				Expect(t.validator.Handle(ctx, t.createRequest(newAggregatedServiceImport(otherClusterID),
+					newAggregatedServiceImport(otherClusterID, testClusterID), admissionv1.Update)).Allowed).To(BeTrue())
+			})
+		})
+	})
+})
+
+type testDriver struct {
+	validator  *webhook.BrokerValidator
+	serializer runtime.Serializer
+	username   string
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		t.username = fmt.Sprintf("system:serviceaccount:%s:cluster-%s", brokerNamespace, testClusterID)
+
+		t.validator = webhook.NewBrokerValidator()
+
+		scheme := webhook.NewScheme()
+		t.serializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{})
+	})
+
+	return t
+}
+
+type Access struct {
+	value   bool
+	message string
+}
+
+var (
+	AllowOwn = Access{value: true, message: "accessing own"}
+	Allow    = Access{value: true}
+	Deny     = Access{value: false}
+)
+
+func (a Access) String() string {
+	if a.value {
+		return "allow"
+	}
+
+	return "deny"
+}
+
+func (t *testDriver) testAccess(desc string, obj runtime.Object, writeAccess Access) {
+	DescribeTableSubtree("with "+desc, t.testHandle,
+		Entry("", admissionv1.Create, obj, writeAccess),
+		Entry("", admissionv1.Update, obj, writeAccess),
+		Entry("", admissionv1.Delete, obj, writeAccess),
+	)
+}
+
+func (t *testDriver) testHandle(op admissionv1.Operation, obj runtime.Object, access Access) {
+	It(fmt.Sprintf("should %s %s access", access, op), func(ctx context.Context) {
+		resp := t.validator.Handle(ctx, t.createRequest(obj, nil, op))
+		Expect(resp.Allowed).To(Equal(access.value))
+
+		if access.message != "" {
+			Expect(resp.Result.Message).To(ContainSubstring(access.message))
+		}
+	})
+}
+
+func (t *testDriver) createRequest(obj, old runtime.Object, op admissionv1.Operation) admission.Request {
+	objBytes, err := runtime.Encode(t.serializer, obj)
+	Expect(err).NotTo(HaveOccurred())
+
+	namespace := resource.MustToMeta(obj).GetNamespace()
+	if namespace == "" {
+		namespace = brokerNamespace
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: op,
+			UserInfo: authenticationv1.UserInfo{
+				Username: t.username,
+			},
+			Kind:      metav1.GroupVersionKind(obj.GetObjectKind().GroupVersionKind()),
+			Name:      resource.MustToMeta(obj).GetName(),
+			Namespace: namespace,
+		},
+	}
+
+	if op == admissionv1.Delete {
+		req.OldObject = runtime.RawExtension{
+			Raw: objBytes,
+		}
+	} else {
+		req.Object = runtime.RawExtension{
+			Raw: objBytes,
+		}
+	}
+
+	if op == admissionv1.Update {
+		if old == nil {
+			old = obj
+		}
+
+		objBytes, err = runtime.Encode(t.serializer, old)
+		Expect(err).NotTo(HaveOccurred())
+
+		req.OldObject = runtime.RawExtension{
+			Raw: objBytes,
+		}
+	}
+
+	return req
+}
+
+func newSecret(clusterID string) *corev1.Secret {
+	s := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-secret",
+		},
+	}
+
+	if clusterID != "" {
+		s.Labels = map[string]string{webhook.SigningRequestLabelKey: clusterID}
+	}
+
+	return s
+}
+
+func newCluster(clusterID string) *submarinerv1.Cluster {
+	return &submarinerv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: submarinerv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterID,
+		},
+		Spec: submarinerv1.ClusterSpec{
+			ClusterID: clusterID,
+		},
+	}
+}
+
+func newEndpoint(clusterID string) *submarinerv1.Endpoint {
+	return &submarinerv1.Endpoint{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Endpoint",
+			APIVersion: submarinerv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-endpoint",
+		},
+		Spec: submarinerv1.EndpointSpec{
+			ClusterID: clusterID,
+		},
+	}
+}
+
+func newEndpointSlice(clusterID string) *discoveryv1.EndpointSlice {
+	s := &discoveryv1.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EndpointSlice",
+			APIVersion: discoveryv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-eps",
+		},
+	}
+
+	if clusterID != "" {
+		s.Labels = map[string]string{mcsv1a1.LabelSourceCluster: clusterID}
+	}
+
+	return s
+}
+
+func newServiceImport(clusterID string) *mcsv1a1.ServiceImport {
+	s := &mcsv1a1.ServiceImport{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceImport",
+			APIVersion: mcsv1a1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-si",
+			Labels: map[string]string{mcsv1a1.LabelServiceName: "nginx"},
+		},
+	}
+
+	if clusterID != "" {
+		s.Labels[mcsv1a1.LabelSourceCluster] = clusterID
+	}
+
+	return s
+}
+
+func newAggregatedServiceImport(clusterIDs ...string) *mcsv1a1.ServiceImport {
+	s := &mcsv1a1.ServiceImport{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceImport",
+			APIVersion: mcsv1a1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-si",
+			Annotations: map[string]string{mcsv1a1.LabelServiceName: "nginx"},
+		},
+	}
+
+	for _, clusterID := range clusterIDs {
+		s.Status.Clusters = append(s.Status.Clusters, mcsv1a1.ClusterStatus{Cluster: clusterID})
+	}
+
+	return s
+}

--- a/pkg/webhook/broker_validator_test.go
+++ b/pkg/webhook/broker_validator_test.go
@@ -67,8 +67,26 @@ var _ = Describe("BrokerValidator", func() {
 	t.testAccess("another cluster's certificate Secret", newSecret("cluster-b"), Deny)
 	t.testAccess("unlabeled Secret", newSecret(""), Deny)
 
+	Context("attempting to take over another cluster's Secret via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldSecret := newSecret(otherClusterID)
+			newSecret := newSecret(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newSecret, oldSecret, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
+
 	t.testAccess("own Endpoint", newEndpoint(testClusterID), AllowOwn)
 	t.testAccess("another cluster's Endpoint", newEndpoint("cluster-b"), Deny)
+
+	Context("attempting to take over another cluster's Endpoint via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldEndpoint := newEndpoint(otherClusterID)
+			newEndpoint := newEndpoint(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newEndpoint, oldEndpoint, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
 
 	t.testAccess("own Cluster", newCluster(testClusterID), AllowOwn)
 	t.testAccess("another cluster's Cluster", newCluster("cluster-b"), Deny)
@@ -77,9 +95,43 @@ var _ = Describe("BrokerValidator", func() {
 	t.testAccess("another cluster's EndpointSlice", newEndpointSlice("cluster-b"), Deny)
 	t.testAccess("unlabeled EndpointSlice", newEndpointSlice(""), Deny)
 
+	Context("attempting to take over another cluster's EndpointSlice via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldEPS := newEndpointSlice(otherClusterID)
+			newEPS := newEndpointSlice(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newEPS, oldEPS, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
+
 	t.testAccess("own ServiceImport", newServiceImport(testClusterID), AllowOwn)
 	t.testAccess("another cluster's ServiceImport", newServiceImport("cluster-b"), Deny)
 	t.testAccess("unlabeled ServiceImport", newServiceImport(""), Deny)
+
+	Context("attempting to take over another cluster's ServiceImport via Update", func() {
+		It("should deny", func(ctx context.Context) {
+			oldSI := newServiceImport(otherClusterID)
+			newSI := newServiceImport(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newSI, oldSI, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
+
+	Context("attempting to change ServiceImport classification", func() {
+		It("should deny local to aggregated", func(ctx context.Context) {
+			oldSI := newServiceImport(testClusterID)
+			newSI := newAggregatedServiceImport(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newSI, oldSI, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should deny aggregated to local", func(ctx context.Context) {
+			oldSI := newAggregatedServiceImport(testClusterID)
+			newSI := newServiceImport(testClusterID)
+			resp := t.validator.Handle(ctx, t.createRequest(newSI, oldSI, admissionv1.Update))
+			Expect(resp.Allowed).To(BeFalse())
+		})
+	})
 
 	t.testAccess("an aggregate ServiceImport with only other clusters present", newAggregatedServiceImport(otherClusterID), Deny)
 

--- a/pkg/webhook/deploy/deploy.go
+++ b/pkg/webhook/deploy/deploy.go
@@ -1,0 +1,203 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"context"
+
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/util"
+	webhookyaml "github.com/submariner-io/submariner-operator/config/webhook"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+const OperatorNamespace = "submariner-operator"
+
+var CertManagerGroupVersion = schema.GroupVersion{Group: "cert-manager.io", Version: "v1"}
+
+func Webhook(ctx context.Context, client controllerClient.Client, issuerName, operatorImage, brokerNamespace string,
+	status reporter.Interface,
+) error {
+	if operatorImage == "" {
+		var err error
+
+		operatorImage, err = getOperatorImage(ctx, client, status)
+		if err != nil {
+			return err
+		}
+	}
+
+	if issuerName != "" {
+		if err := deployCertificate(ctx, client, issuerName, status); err != nil {
+			return err
+		}
+	}
+
+	if err := deployService(ctx, client, status); err != nil {
+		return err
+	}
+
+	if err := deployWebhookConfig(ctx, client, brokerNamespace, status); err != nil {
+		return err
+	}
+
+	return deployOperator(ctx, client, operatorImage, status)
+}
+
+func getOperatorImage(ctx context.Context, client controllerClient.Client, status reporter.Interface) (string, error) {
+	status.Start("Retrieving Submariner operator")
+	defer status.End()
+
+	// Get the existing operator deployment to extract its image
+	existingDeployment := &appsv1.Deployment{}
+
+	err := client.Get(ctx, controllerClient.ObjectKey{Namespace: OperatorNamespace, Name: OperatorNamespace}, existingDeployment)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", status.Error(err, "no existing Submariner operator deployment was found in namespace %q", OperatorNamespace)
+		}
+
+		return "", status.Error(err, "error retrieving submariner-operator deployment")
+	}
+
+	return existingDeployment.Spec.Template.Spec.Containers[0].Image, nil
+}
+
+func deployCertificate(ctx context.Context, client controllerClient.Client, issuerName string, status reporter.Interface) error {
+	kind, err := getIssuerKind(ctx, client, issuerName, status)
+	if err != nil {
+		return err
+	}
+
+	status.Start("Deploying the Certificate")
+	defer status.End()
+
+	certificate := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(webhookyaml.Certificate, certificate); err != nil {
+		return status.Error(err, "error parsing Certificate YAML")
+	}
+
+	if err := unstructured.SetNestedField(certificate.Object, issuerName, "spec", "issuerRef", "name"); err != nil {
+		return status.Error(err, "error setting issuerRef name")
+	}
+
+	if err := unstructured.SetNestedField(certificate.Object, kind, "spec", "issuerRef", "kind"); err != nil {
+		return status.Error(err, "error setting issuerRef kind")
+	}
+
+	err = Ensure(ctx, client, certificate)
+
+	return status.Error(err, "error deploying Certificate")
+}
+
+func getIssuerKind(ctx context.Context, client controllerClient.Client, issuerName string,
+	status reporter.Interface,
+) (string, error) {
+	status.Start("Retrieving Issuer %q", issuerName)
+	defer status.End()
+
+	// Try to get Issuer (namespace-scoped) first
+	issuer := &unstructured.Unstructured{}
+	issuer.SetGroupVersionKind(CertManagerGroupVersion.WithKind("Issuer"))
+
+	err := client.Get(ctx, controllerClient.ObjectKey{Namespace: OperatorNamespace, Name: issuerName}, issuer)
+	if err == nil {
+		return issuer.GetKind(), nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return "", status.Error(err, "error checking for Issuer %q in namespace %q", issuerName, OperatorNamespace)
+	}
+
+	// Issuer not found, try ClusterIssuer (cluster-scoped)
+	clusterIssuer := &unstructured.Unstructured{}
+	clusterIssuer.SetGroupVersionKind(CertManagerGroupVersion.WithKind("ClusterIssuer"))
+
+	err = client.Get(ctx, controllerClient.ObjectKey{Name: issuerName}, clusterIssuer)
+	if err == nil {
+		return clusterIssuer.GetKind(), nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		return "", status.Error(err, "No Issuer or ClusterIssuer %q found", issuerName)
+	}
+
+	return "", status.Error(err, "error checking for ClusterIssuer %q", issuerName)
+}
+
+func deployService(ctx context.Context, client controllerClient.Client, status reporter.Interface) error {
+	status.Start("Deploying the Service")
+	defer status.End()
+
+	service := &corev1.Service{}
+	if err := yaml.Unmarshal(webhookyaml.Service, service); err != nil {
+		return status.Error(err, "error parsing Service YAML")
+	}
+
+	err := Ensure(ctx, client, service)
+
+	return status.Error(err, "error deploying Service")
+}
+
+func deployOperator(ctx context.Context, client controllerClient.Client, operatorImage string, status reporter.Interface) error {
+	status.Start("Deploying the Operator")
+	defer status.End()
+
+	deployment := &appsv1.Deployment{}
+	if err := yaml.Unmarshal(webhookyaml.Deployment, deployment); err != nil {
+		return status.Error(err, "error parsing Deployment YAML")
+	}
+
+	deployment.Spec.Template.Spec.Containers[0].Image = operatorImage
+
+	err := Ensure(ctx, client, deployment)
+
+	return status.Error(err, "error deploying Deployment")
+}
+
+func deployWebhookConfig(ctx context.Context, client controllerClient.Client, brokerNamespace string,
+	status reporter.Interface,
+) error {
+	status.Start("Deploying the ValidatingWebhookConfiguration")
+	defer status.End()
+
+	webhookConfig := &admissionregv1.ValidatingWebhookConfiguration{}
+	if err := yaml.Unmarshal(webhookyaml.ValidatingWebhookConfig, webhookConfig); err != nil {
+		return status.Error(err, "error parsing ValidatingWebhookConfig YAML")
+	}
+
+	webhookConfig.Webhooks[0].NamespaceSelector.MatchExpressions[0].Values = []string{brokerNamespace}
+
+	err := Ensure(ctx, client, webhookConfig)
+
+	return status.Error(err, "error deploying ValidatingWebhookConfiguration")
+}
+
+func Ensure[T controllerClient.Object](ctx context.Context, client controllerClient.Client, obj T) error {
+	_, err := util.CreateOrUpdate(ctx, resource.ForControllerClient(client, OperatorNamespace, obj), obj, util.Replace(obj))
+	return err //nolint:wrapcheck // No need to wrap.
+}

--- a/pkg/webhook/deploy/deploy_suite_test.go
+++ b/pkg/webhook/deploy/deploy_suite_test.go
@@ -15,21 +15,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package e2e_test
+
+package deploy_test
 
 import (
 	"testing"
 
-	"github.com/submariner-io/shipyard/test/e2e"
-	"github.com/submariner-io/shipyard/test/e2e/framework"
-	_ "github.com/submariner-io/submariner-operator/test/e2e/cleanup"
-	"github.com/submariner-io/submariner-operator/test/e2e/webhook"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func init() {
-	framework.AddBeforeSuite(webhook.Deploy)
-}
-
-func TestE2E(t *testing.T) {
-	e2e.RunE2ETests(t)
+func TestDeploy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deploy Suite")
 }

--- a/pkg/webhook/deploy/deploy_test.go
+++ b/pkg/webhook/deploy/deploy_test.go
@@ -1,0 +1,199 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/names"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/submariner-operator/pkg/webhook/deploy"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	issuerName      = "test-issuer"
+	certificateName = "submariner-operator-serving-cert"
+	operatorImage   = "existing-operator-image"
+	brokerNamespace = "broker-namespace"
+)
+
+var _ = Describe("Webhook", func() {
+	var (
+		client        controllerClient.Client
+		clientBuilder *fakeClient.ClientBuilder
+		status        reporter.Interface
+	)
+
+	BeforeEach(func() {
+		status = reporter.Stdout()
+		clientBuilder = fakeClient.NewClientBuilder()
+	})
+
+	JustBeforeEach(func() {
+		client = clientBuilder.Build()
+	})
+
+	It("should deploy the webhook with the provided operator image", func(ctx context.Context) {
+		Expect(deploy.Webhook(ctx, client, "", operatorImage, brokerNamespace, status)).To(Succeed())
+		verifyWebhookDeployment(ctx, client, operatorImage)
+	})
+
+	When("Submariner is deployed", func() {
+		BeforeEach(func() {
+			clientBuilder = clientBuilder.WithRuntimeObjects(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      names.OperatorComponent,
+					Namespace: deploy.OperatorNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: operatorImage,
+								},
+							},
+						},
+					},
+				},
+			})
+		})
+
+		It("should deploy the webhook with the existing operator image", func(ctx context.Context) {
+			Expect(deploy.Webhook(ctx, client, "", "", brokerNamespace, status)).To(Succeed())
+			verifyWebhookDeployment(ctx, client, operatorImage)
+		})
+	})
+
+	When("Submariner is not deployed", func() {
+		It("should deploy the webhook with the provided operator image", func(ctx context.Context) {
+			Expect(deploy.Webhook(ctx, client, "", operatorImage, brokerNamespace, status)).To(Succeed())
+			verifyWebhookDeployment(ctx, client, operatorImage)
+		})
+	})
+
+	When("an issuerName is provided", func() {
+		Context("and an Issuer exists in the namespace", func() {
+			BeforeEach(func() {
+				clientBuilder = clientBuilder.WithRuntimeObjects(newIssuer())
+			})
+
+			It("should deploy the Certificate with Issuer kind", func(ctx context.Context) {
+				Expect(deploy.Webhook(ctx, client, issuerName, operatorImage, brokerNamespace, status)).To(Succeed())
+				verifyCertificate(ctx, client, "Issuer")
+			})
+		})
+
+		Context("a ClusterIssuer exists", func() {
+			BeforeEach(func() {
+				clientBuilder = clientBuilder.WithRuntimeObjects(newClusterIssuer())
+			})
+
+			It("should deploy the Certificate with ClusterIssuer kind", func(ctx context.Context) {
+				Expect(deploy.Webhook(ctx, client, issuerName, operatorImage, brokerNamespace, status)).To(Succeed())
+				verifyCertificate(ctx, client, "ClusterIssuer")
+			})
+		})
+
+		Context("but neither an Issuer nor ClusterIssuer exists", func() {
+			It("should return an error", func(ctx context.Context) {
+				Expect(deploy.Webhook(ctx, client, issuerName, operatorImage, brokerNamespace, status)).NotTo(Succeed())
+			})
+		})
+
+		Context("and the Certificate already exists", func() {
+			BeforeEach(func() {
+				clientBuilder = clientBuilder.WithRuntimeObjects(newIssuer(), newCertificate())
+			})
+
+			It("should update the existing Certificate", func(ctx context.Context) {
+				Expect(deploy.Webhook(ctx, client, issuerName, operatorImage, brokerNamespace, status)).To(Succeed())
+				verifyCertificate(ctx, client, "Issuer")
+			})
+		})
+	})
+})
+
+func newIssuer() *unstructured.Unstructured {
+	issuer := &unstructured.Unstructured{}
+	issuer.SetGroupVersionKind(deploy.CertManagerGroupVersion.WithKind("Issuer"))
+	issuer.SetName(issuerName)
+	issuer.SetNamespace(deploy.OperatorNamespace)
+
+	return issuer
+}
+
+func newClusterIssuer() *unstructured.Unstructured {
+	clusterIssuer := &unstructured.Unstructured{}
+	clusterIssuer.SetGroupVersionKind(deploy.CertManagerGroupVersion.WithKind("ClusterIssuer"))
+	clusterIssuer.SetName(issuerName)
+
+	return clusterIssuer
+}
+
+func newCertificate() runtime.Object {
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(deploy.CertManagerGroupVersion.WithKind("Certificate"))
+	cert.SetName(certificateName)
+	cert.SetNamespace(deploy.OperatorNamespace)
+
+	return cert
+}
+
+func verifyCertificate(ctx context.Context, client controllerClient.Client, kind string) {
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(deploy.CertManagerGroupVersion.WithKind("Certificate"))
+	err := client.Get(ctx, controllerClient.ObjectKey{
+		Namespace: deploy.OperatorNamespace,
+		Name:      certificateName,
+	}, cert)
+	Expect(err).NotTo(HaveOccurred())
+
+	issuerRef, found, err := unstructured.NestedMap(cert.Object, "spec", "issuerRef")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(issuerRef["name"]).To(Equal(issuerName))
+	Expect(issuerRef["kind"]).To(Equal(kind))
+}
+
+func verifyWebhookDeployment(ctx context.Context, client controllerClient.Client, image string) {
+	service := &corev1.Service{}
+	Expect(client.Get(ctx, controllerClient.ObjectKey{Namespace: deploy.OperatorNamespace, Name: "submariner-operator-webhook"},
+		service)).NotTo(HaveOccurred())
+
+	deployment := &appsv1.Deployment{}
+	Expect(client.Get(ctx, controllerClient.ObjectKey{Namespace: deploy.OperatorNamespace, Name: "submariner-operator-webhook"},
+		deployment)).NotTo(HaveOccurred())
+	Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(image))
+
+	webhookConfig := &admissionregv1.ValidatingWebhookConfiguration{}
+	Expect(client.Get(ctx, controllerClient.ObjectKey{Name: "submariner-broker-validator"},
+		webhookConfig)).NotTo(HaveOccurred())
+	Expect(webhookConfig.Webhooks[0].NamespaceSelector.MatchExpressions[0].Values).To(Equal([]string{brokerNamespace}))
+}

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -15,21 +15,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package e2e_test
+
+package webhook_test
 
 import (
+	"flag"
 	"testing"
 
-	"github.com/submariner-io/shipyard/test/e2e"
-	"github.com/submariner-io/shipyard/test/e2e/framework"
-	_ "github.com/submariner-io/submariner-operator/test/e2e/cleanup"
-	"github.com/submariner-io/submariner-operator/test/e2e/webhook"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 )
 
 func init() {
-	framework.AddBeforeSuite(webhook.Deploy)
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	_ = flags.Parse([]string{"-v=3"})
+
+	kzerolog.AddFlags(nil)
 }
 
-func TestE2E(t *testing.T) {
-	e2e.RunE2ETests(t)
+var _ = Describe("", func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
 }

--- a/scripts/test/deploy-plugin.sh
+++ b/scripts/test/deploy-plugin.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+function post_deploy() {
+    echo "Installing cert-manager on all clusters..."
+    run_all_clusters install_cert_manager
+}
+
+function install_cert_manager() {
+    local cert_manager_version="${CERT_MANAGER_VERSION:-v1.17.4}"
+
+    # shellcheck disable=SC2154 # cluster is set by run_all_clusters
+    echo "Installing cert-manager ${cert_manager_version} on cluster ${cluster}..."
+
+    kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_manager_version}/cert-manager.yaml"
+
+    kubectl wait --for=condition=Available --timeout=300s deployment/cert-manager -n cert-manager
+    kubectl wait --for=condition=Available --timeout=300s deployment/cert-manager-webhook -n cert-manager
+    kubectl wait --for=condition=Available --timeout=300s deployment/cert-manager-cainjector -n cert-manager
+
+    echo "cert-manager is ready on cluster ${cluster}"
+}

--- a/test/e2e/webhook/deploy.go
+++ b/test/e2e/webhook/deploy.go
@@ -1,0 +1,92 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
+	webhookyaml "github.com/submariner-io/submariner-operator/config/webhook"
+	"github.com/submariner-io/submariner-operator/pkg/webhook/deploy"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+func Deploy() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancel()
+
+	brokerCluster, brokerNamespace := findBrokerCluster(ctx)
+	framework.By("Deploying webhook on broker cluster " + framework.TestContext.ClusterIDs[brokerCluster])
+
+	crClient, err := client.New(framework.RestConfigs[brokerCluster], client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Deploy self-signed issuer
+	framework.By("Deploying self-signed issuer")
+
+	issuer := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal(webhookyaml.SelfSignedIssuer, issuer)).To(Succeed())
+	Expect(deploy.Ensure(ctx, crClient, issuer)).To(Succeed())
+
+	// Deploy webhook components
+	framework.By("Deploying webhook components")
+	Expect(deploy.Webhook(ctx, crClient, issuer.GetName(), "", brokerNamespace, reporter.Stdout())).To(Succeed())
+
+	// Wait for webhook deployment to be ready
+	framework.By("Waiting for webhook deployment to be ready")
+	framework.AwaitUntil("find ready webhook deployment", func() (*appsv1.Deployment, error) {
+		deployment := &appsv1.Deployment{}
+		err := crClient.Get(ctx, client.ObjectKey{
+			Namespace: deploy.OperatorNamespace,
+			Name:      "submariner-operator-webhook",
+		}, deployment)
+
+		return deployment, err
+	}, func(result *appsv1.Deployment) (bool, string, error) {
+		if result.Status.ReadyReplicas > 0 && result.Status.AvailableReplicas > 0 {
+			return true, "", nil
+		}
+
+		return false, "Deployment not ready yet", nil
+	})
+}
+
+func findBrokerCluster(ctx context.Context) (framework.ClusterIndex, string) {
+	for i, c := range framework.DynClients {
+		list, err := c.Resource(operatorv1alpha1.GroupVersion.WithResource("brokers")).Namespace(metav1.NamespaceAll).
+			List(ctx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		for j := range list.Items {
+			return framework.ClusterIndex(i), list.Items[j].GetNamespace()
+		}
+	}
+
+	framework.Fail("Broker cluster not found")
+
+	return 0, ""
+}

--- a/test/e2e/webhook/deploy.go
+++ b/test/e2e/webhook/deploy.go
@@ -58,7 +58,7 @@ func Deploy() {
 
 	// Wait for webhook deployment to be ready
 	framework.By("Waiting for webhook deployment to be ready")
-	framework.AwaitUntil("find ready webhook deployment", func() (*appsv1.Deployment, error) {
+	framework.AwaitUntil("find ready webhook deployment", func() (interface{}, error) {
 		deployment := &appsv1.Deployment{}
 		err := crClient.Get(ctx, client.ObjectKey{
 			Namespace: deploy.OperatorNamespace,
@@ -66,7 +66,9 @@ func Deploy() {
 		}, deployment)
 
 		return deployment, err
-	}, func(result *appsv1.Deployment) (bool, string, error) {
+	}, func(obj interface{}) (bool, string, error) {
+		result := obj.(*appsv1.Deployment)
+
 		if result.Status.ReadyReplicas > 0 && result.Status.AvailableReplicas > 0 {
 			return true, "", nil
 		}

--- a/test/e2e/webhook/webhook.go
+++ b/test/e2e/webhook/webhook.go
@@ -286,7 +286,7 @@ var _ = Describe("Broker webhook", func() {
 					Namespace: brokerNamespace,
 					Name:      fmt.Sprintf("%s-%s", serviceName, serviceNamespace),
 				}, serviceImport)).To(Succeed())
-			}).Within(5 * time.Second).To(Succeed())
+			}).Within(time.Minute).To(Succeed())
 
 			impersonatedConfig := rest.CopyConfig(framework.RestConfigs[brokerCluster])
 			impersonatedConfig.Impersonate = rest.ImpersonationConfig{

--- a/test/e2e/webhook/webhook.go
+++ b/test/e2e/webhook/webhook.go
@@ -1,0 +1,376 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+var _ = Describe("Broker webhook", func() {
+	var (
+		generalClient      client.Client
+		impersonatedClient client.Client
+		otherClusterID     string
+		submariner         *operatorv1alpha1.Submariner
+		scheme             *runtime.Scheme
+		brokerCluster      framework.ClusterIndex
+		brokerNamespace    string
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		var err error
+
+		brokerCluster, brokerNamespace = findBrokerCluster(ctx)
+		framework.By(fmt.Sprintf("Found broker on cluster %q, namespace %q",
+			framework.TestContext.ClusterIDs[brokerCluster], brokerNamespace))
+
+		otherClusterIndex := framework.FindOtherClusterIndex(int(brokerCluster))
+		Expect(otherClusterIndex).NotTo(Equal(-1))
+
+		otherClusterID = framework.TestContext.ClusterIDs[otherClusterIndex]
+
+		framework.By(fmt.Sprintf("Impersonating SA for cluster %q", framework.TestContext.ClusterIDs[brokerCluster]))
+
+		// Create impersonated client for ClusterA's broker client service account
+		impersonatedConfig := rest.CopyConfig(framework.RestConfigs[brokerCluster])
+		impersonatedConfig.Impersonate = rest.ImpersonationConfig{
+			UserName: "system:serviceaccount:" + brokerNamespace + ":" +
+				names.ForClusterSA(framework.TestContext.ClusterIDs[brokerCluster]),
+		}
+
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+		Expect(discoveryv1.AddToScheme(scheme)).To(Succeed())
+		Expect(mcsv1a1.Install(scheme)).To(Succeed())
+		Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())
+		Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		impersonatedClient, err = client.New(impersonatedConfig, client.Options{Scheme: scheme})
+		Expect(err).NotTo(HaveOccurred())
+
+		generalClient, err = client.New(framework.RestConfigs[brokerCluster], client.Options{Scheme: scheme})
+		Expect(err).To(Succeed())
+
+		submariner = &operatorv1alpha1.Submariner{}
+		err = generalClient.Get(ctx, client.ObjectKey{
+			Namespace: framework.TestContext.SubmarinerNamespace,
+			Name:      names.SubmarinerCrName,
+		}, submariner)
+		Expect(err).To(Succeed())
+	})
+
+	It("should deny all write access to another cluster's Endpoint", func(ctx context.Context) {
+		newEndpoint := &submarinerv1.Endpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "forbidden-endpoint",
+				Namespace: brokerNamespace,
+			},
+			Spec: submarinerv1.EndpointSpec{
+				ClusterID: otherClusterID,
+				CableName: "submariner-cable-other-192-168-1-200",
+				Subnets:   []string{"10.245.0.0/16"},
+			},
+		}
+
+		framework.By(fmt.Sprintf("Attempting Endpoint create/update/delete for cluster %q", otherClusterID))
+
+		Eventually(func(g Gomega) {
+			existing := findEndpoint(ctx, g, impersonatedClient, otherClusterID, brokerNamespace)
+
+			expectForbidden(g, impersonatedClient.Create(ctx, newEndpoint))
+			expectForbidden(g, impersonatedClient.Update(ctx, existing))
+			expectForbidden(g, impersonatedClient.Delete(ctx, existing))
+		}).Within(time.Minute).ProbeEvery(time.Second).Should(Succeed())
+	})
+
+	It("should deny all write access to another cluster's Cluster", func(ctx context.Context) {
+		newCluster := &submarinerv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "forbidden-cluster",
+				Namespace: brokerNamespace,
+			},
+			Spec: submarinerv1.ClusterSpec{
+				ClusterID:   "forbidden-cluster",
+				ClusterCIDR: []string{"10.86.0.0/16"},
+				ServiceCIDR: []string{"10.140.0.0/16"},
+				GlobalCIDR:  []string{},
+			},
+		}
+
+		framework.By(fmt.Sprintf("Attempting Cluster create/update/delete for cluster %q", otherClusterID))
+
+		Eventually(func(g Gomega) {
+			existing := &submarinerv1.Cluster{}
+			g.Expect(impersonatedClient.Get(ctx, client.ObjectKey{Name: otherClusterID, Namespace: brokerNamespace},
+				existing)).To(Succeed())
+
+			expectForbidden(g, impersonatedClient.Create(ctx, newCluster))
+			expectForbidden(g, impersonatedClient.Update(ctx, existing))
+			expectForbidden(g, impersonatedClient.Delete(ctx, existing))
+		}).Within(time.Second * 2).ProbeEvery(time.Second).Should(Succeed())
+	})
+
+	DescribeTableSubtree("",
+		func(typeStr string, newObj func() client.Object) {
+			It("should deny create access to another cluster's "+typeStr, func(ctx context.Context) {
+				obj := newObj()
+				framework.By(fmt.Sprintf("Attempting to create %T for cluster %q: %s", obj, otherClusterID,
+					resource.ToJSON(obj)))
+
+				Eventually(func(g Gomega) {
+					expectForbidden(g, impersonatedClient.Create(ctx, obj))
+				}).Within(time.Second * 5).ProbeEvery(time.Second).Should(Succeed())
+			})
+		},
+		Entry("", "Secret", func() client.Object {
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "forbidden-secret",
+					Namespace: brokerNamespace,
+					Labels:    map[string]string{"submariner.io/csr-request": otherClusterID},
+				},
+			}
+		}),
+		Entry("", "EndpointSlice", func() client.Object {
+			return &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "forbidden-eps",
+					Namespace: brokerNamespace,
+					Labels:    map[string]string{mcsv1a1.LabelSourceCluster: otherClusterID},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+			}
+		}),
+		Entry("", "ServiceImport", func() client.Object {
+			return &mcsv1a1.ServiceImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "forbidden-si",
+					Namespace: brokerNamespace,
+					Labels: map[string]string{
+						mcsv1a1.LabelServiceName:   "nginx",
+						mcsv1a1.LabelSourceCluster: otherClusterID,
+					},
+				},
+				Spec: mcsv1a1.ServiceImportSpec{
+					Type:  mcsv1a1.ClusterSetIP,
+					Ports: []mcsv1a1.ServicePort{},
+				},
+			}
+		}),
+	)
+
+	Context("for aggregate ServiceImports", func() {
+		BeforeEach(func() {
+			if !submariner.Spec.ServiceDiscoveryEnabled {
+				Skip("Service Discovery is not enabled")
+			}
+
+			err := generalClient.Create(context.TODO(), &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      names.ForClusterSA(otherClusterID) + "-submariner-k8s-broker-cluster",
+					Namespace: brokerNamespace,
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "submariner-k8s-broker-cluster",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Namespace: brokerNamespace,
+						Name:      names.ForClusterSA(otherClusterID),
+						Kind:      "ServiceAccount",
+					},
+				},
+			})
+			if !apierrors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should only allow access to participating clusters", func(ctx context.Context) {
+			serviceName := "test-service"
+			clusterName := framework.TestContext.ClusterIDs[brokerCluster]
+
+			framework.By(fmt.Sprintf("Creating test namespace on %q", clusterName))
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-webhook-",
+				},
+			}
+			Expect(generalClient.Create(ctx, ns)).To(Succeed())
+
+			serviceNamespace := ns.Name
+
+			DeferCleanup(func(ctx context.Context) {
+				Expect(generalClient.Delete(ctx, ns)).To(Succeed())
+			})
+
+			framework.By(fmt.Sprintf("Creating test service on %q", clusterName))
+
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: serviceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+						},
+					},
+					Selector: map[string]string{
+						"app": "test",
+					},
+				},
+			}
+			Expect(generalClient.Create(ctx, svc)).To(Succeed())
+
+			framework.By(fmt.Sprintf("Exporting the service on %q", clusterName))
+
+			serviceExport := &mcsv1a1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: serviceNamespace,
+				},
+			}
+			Expect(generalClient.Create(ctx, serviceExport)).To(Succeed())
+
+			framework.By("Awaiting aggregated ServiceImport")
+
+			serviceImport := &mcsv1a1.ServiceImport{}
+
+			Eventually(func(g Gomega) {
+				g.Expect(generalClient.Get(ctx, client.ObjectKey{
+					Namespace: brokerNamespace,
+					Name:      fmt.Sprintf("%s-%s", serviceName, serviceNamespace),
+				}, serviceImport)).To(Succeed())
+			}).Within(5 * time.Second).To(Succeed())
+
+			impersonatedConfig := rest.CopyConfig(framework.RestConfigs[brokerCluster])
+			impersonatedConfig.Impersonate = rest.ImpersonationConfig{
+				UserName: "system:serviceaccount:" + brokerNamespace + ":" + names.ForClusterSA(otherClusterID),
+			}
+
+			otherClusterClient, err := client.New(impersonatedConfig, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			framework.By(fmt.Sprintf("Attempting access to ServiceImport impersonating cluster %q - should be denied", otherClusterID))
+
+			expectForbidden(Default, otherClusterClient.Delete(ctx, serviceImport))
+
+			resourceClient := resource.ForControllerClient(otherClusterClient, brokerNamespace, &mcsv1a1.ServiceImport{})
+
+			Eventually(func(g Gomega) {
+				expectForbidden(g, util.MustUpdate(ctx, resourceClient, serviceImport, util.Replace(serviceImport)))
+			}).Within(5 * time.Second).To(Succeed())
+
+			framework.By(fmt.Sprintf("Attempting to add cluster %q to the Status impersonating cluster %q - should be allowed",
+				otherClusterID, otherClusterID))
+
+			Eventually(func(g Gomega) {
+				g.Expect(util.MustUpdate(ctx, resourceClient, serviceImport, func(si *mcsv1a1.ServiceImport) (*mcsv1a1.ServiceImport, error) {
+					si.Status.Clusters = append(si.Status.Clusters, mcsv1a1.ClusterStatus{Cluster: otherClusterID})
+					return si, nil
+				})).To(Succeed())
+			}).Within(5 * time.Second).To(Succeed())
+
+			framework.By(fmt.Sprintf("Attempting to remove cluster %q from the Status impersonating cluster %q - should be denied",
+				clusterName, otherClusterID))
+
+			Eventually(func(g Gomega) {
+				expectForbidden(g, util.MustUpdate(ctx, resourceClient, serviceImport, func(si *mcsv1a1.ServiceImport) (*mcsv1a1.ServiceImport, error) {
+					si.Status.Clusters = slices.DeleteFunc(si.Status.Clusters, func(c mcsv1a1.ClusterStatus) bool {
+						return c.Cluster == clusterName
+					})
+
+					return si, nil
+				}))
+			}).Within(5 * time.Second).To(Succeed())
+
+			framework.By(fmt.Sprintf("Attempting to remove cluster %q from the Status impersonating cluster %q - should be allowed",
+				otherClusterID, otherClusterID))
+
+			Eventually(func(g Gomega) {
+				g.Expect(util.MustUpdate(ctx, resourceClient, serviceImport, func(si *mcsv1a1.ServiceImport) (*mcsv1a1.ServiceImport, error) {
+					si.Status.Clusters = slices.DeleteFunc(si.Status.Clusters, func(c mcsv1a1.ClusterStatus) bool {
+						return c.Cluster == otherClusterID
+					})
+
+					return si, nil
+				})).To(Succeed())
+			}).Within(5 * time.Second).To(Succeed())
+
+			framework.By("Deleting ServiceExport")
+
+			Expect(generalClient.Delete(ctx, serviceExport)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := generalClient.Get(ctx, client.ObjectKey{
+					Namespace: brokerNamespace,
+					Name:      fmt.Sprintf("%s-%s", serviceName, serviceNamespace),
+				}, serviceImport)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ServiceImport should be deleted")
+			}).Within(10 * time.Second).To(Succeed())
+		})
+	})
+})
+
+func expectForbidden(g Gomega, err error) {
+	g.Expect(apierrors.IsForbidden(err)).To(BeTrue(), "Expected Forbidden error but got %q, %T, %s",
+		err, err, resource.ToJSON(err))
+}
+
+func findEndpoint(ctx context.Context, g Gomega, c client.Client, clusterID, brokerNamespace string) *submarinerv1.Endpoint {
+	endpointList := &submarinerv1.EndpointList{}
+	g.Expect(c.List(ctx, endpointList, client.InNamespace(brokerNamespace))).To(Succeed())
+
+	index := slices.IndexFunc(endpointList.Items, func(e submarinerv1.Endpoint) bool {
+		return e.Spec.ClusterID == clusterID
+	})
+
+	g.Expect(index).NotTo(Equal(-1))
+
+	return &endpointList.Items[index]
+}

--- a/test/e2e/webhook/webhook.go
+++ b/test/e2e/webhook/webhook.go
@@ -43,6 +43,8 @@ import (
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
+const LabelSourceCluster = "multicluster.kubernetes.io/source-cluster"
+
 var _ = Describe("Broker webhook", func() {
 	var (
 		generalClient      client.Client
@@ -156,7 +158,8 @@ var _ = Describe("Broker webhook", func() {
 					resource.ToJSON(obj)))
 
 				Eventually(func(g Gomega) {
-					expectForbidden(g, impersonatedClient.Create(ctx, obj))
+					// Create a fresh object for each retry to avoid resourceVersion issues
+					expectForbidden(g, impersonatedClient.Create(ctx, newObj()))
 				}).Within(time.Second * 5).ProbeEvery(time.Second).Should(Succeed())
 			})
 		},
@@ -174,7 +177,7 @@ var _ = Describe("Broker webhook", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "forbidden-eps",
 					Namespace: brokerNamespace,
-					Labels:    map[string]string{mcsv1a1.LabelSourceCluster: otherClusterID},
+					Labels:    map[string]string{LabelSourceCluster: otherClusterID},
 				},
 				AddressType: discoveryv1.AddressTypeIPv4,
 			}
@@ -185,8 +188,8 @@ var _ = Describe("Broker webhook", func() {
 					Name:      "forbidden-si",
 					Namespace: brokerNamespace,
 					Labels: map[string]string{
-						mcsv1a1.LabelServiceName:   "nginx",
-						mcsv1a1.LabelSourceCluster: otherClusterID,
+						mcsv1a1.LabelServiceName: "nginx",
+						LabelSourceCluster:       otherClusterID,
 					},
 				},
 				Spec: mcsv1a1.ServiceImportSpec{
@@ -286,7 +289,7 @@ var _ = Describe("Broker webhook", func() {
 					Namespace: brokerNamespace,
 					Name:      fmt.Sprintf("%s-%s", serviceName, serviceNamespace),
 				}, serviceImport)).To(Succeed())
-			}).Within(time.Minute).To(Succeed())
+			}).Within(time.Minute).Should(Succeed())
 
 			impersonatedConfig := rest.CopyConfig(framework.RestConfigs[brokerCluster])
 			impersonatedConfig.Impersonate = rest.ImpersonationConfig{
@@ -304,7 +307,7 @@ var _ = Describe("Broker webhook", func() {
 
 			Eventually(func(g Gomega) {
 				expectForbidden(g, util.MustUpdate(ctx, resourceClient, serviceImport, util.Replace(serviceImport)))
-			}).Within(5 * time.Second).To(Succeed())
+			}).Within(5 * time.Second).Should(Succeed())
 
 			framework.By(fmt.Sprintf("Attempting to add cluster %q to the Status impersonating cluster %q - should be allowed",
 				otherClusterID, otherClusterID))
@@ -314,7 +317,7 @@ var _ = Describe("Broker webhook", func() {
 					si.Status.Clusters = append(si.Status.Clusters, mcsv1a1.ClusterStatus{Cluster: otherClusterID})
 					return si, nil
 				})).To(Succeed())
-			}).Within(5 * time.Second).To(Succeed())
+			}).Within(5 * time.Second).Should(Succeed())
 
 			framework.By(fmt.Sprintf("Attempting to remove cluster %q from the Status impersonating cluster %q - should be denied",
 				clusterName, otherClusterID))
@@ -327,7 +330,7 @@ var _ = Describe("Broker webhook", func() {
 
 					return si, nil
 				}))
-			}).Within(5 * time.Second).To(Succeed())
+			}).Within(5 * time.Second).Should(Succeed())
 
 			framework.By(fmt.Sprintf("Attempting to remove cluster %q from the Status impersonating cluster %q - should be allowed",
 				otherClusterID, otherClusterID))
@@ -340,7 +343,7 @@ var _ = Describe("Broker webhook", func() {
 
 					return si, nil
 				})).To(Succeed())
-			}).Within(5 * time.Second).To(Succeed())
+			}).Within(5 * time.Second).Should(Succeed())
 
 			framework.By("Deleting ServiceExport")
 
@@ -352,7 +355,7 @@ var _ = Describe("Broker webhook", func() {
 					Name:      fmt.Sprintf("%s-%s", serviceName, serviceNamespace),
 				}, serviceImport)
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ServiceImport should be deleted")
-			}).Within(10 * time.Second).To(Succeed())
+			}).Within(10 * time.Second).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Backport of #4200 on release-0.18.

#4200: Add validating webhook for broker resource isolation

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admission webhook that validates broker resource ownership and blocks unauthorized cross-cluster changes.
  * Added automated deployment of the webhook, including TLS certificates, service configuration, and Kubernetes admission rules.
  * Added an option to start the application in webhook mode.
  * Added end-to-end coverage for webhook deployment, authorization, and ServiceImport validation.

* **Bug Fixes**
  * Prevented service accounts from taking over or modifying resources owned by another cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->