### PR TITLE
Update bundle SHAs to latest

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
-    createdAt: "2026-08-30 18:56:35"
+    createdAt: "2026-08-31 18:22:04"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -723,9 +723,9 @@ spec:
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
                   value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:f9eb92b1bfed9df285cf4cb02c4d9a8fceb950ac9a0dbc0318a188e8e6f73cef
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:ddb412ca375e3d5b27fda072fbce9521492cec037bbda38b25cad556777634cd
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:ddb412ca375e3d5b27fda072fbce9521492cec037bbda38b25cad556777634cd
                 image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14
                 imagePullPolicy: Always
                 name: submariner-operator
@@ -891,7 +891,7 @@ spec:
     name: submariner-lighthouse-agent
   - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:f9eb92b1bfed9df285cf4cb02c4d9a8fceb950ac9a0dbc0318a188e8e6f73cef
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:ddb412ca375e3d5b27fda072fbce9521492cec037bbda38b25cad556777634cd
     name: ""
   selector:
     matchLabels:

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -9,6 +9,6 @@ patches:
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-08-30 18:56:35"
+  createdAt: "2026-08-31 18:22:04"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -33,12 +33,12 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:ddb412ca375e3d5b27fda072fbce9521492cec037bbda38b25cad556777634cd
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:08f1605cd95eeb20152b1bcf876a2ddc4863e2dbc1e470dbf5c86a9e0808b456
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:ddb412ca375e3d5b27fda072fbce9521492cec037bbda38b25cad556777634cd
 - op: replace
   path: /spec/template/spec/containers/0/image
   value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:e5a8b71af403847967f367a22ddc05c7399aec9c3fe871d997e7c7b20f861e14


### PR DESCRIPTION
Updates container image SHAs to match Konflux snapshot.

Snapshot: submariner-0-24-20260831-085849-000

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled network testing and metrics proxy container images to newer verified versions.
  * Ensured deployment configuration consistently references the updated images.

* **Chores**
  * Refreshed release metadata timestamps across deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->