### PR TITLE
Add NetworkPolicy RBAC to satisfy EC olm.required_network_policy_rbac_for_operands

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -670,6 +670,18 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: submariner-operator
       deployments:
       - label:

--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -90,3 +90,15 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
The `olm.required_network_policy_rbac_for_operands` Enterprise Contract rule
(effective 2025-05-01) requires operators managing NetworkPolicy resources to
declare the corresponding RBAC in the CSV and ClusterRole.

Add `networking.k8s.io/networkpolicies` with verbs create, delete, get, list,
patch, update, watch to both `config/rbac/submariner-operator/cluster_role.yaml`
and `bundle/manifests/submariner.clusterserviceversion.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing Kubernetes network policies.
  * Enabled creating, updating, deleting, viewing, and monitoring network policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->