### PR TITLE
Automated backport of #4206: Backport webhook improvements

### DIFF
--- a/internal/controllers/servicediscovery/servicediscovery_controller.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller.go
@@ -211,7 +211,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 		})
 	}
 
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
 			Name:      name,
@@ -241,9 +241,7 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 								{Name: "SUBMARINER_GLOBALNET_ENABLED", Value: strconv.FormatBool(cr.Spec.GlobalnetEnabled)},
 								{Name: "SUBMARINER_HALT_ON_CERT_ERROR", Value: strconv.FormatBool(cr.Spec.HaltOnCertificateError)},
 								{Name: broker.EnvironmentVariable("ApiServer"), Value: cr.Spec.BrokerK8sApiServer},
-								{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
 								{Name: broker.EnvironmentVariable("RemoteNamespace"), Value: cr.Spec.BrokerK8sRemoteNamespace},
-								{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA},
 								{Name: broker.EnvironmentVariable("Insecure"), Value: strconv.FormatBool(cr.Spec.BrokerK8sInsecure)},
 								{Name: broker.EnvironmentVariable("Secret"), Value: cr.Spec.BrokerK8sSecret},
 							}),
@@ -260,6 +258,15 @@ func newLighthouseAgent(cr *submarinerv1alpha1.ServiceDiscovery, name string) *a
 			},
 		},
 	}
