### PR TITLE
Update bundle to 0.24.1

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "release-0.24-ba3dcc3ca66a"
+            "version": "0.24.1"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "release-0.24-ba3dcc3ca66a"
+            "version": "0.24.1"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
-    createdAt: "2026-08-12 13:20:17"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
+    createdAt: "2026-08-30 18:56:35"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -93,7 +93,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/submariner-io/submariner-operator
     support: Submariner
-  name: submariner.v0.24.0
+  name: submariner.v0.24.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -711,22 +711,22 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
+                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:555600cd3ad21067a9af4c39efd643ed399e1afc7bf3ccb5ea09caa46270d59b
+                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:1ba40b556790d8ae5dbd9e8ddeb22c38e6d92957a68ff09291455e41a790b0bd
                 - name: RELATED_IMAGE_submariner-routeagent
-                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:26dcbee8a483ca73524cc7c43ec531ce0e001e07d0035f77e9355a51a81cf475
+                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:b29099252264cc3d9945ca91c5619c58459df38c37e47e35ff91cda11e7f21e3
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:144911a1a3aee93e56284d21e6665d3f403f1fe018b5bfa215ade7ea4c2a2de2
+                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:eb3b019119e87117fd5b9cb6b1b8107991e127c8ab75684cb3558f796f812297
                 - name: RELATED_IMAGE_submariner-lighthouse-agent
-                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:cc935254131e7ef440b411ea6c6660356308bd961b19f4010c9cc8bb310f830c
+                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:5f4d0bee537dfd7d6da06f97320f292d7c9b0c905ba544ddae102e415b786387
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
-                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:9db81558008c12388ff1332e18d74fd9ea38dbea2636a8ce1b56970a846c7344
+                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:f9eb92b1bfed9df285cf4cb02c4d9a8fceb950ac9a0dbc0318a188e8e6f73cef
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
-                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
+                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -879,21 +879,21 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
+  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
     name: submariner-operator
-  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:555600cd3ad21067a9af4c39efd643ed399e1afc7bf3ccb5ea09caa46270d59b
+  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:1ba40b556790d8ae5dbd9e8ddeb22c38e6d92957a68ff09291455e41a790b0bd
     name: submariner-gateway
-  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:26dcbee8a483ca73524cc7c43ec531ce0e001e07d0035f77e9355a51a81cf475
+  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:b29099252264cc3d9945ca91c5619c58459df38c37e47e35ff91cda11e7f21e3
     name: submariner-routeagent
-  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:144911a1a3aee93e56284d21e6665d3f403f1fe018b5bfa215ade7ea4c2a2de2
+  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:eb3b019119e87117fd5b9cb6b1b8107991e127c8ab75684cb3558f796f812297
     name: submariner-globalnet
-  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:cc935254131e7ef440b411ea6c6660356308bd961b19f4010c9cc8bb310f830c
+  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:5f4d0bee537dfd7d6da06f97320f292d7c9b0c905ba544ddae102e415b786387
     name: submariner-lighthouse-agent
-  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:9db81558008c12388ff1332e18d74fd9ea38dbea2636a8ce1b56970a846c7344
+  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:f9eb92b1bfed9df285cf4cb02c4d9a8fceb950ac9a0dbc0318a188e8e6f73cef
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
     name: ""
   selector:
     matchLabels:
       control-plane: submariner-operator
-  version: 0.24.0
+  version: 0.24.1

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -5,10 +5,10 @@ patches:
   target:
     group: operators.coreos.com
     kind: ClusterServiceVersion
-    name: submariner.v0.24.0
+    name: submariner.v0.24.1
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-08-12 13:20:17"
+  createdAt: "2026-08-30 18:56:35"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -3,42 +3,42 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-operator
-    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
+    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-gateway
-    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:555600cd3ad21067a9af4c39efd643ed399e1afc7bf3ccb5ea09caa46270d59b
+    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:1ba40b556790d8ae5dbd9e8ddeb22c38e6d92957a68ff09291455e41a790b0bd
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-routeagent
-    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:26dcbee8a483ca73524cc7c43ec531ce0e001e07d0035f77e9355a51a81cf475
+    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:b29099252264cc3d9945ca91c5619c58459df38c37e47e35ff91cda11e7f21e3
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-globalnet
-    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:144911a1a3aee93e56284d21e6665d3f403f1fe018b5bfa215ade7ea4c2a2de2
+    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:eb3b019119e87117fd5b9cb6b1b8107991e127c8ab75684cb3558f796f812297
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-agent
-    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:cc935254131e7ef440b411ea6c6660356308bd961b19f4010c9cc8bb310f830c
+    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:5f4d0bee537dfd7d6da06f97320f292d7c9b0c905ba544ddae102e415b786387
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-coredns
-    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:9db81558008c12388ff1332e18d74fd9ea38dbea2636a8ce1b56970a846c7344
+    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:f9eb92b1bfed9df285cf4cb02c4d9a8fceb950ac9a0dbc0318a188e8e6f73cef
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:170a9fc26d62faf1c02be2e83bf496e85b06be86b615bb9e2592d9e67951a7ec
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:746fe224f8d4e6ba26ae3c73c5f37066613d76686c318aaaf1126488c7710350
+  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: release-0.24-ba3dcc3ca66a
+  newTag: 0.24.1
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
Updates container image SHAs to match Konflux snapshot.

Snapshot: submariner-0-24-20260830-154946-000

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated Submariner components and deployment images to version 0.24.1.
  * Refreshed bundled image references and digests for the operator, networking agents, DNS, gateway, and testing components.
  * Updated deployment metadata and manifest timestamps to reflect the new release.
* **Maintenance**
  * Standardized the controller image reference for the 0.24.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->