### PR TITLE
Update version labels to v0.23.2

### DIFF
--- a/bundle.Dockerfile.konflux
+++ b/bundle.Dockerfile.konflux
@@ -23,16 +23,16 @@ COPY bundle/tests/scorecard /tests/scorecard/
 ARG SOURCE_DATE_EPOCH
 
 LABEL cpe="cpe:/a:redhat:acm:2.16::el9"
-LABEL csv-version="0.23.1"
+LABEL csv-version="0.23.2"
 LABEL description="submariner-operator-bundle"
 LABEL distribution-scope="public"
 LABEL maintainer="['multi-cluster-networking@redhat.com']"
 LABEL name="rhacm2/submariner-operator-bundle"
-LABEL release="v0.23.1"
+LABEL release="v0.23.2"
 LABEL summary="submariner-operator-bundle"
 LABEL url="https://github.com/submariner-io/submariner-operator"
 LABEL vendor="Red Hat, Inc."
-LABEL version="v0.23.1"
+LABEL version="v0.23.2"
 
 LABEL com.github.url="https://github.com/submariner-io/submariner-operator.git"
 

--- a/package/Dockerfile.submariner-operator.konflux
+++ b/package/Dockerfile.submariner-operator.konflux
@@ -63,7 +63,7 @@ USER submariner
 
 LABEL com.redhat.component="submariner-operator-container" \
       name="rhacm2/submariner-rhel9-operator" \
-      version="v0.23.0" \
+      version="v0.23.2" \
       summary="Submariner Operator" \
       description="The Submariner Operator manages the lifecycle of Submariner components." \
       io.k8s.display-name="Submariner Operator" \


### PR DESCRIPTION
Enables correct Konflux image tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the bundle container image version to 0.23.2.
  - Updated the operator container image version to 0.23.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->