+
+	// Conditionally inject broker token and CA as environment variables for legacy compatibility when BrokerK8sSecret isn't set.
+	if cr.Spec.BrokerK8sSecret == "" {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
+			corev1.EnvVar{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA})
+	}
+
+	return deployment
 }
 
 func newLighthouseDNSConfigMap(cr *submarinerv1alpha1.ServiceDiscovery) *corev1.ConfigMap {

--- a/internal/controllers/servicediscovery/servicediscovery_controller_test.go
+++ b/internal/controllers/servicediscovery/servicediscovery_controller_test.go
@@ -19,13 +19,16 @@ limitations under the License.
 package servicediscovery_test
 
 import (
+	"encoding/base64"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/names"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	submariner_v1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/internal/controllers/servicediscovery"
+	"github.com/submariner-io/submariner-operator/internal/controllers/test"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +48,47 @@ func testReconciliation() {
 	It("should add a finalizer to the ServiceDiscovery resource", func(ctx SpecContext) {
 		_, _ = t.DoReconcile(ctx)
 		t.awaitFinalizer()
+	})
+
+	When("BrokerK8sSecret is set", func() {
+		BeforeEach(func() {
+			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
+			t.serviceDiscovery.Spec.BrokerK8sSecret = "my-broker-secret"
+			t.serviceDiscovery.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("secret-token"))
+			t.serviceDiscovery.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("secret-ca"))
+		})
+
+		Specify("the lighthouse agent deployment should NOT have broker credentials as env vars",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				deployment := t.AssertDeployment(ctx, names.ServiceDiscoveryComponent)
+				envMap := test.EnvMapFromVars(deployment.Spec.Template.Spec.Containers[0].Env)
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("ApiServerToken")))
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("CA")))
+			})
+	})
+
+	When("BrokerK8sSecret is NOT set", func() {
+		BeforeEach(func() {
+			t.InitScopedClientObjs = append(t.InitScopedClientObjs, newDNSService(clusterIP))
+			t.InitGeneralClientObjs = append(t.InitGeneralClientObjs, newDNSConfig(""))
+			t.serviceDiscovery.Spec.BrokerK8sSecret = ""
+			t.serviceDiscovery.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("plaintext-token"))
+			t.serviceDiscovery.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("plaintext-ca"))
+		})
+
+		Specify("the lighthouse agent deployment should have broker credentials as env vars for backwards compatibility",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				deployment := t.AssertDeployment(ctx, names.ServiceDiscoveryComponent)
+				envMap := test.EnvMapFromVars(deployment.Spec.Template.Spec.Containers[0].Env)
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("ApiServerToken"),
+					t.serviceDiscovery.Spec.BrokerK8sApiServerToken))
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("CA"), t.serviceDiscovery.Spec.BrokerK8sCA))
+			})
 	})
 
 	When("the openshift DNS config exists", func() {

--- a/internal/controllers/submariner/gateway_resources.go
+++ b/internal/controllers/submariner/gateway_resources.go
@@ -208,12 +208,9 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 						{Name: "SUBMARINER_BROKER", Value: cr.Spec.Broker},
 						{Name: "SUBMARINER_CABLEDRIVER", Value: cr.Spec.CableDriver},
 						{Name: broker.EnvironmentVariable("ApiServer"), Value: cr.Spec.BrokerK8sApiServer},
-						{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
 						{Name: broker.EnvironmentVariable("RemoteNamespace"), Value: cr.Spec.BrokerK8sRemoteNamespace},
-						{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA},
 						{Name: broker.EnvironmentVariable("Insecure"), Value: strconv.FormatBool(cr.Spec.BrokerK8sInsecure)},
 						{Name: broker.EnvironmentVariable("Secret"), Value: cr.Spec.BrokerK8sSecret},
-						{Name: "CE_IPSEC_PSK", Value: cr.Spec.CeIPSecPSK},
 						{Name: "CE_IPSEC_PSKSECRET", Value: cr.Spec.CeIPSecPSKSecret},
 						{Name: "CE_IPSEC_DEBUG", Value: strconv.FormatBool(cr.Spec.CeIPSecDebug)},
 						{Name: "SUBMARINER_HEALTHCHECKENABLED", Value: strconv.FormatBool(healthCheckEnabled)},
@@ -255,6 +252,19 @@ func newGatewayPodTemplate(cr *v1alpha1.Submariner, name string, podSelectorLabe
 		corev1.EnvVar{Name: "CE_IPSEC_PREFERREDSERVER", Value: strconv.FormatBool(cr.Spec.CeIPSecPreferredServer ||
 			cr.Spec.LoadBalancerEnabled)},
 		corev1.EnvVar{Name: "CE_IPSEC_FORCEENCAPS", Value: strconv.FormatBool(cr.Spec.CeIPSecForceUDPEncaps)})
+
+	// Conditionally inject broker token and CA as environment variables for legacy compatibility when BrokerK8sSecret isn't set.
+	if cr.Spec.BrokerK8sSecret == "" {
+		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: broker.EnvironmentVariable("ApiServerToken"), Value: cr.Spec.BrokerK8sApiServerToken},
+			corev1.EnvVar{Name: broker.EnvironmentVariable("CA"), Value: cr.Spec.BrokerK8sCA})
+	}
+
+	// Conditionally inject IPSec PSK as environment variable for legacy compatibility when CeIPSecPSKSecret isn't set.
+	if cr.Spec.CeIPSecPSKSecret == "" {
+		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: "CE_IPSEC_PSK", Value: cr.Spec.CeIPSecPSK})
+	}
 
 	if cr.Spec.LoadBalancerEnabled {
 		podTemplate.Spec.Containers[0].Env = append(podTemplate.Spec.Containers[0].Env,

--- a/internal/controllers/submariner/submariner_controller_test.go
+++ b/internal/controllers/submariner/submariner_controller_test.go
@@ -20,6 +20,7 @@ package submariner_test
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"reflect"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	syncertest "github.com/submariner-io/admiral/pkg/syncer/test"
 	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
@@ -168,6 +170,7 @@ func testSubmarinerResourceReconciliation() {
 	})
 }
 
+//nolint:maintidx // Ignore for unit tests.
 func testDaemonSetReconciliation() {
 	t := newTestDriver()
 
@@ -195,6 +198,79 @@ func testDaemonSetReconciliation() {
 			updatedDaemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
 			Expect(test.EnvMapFrom(updatedDaemonSet)).To(HaveKeyWithValue("SUBMARINER_SERVICECIDR", initial.Spec.ServiceCIDR))
 		})
+	})
+	
+	When("BrokerK8sSecret is set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.BrokerK8sSecret = "my-broker-secret"
+			t.submariner.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("secret-token"))
+			t.submariner.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("secret-ca"))
+
+			t.getAuthorizedBrokerClientFor = func(_ *v1alpha1.SubmarinerSpec, brokerToken, brokerCA string,
+				_ schema.GroupVersionResource,
+			) (dynamic.Interface, error) {
+				return t.dynClient, nil
+			}
+		})
+
+		Specify("the submariner gateway DaemonSet should NOT have broker credentials as env vars",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				envMap := test.EnvMapFrom(daemonSet)
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("ApiServerToken")))
+				Expect(envMap).NotTo(HaveKey(broker.EnvironmentVariable("CA")))
+			})
+	})
+
+	When("BrokerK8sSecret is not set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.BrokerK8sSecret = ""
+			t.submariner.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("plaintext-token"))
+			t.submariner.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte("plaintext-ca"))
+		})
+
+		Specify("the submariner gateway DaemonSet should have broker credentials as env vars for backwards compatibility",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				envMap := test.EnvMapFrom(daemonSet)
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("ApiServerToken"),
+					t.submariner.Spec.BrokerK8sApiServerToken))
+				Expect(envMap).To(HaveKeyWithValue(broker.EnvironmentVariable("CA"), t.submariner.Spec.BrokerK8sCA))
+			})
+	})
+
+	When("CeIPSecPSKSecret is set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CeIPSecPSKSecret = "my-psk-secret"
+			t.submariner.Spec.CeIPSecPSK = "secret-psk"
+		})
+
+		Specify("the submariner gateway DaemonSet should NOT have PSK as env var",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				Expect(test.EnvMapFrom(daemonSet)).NotTo(HaveKey("CE_IPSEC_PSK"))
+			})
+	})
+
+	When("CeIPSecPSKSecret is not set", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.CeIPSecPSKSecret = ""
+			t.submariner.Spec.CeIPSecPSK = "plaintext-psk"
+		})
+
+		Specify("the submariner gateway DaemonSet should have PSK as env var for backwards compatibility",
+			func(ctx SpecContext) {
+				t.AssertReconcileSuccess(ctx)
+
+				daemonSet := t.AssertDaemonSet(ctx, names.GatewayComponent)
+				Expect(test.EnvMapFrom(daemonSet)).To(HaveKeyWithValue("CE_IPSEC_PSK", "plaintext-psk"))
+			})
 	})
 
 	When("the submariner route-agent DaemonSet doesn't exist", func() {

--- a/pkg/images/image_parsing_test.go
+++ b/pkg/images/image_parsing_test.go
@@ -41,18 +41,48 @@ var imageTests = []struct {
 	{"submariner-operator", "", apis.DefaultSubmarinerOperatorVersion},
 }
 
-var _ = Describe("image parsing", func() {
-	When("Parsing image", func() {
-		It("Should parse version and repository", func() {
-			_, rep := images.ParseOperatorImage("localhost:5000/submariner-operator:local")
-			Expect(rep).To(Equal("localhost:5000"))
+var _ = Describe("GetImagePath", func() {
+	When("a RELATED_IMAGE_<component> env var is set", func() {
+		It("should ignore supplied imageOverrides for that component", func() {
+			GinkgoT().Setenv("RELATED_IMAGE_submariner-gateway", "registry.redhat.io/rhacm2/gateway@sha256:abc")
 
-			for _, tt := range imageTests {
-				version, repository := images.ParseOperatorImage(tt.image)
-				Expect(repository).To(Equal(tt.repository))
-				Expect(version).To(Equal(tt.version))
-			}
+			path := images.GetImagePath("quay.io/submariner", "0.20.0", "submariner-gateway", "submariner-gateway",
+				map[string]string{"submariner-gateway": "evil.example.com/pwn:latest"})
+			Expect(path).To(Equal("registry.redhat.io/rhacm2/gateway@sha256:abc"))
 		})
+	})
+
+	When("a RELATED_IMAGE_<component> env var is not set", func() {
+		It("should honour supplied imageOverrides", func() {
+			path := images.GetImagePath("quay.io/submariner", "0.20.0", "submariner-gateway", "no-related-image",
+				map[string]string{"no-related-image": "localhost:5000/dev:local"})
+			Expect(path).To(Equal("localhost:5000/dev:local"))
+		})
+	})
+
+	When("no RELATED_IMAGE env var or imageOverride is set", func() {
+		It("should construct path with repository and version", func() {
+			path := images.GetImagePath("quay.io/submariner", "0.20.0", "submariner-gateway", "submariner-gateway", nil)
+			Expect(path).To(Equal("quay.io/submariner/submariner-gateway:0.20.0"))
+		})
+
+		It("should construct path without repository prefix when repo is 'local'", func() {
+			path := images.GetImagePath("local", "dev", "submariner-gateway", "submariner-gateway", nil)
+			Expect(path).To(Equal("submariner-gateway:dev"))
+		})
+	})
+})
+
+var _ = Describe("ParseOperatorImage", func() {
+	It("should parse version and repository", func() {
+		_, rep := images.ParseOperatorImage("localhost:5000/submariner-operator:local")
+		Expect(rep).To(Equal("localhost:5000"))
+
+		for _, tt := range imageTests {
+			version, repository := images.ParseOperatorImage(tt.image)
+			Expect(repository).To(Equal(tt.repository))
+			Expect(version).To(Equal(tt.version))
+		}
 	})
 })
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -30,12 +30,21 @@ import (
 )
 
 func GetImagePath(repo, version, image, component string, imageOverrides map[string]string) string {
-	if override, ok := imageOverrides[component]; ok {
-		return logIfChanged(repo, version, image, component, override, "Image is overridden")
+	// Treat RELATED_IMAGE_* as a trusted source (e.g. set by OLM from the trusted operator bundle) that takes precedence over the
+	// supplied imageOverrides map, which is assumed to be user-supplied (e.g. from the Submariner CR which is namespaced and writable
+	// by lesser-privileged principals). Honouring the latter ahead of the former could let a bad actor pull arbitrary images into
+	// the privileged hostNetwork DaemonSets the operator manages.
+	if relatedImage, present := os.LookupEnv("RELATED_IMAGE_" + component); present {
+		if override, ok := imageOverrides[component]; ok && override != relatedImage {
+			log.Info("Ignoring image override as RELATED_IMAGE_* takes precedence",
+				"component", component, "override", override, "relatedImage", relatedImage)
+		}
+
+		return logIfChanged(repo, version, image, component, relatedImage, "Related image in the environment")
 	}
 
-	if relatedImage, present := os.LookupEnv("RELATED_IMAGE_" + component); present {
-		return logIfChanged(repo, version, image, component, relatedImage, "Related image in the environment")
+	if override, ok := imageOverrides[component]; ok {
+		return logIfChanged(repo, version, image, component, override, "Image is overridden")
 	}
 
 	path := image

--- a/pkg/webhook/deploy/deploy.go
+++ b/pkg/webhook/deploy/deploy.go
@@ -247,8 +247,16 @@ func waitForDeploymentReady(ctx context.Context, client controllerClient.Client,
 			return false, err //nolint:wrapcheck // No need to wrap
 		}
 
-		// Check if deployment has available replicas
-		if deployment.Status.AvailableReplicas > 0 {
+		expectedReplicas := int32(1)
+		if deployment.Spec.Replicas != nil {
+			expectedReplicas = *deployment.Spec.Replicas
+		}
+
+		// Check if deployment has converged to the current generation
+		if deployment.Status.ObservedGeneration == deployment.Generation &&
+			deployment.Status.UpdatedReplicas >= expectedReplicas &&
+			deployment.Status.ReadyReplicas >= expectedReplicas &&
+			deployment.Status.AvailableReplicas >= expectedReplicas {
 			return true, nil
 		}
 

--- a/pkg/webhook/deploy/deploy.go
+++ b/pkg/webhook/deploy/deploy.go
@@ -20,6 +20,7 @@ package deploy
 
 import (
 	"context"
+	"time"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/admiral/pkg/resource"
@@ -31,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -52,7 +54,12 @@ func Webhook(ctx context.Context, client controllerClient.Client, issuerName, op
 	}
 
 	if issuerName != "" {
-		if err := deployCertificate(ctx, client, issuerName, status); err != nil {
+		secretName, err := deployCertificate(ctx, client, issuerName, status)
+		if err != nil {
+			return err
+		}
+
+		if err := waitForCertificateSecret(ctx, client, secretName, status); err != nil {
 			return err
 		}
 	}
@@ -61,11 +68,16 @@ func Webhook(ctx context.Context, client controllerClient.Client, issuerName, op
 		return err
 	}
 
-	if err := deployWebhookConfig(ctx, client, brokerNamespace, status); err != nil {
+	deploymentName, err := deployOperator(ctx, client, operatorImage, status)
+	if err != nil {
 		return err
 	}
 
-	return deployOperator(ctx, client, operatorImage, status)
+	if err := waitForDeploymentReady(ctx, client, deploymentName, status); err != nil {
+		return err
+	}
+
+	return deployWebhookConfig(ctx, client, brokerNamespace, status)
 }
 
 func getOperatorImage(ctx context.Context, client controllerClient.Client, status reporter.Interface) (string, error) {
@@ -87,10 +99,11 @@ func getOperatorImage(ctx context.Context, client controllerClient.Client, statu
 	return existingDeployment.Spec.Template.Spec.Containers[0].Image, nil
 }
 
-func deployCertificate(ctx context.Context, client controllerClient.Client, issuerName string, status reporter.Interface) error {
+func deployCertificate(ctx context.Context, client controllerClient.Client, issuerName string, status reporter.Interface,
+) (string, error) {
 	kind, err := getIssuerKind(ctx, client, issuerName, status)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	status.Start("Deploying the Certificate")
@@ -98,20 +111,25 @@ func deployCertificate(ctx context.Context, client controllerClient.Client, issu
 
 	certificate := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal(webhookyaml.Certificate, certificate); err != nil {
-		return status.Error(err, "error parsing Certificate YAML")
+		return "", status.Error(err, "error parsing Certificate YAML")
 	}
 
 	if err := unstructured.SetNestedField(certificate.Object, issuerName, "spec", "issuerRef", "name"); err != nil {
-		return status.Error(err, "error setting issuerRef name")
+		return "", status.Error(err, "error setting issuerRef name")
 	}
 
 	if err := unstructured.SetNestedField(certificate.Object, kind, "spec", "issuerRef", "kind"); err != nil {
-		return status.Error(err, "error setting issuerRef kind")
+		return "", status.Error(err, "error setting issuerRef kind")
 	}
 
 	err = Ensure(ctx, client, certificate)
+	if err != nil {
+		return "", status.Error(err, "error deploying Certificate")
+	}
 
-	return status.Error(err, "error deploying Certificate")
+	secretName, _, err := unstructured.NestedString(certificate.Object, "spec", "secretName")
+
+	return secretName, status.Error(err, "error getting secretName")
 }
 
 func getIssuerKind(ctx context.Context, client controllerClient.Client, issuerName string,
@@ -163,20 +181,21 @@ func deployService(ctx context.Context, client controllerClient.Client, status r
 	return status.Error(err, "error deploying Service")
 }
 
-func deployOperator(ctx context.Context, client controllerClient.Client, operatorImage string, status reporter.Interface) error {
+func deployOperator(ctx context.Context, client controllerClient.Client, operatorImage string, status reporter.Interface,
+) (string, error) {
 	status.Start("Deploying the Operator")
 	defer status.End()
 
 	deployment := &appsv1.Deployment{}
 	if err := yaml.Unmarshal(webhookyaml.Deployment, deployment); err != nil {
-		return status.Error(err, "error parsing Deployment YAML")
+		return "", status.Error(err, "error parsing Deployment YAML")
 	}
 
 	deployment.Spec.Template.Spec.Containers[0].Image = operatorImage
 
 	err := Ensure(ctx, client, deployment)
 
-	return status.Error(err, "error deploying Deployment")
+	return deployment.Name, status.Error(err, "error deploying Deployment")
 }
 
 func deployWebhookConfig(ctx context.Context, client controllerClient.Client, brokerNamespace string,
@@ -200,4 +219,78 @@ func deployWebhookConfig(ctx context.Context, client controllerClient.Client, br
 func Ensure[T controllerClient.Object](ctx context.Context, client controllerClient.Client, obj T) error {
 	_, err := util.CreateOrUpdate(ctx, resource.ForControllerClient(client, OperatorNamespace, obj), obj, util.Replace(obj))
 	return err //nolint:wrapcheck // No need to wrap.
+}
+
+func waitForDeploymentReady(ctx context.Context, client controllerClient.Client, deploymentName string, status reporter.Interface) error {
+	status.Start("Waiting for webhook deployment to become ready")
+	defer status.End()
+
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   1.5,
+		Steps:    20,
+		Cap:      30 * time.Second,
+	}
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		deployment := &appsv1.Deployment{}
+
+		err := client.Get(ctx, controllerClient.ObjectKey{
+			Namespace: OperatorNamespace,
+			Name:      deploymentName,
+		}, deployment)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err //nolint:wrapcheck // No need to wrap
+		}
+
+		// Check if deployment has available replicas
+		if deployment.Status.AvailableReplicas > 0 {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	return status.Error(err, "webhook deployment did not become ready")
+}
+
+func waitForCertificateSecret(ctx context.Context, client controllerClient.Client, secretName string, status reporter.Interface) error {
+	status.Start("Waiting for webhook certificate to be issued")
+	defer status.End()
+
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   1.5,
+		Steps:    20,
+		Cap:      30 * time.Second,
+	}
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		secret := &corev1.Secret{}
+
+		err := client.Get(ctx, controllerClient.ObjectKey{
+			Namespace: OperatorNamespace,
+			Name:      secretName,
+		}, secret)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err //nolint:wrapcheck // No need to wrap
+		}
+
+		// Check if secret contains the expected certificate data
+		if len(secret.Data["tls.crt"]) > 0 && len(secret.Data["tls.key"]) > 0 {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	return status.Error(err, "certificate secret %q was not created", secretName)
 }

--- a/pkg/webhook/deploy/deploy_test.go
+++ b/pkg/webhook/deploy/deploy_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -52,7 +53,31 @@ var _ = Describe("Webhook", func() {
 
 	BeforeEach(func() {
 		status = reporter.Stdout()
-		clientBuilder = fakeClient.NewClientBuilder()
+		clientBuilder = fakeClient.NewClientBuilder().
+			WithStatusSubresource(&appsv1.Deployment{}, &corev1.Secret{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, client controllerClient.WithWatch, key controllerClient.ObjectKey,
+					obj controllerClient.Object, opts ...controllerClient.GetOption,
+				) error {
+					if err := client.Get(ctx, key, obj, opts...); err != nil {
+						return err
+					}
+
+					// Simulate deployment controller - populate status fields
+					if deployment, ok := obj.(*appsv1.Deployment); ok {
+						if deployment.Generation == 0 {
+							deployment.Generation = 1
+						}
+
+						deployment.Status.ObservedGeneration = deployment.Generation
+						deployment.Status.UpdatedReplicas = 1
+						deployment.Status.ReadyReplicas = 1
+						deployment.Status.AvailableReplicas = 1
+					}
+
+					return nil
+				},
+			})
 	})
 
 	JustBeforeEach(func() {
@@ -101,7 +126,7 @@ var _ = Describe("Webhook", func() {
 	When("an issuerName is provided", func() {
 		Context("and an Issuer exists in the namespace", func() {
 			BeforeEach(func() {
-				clientBuilder = clientBuilder.WithRuntimeObjects(newIssuer())
+				clientBuilder = clientBuilder.WithRuntimeObjects(newIssuer(), newCertificateSecret())
 			})
 
 			It("should deploy the Certificate with Issuer kind", func(ctx context.Context) {
@@ -112,7 +137,7 @@ var _ = Describe("Webhook", func() {
 
 		Context("a ClusterIssuer exists", func() {
 			BeforeEach(func() {
-				clientBuilder = clientBuilder.WithRuntimeObjects(newClusterIssuer())
+				clientBuilder = clientBuilder.WithRuntimeObjects(newClusterIssuer(), newCertificateSecret())
 			})
 
 			It("should deploy the Certificate with ClusterIssuer kind", func(ctx context.Context) {
@@ -129,7 +154,7 @@ var _ = Describe("Webhook", func() {
 
 		Context("and the Certificate already exists", func() {
 			BeforeEach(func() {
-				clientBuilder = clientBuilder.WithRuntimeObjects(newIssuer(), newCertificate())
+				clientBuilder = clientBuilder.WithRuntimeObjects(newIssuer(), newCertificate(), newCertificateSecret())
 			})
 
 			It("should update the existing Certificate", func(ctx context.Context) {
@@ -180,6 +205,19 @@ func verifyCertificate(ctx context.Context, client controllerClient.Client, kind
 	Expect(found).To(BeTrue())
 	Expect(issuerRef["name"]).To(Equal(issuerName))
 	Expect(issuerRef["kind"]).To(Equal(kind))
+}
+
+func newCertificateSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "submariner-operator-webhook-cert",
+			Namespace: deploy.OperatorNamespace,
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("fake-cert"),
+			"tls.key": []byte("fake-key"),
+		},
+	}
 }
 
 func verifyWebhookDeployment(ctx context.Context, client controllerClient.Client, image string) {

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -189,9 +189,6 @@ function verify_subm_cr() {
   validate_equals '.kind' 'Submariner'
   validate_equals '.metadata.name' "$deployment_name"
   validate_equals '.spec.brokerK8sApiServer' "$SUBMARINER_BROKER_URL"
-  # TODO: every cluster must have it's own token / SA (not working when using bundle/acm)
-  # validate_not_equals '.spec.brokerK8sApiServerToken' $SUBMARINER_BROKER_TOKEN
-  validate_equals '.spec.brokerK8sCA' "$SUBMARINER_BROKER_CA"
   validate_equals '.spec.brokerK8sRemoteNamespace' "$SUBMARINER_BROKER_NS"
   validate_equals '.spec.ceIPSecDebug' "$ce_ipsec_debug"
   validate_equals '.spec.ceIPSecNATTPort' "$ce_ipsec_nattport"
@@ -266,7 +263,6 @@ function verify_subm_gateway_pod() {
   validate_pod_container_env 'SUBMARINER_NATENABLED' "$natEnabled"
   validate_pod_container_env 'BROKER_K8S_APISERVER' "$SUBMARINER_BROKER_URL"
   validate_pod_container_env 'BROKER_K8S_REMOTENAMESPACE' "$SUBMARINER_BROKER_NS"
-  validate_pod_container_env 'BROKER_K8S_CA' "$SUBMARINER_BROKER_CA"
   validate_pod_container_env 'CE_IPSEC_DEBUG' "$ce_ipsec_debug"
   validate_pod_container_env 'CE_IPSEC_NATTPORT' "$ce_ipsec_nattport"
 
@@ -345,7 +341,6 @@ function verify_subm_gateway_container() {
   # Verify SubM Gateway pod environment variables
   grep "BROKER_K8S_APISERVER=$SUBMARINER_BROKER_URL" "$env_file"
   grep "SUBMARINER_NAMESPACE=$subm_ns" "$env_file"
-  grep "BROKER_K8S_CA=$SUBMARINER_BROKER_CA" "$env_file"
   grep "CE_IPSEC_DEBUG=$ce_ipsec_debug" "$env_file"
   grep "SUBMARINER_DEBUG=$subm_debug" "$env_file"
   grep "BROKER_K8S_REMOTENAMESPACE=$SUBMARINER_BROKER_NS" "$env_file"

--- a/test/e2e/webhook/deploy.go
+++ b/test/e2e/webhook/deploy.go
@@ -69,11 +69,20 @@ func Deploy() {
 	}, func(obj interface{}) (bool, string, error) {
 		result := obj.(*appsv1.Deployment)
 
-		if result.Status.ReadyReplicas > 0 && result.Status.AvailableReplicas > 0 {
+		expectedReplicas := int32(1)
+
+		if result.Spec.Replicas != nil {
+			expectedReplicas = *result.Spec.Replicas
+		}
+
+		if result.Status.ObservedGeneration == result.Generation &&
+			result.Status.UpdatedReplicas >= expectedReplicas &&
+			result.Status.ReadyReplicas >= expectedReplicas &&
+			result.Status.AvailableReplicas >= expectedReplicas {
 			return true, "", nil
 		}
 
-		return false, "Deployment not ready yet", nil
+		return false, "Deployment has not converged", nil
 	})
 }
 

--- a/test/e2e/webhook/webhook.go
+++ b/test/e2e/webhook/webhook.go
@@ -201,12 +201,12 @@ var _ = Describe("Broker webhook", func() {
 	)
 
 	Context("for aggregate ServiceImports", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx context.Context) {
 			if !submariner.Spec.ServiceDiscoveryEnabled {
 				Skip("Service Discovery is not enabled")
 			}
 
-			err := generalClient.Create(context.TODO(), &rbacv1.RoleBinding{
+			roleBinding := &rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      names.ForClusterSA(otherClusterID) + "-submariner-k8s-broker-cluster",
 					Namespace: brokerNamespace,
@@ -223,10 +223,17 @@ var _ = Describe("Broker webhook", func() {
 						Kind:      "ServiceAccount",
 					},
 				},
-			})
-			if !apierrors.IsAlreadyExists(err) {
-				Expect(err).NotTo(HaveOccurred())
 			}
+
+			err := generalClient.Create(ctx, roleBinding)
+			if apierrors.IsAlreadyExists(err) {
+				return
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(generalClient.Delete(ctx, roleBinding)).To(Succeed())
+			})
 		})
 
 		It("should only allow access to participating clusters", func(ctx context.Context) {


### PR DESCRIPTION
Backport of #4206 on release-0.20.

#4206: Avoid injecting credentials as plaintext env vars

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.