### PR TITLE
Update bundle to 0.23.2

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
             "globalnetEnabled": false,
             "namespace": "submariner-operator",
             "repository": "quay.io/submariner",
-            "version": "release-0.23-f38d2964b13a"
+            "version": "0.23.2"
           }
         },
         {
@@ -69,15 +69,15 @@ metadata:
             "repository": "quay.io/submariner",
             "serviceCIDR": "192.168.66.0/24",
             "serviceDiscoveryEnabled": true,
-            "version": "release-0.23-f38d2964b13a"
+            "version": "0.23.2"
           }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
-    createdAt: "2026-08-12 13:32:53"
+    containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8
+    createdAt: "2026-09-11 02:28:11"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -93,7 +93,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/submariner-io/submariner-operator
     support: Submariner
-  name: submariner.v0.23.1
+  name: submariner.v0.23.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -711,22 +711,22 @@ spec:
                 - name: OPERATOR_NAME
                   value: submariner-operator
                 - name: RELATED_IMAGE_submariner-operator
-                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
+                  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8
                 - name: RELATED_IMAGE_submariner-gateway
-                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:f31e0282f8e7512b840a0c8c3017ef96267882fff101db13e4f176de3faf4bf7
+                  value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:86aa589a4336307d8719533696e47e7530aad0c96394ada8829ffc2d21ba4563
                 - name: RELATED_IMAGE_submariner-routeagent
-                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:ead549b8fd3140cb09bda4393dcbdea53264f9ad5e0d1a0fde1ffeb14f360f8f
+                  value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:f1791a980e57b22d008414aace45eab1212a66dbd4d45b8810a983baec53dc83
                 - name: RELATED_IMAGE_submariner-globalnet
-                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:310eda5d4c4c0263c3654e180c36680ed6e92c38d98164be92e60946afad19e0
+                  value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:b642756c5cff9666e88c109b37b0a10dc2fb090e207059177603b68733737be6
                 - name: RELATED_IMAGE_submariner-lighthouse-agent
-                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:9d003dd81854a6cf414117aec4db726614725a81cdd1071a8cefdb3e69f650d0
+                  value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:29db89723b9b03dcefaff3a4b4819e10e5cc97f3e5947d78ba2855c63920c86a
                 - name: RELATED_IMAGE_submariner-lighthouse-coredns
-                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:521afd49e45c32f0f0ebc18708825bdf93b3aab2a990d20e773ca87d6b197389
+                  value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:530574c718eb66f953bc7ba2c46551b659625774bba58dd125af1aa0ffb240ea
                 - name: RELATED_IMAGE_submariner-nettest
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:315dace8eac306f56d642314859e1f9c02441b6c7c76f9754decf020562702a5
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:5851260ce400931b2ac183f307a1c9e9ef4686ae94f73166dcd714635fa2e189
                 - name: RELATED_IMAGE_submariner-metrics-proxy
-                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:315dace8eac306f56d642314859e1f9c02441b6c7c76f9754decf020562702a5
-                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
+                  value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:5851260ce400931b2ac183f307a1c9e9ef4686ae94f73166dcd714635fa2e189
+                image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8
                 imagePullPolicy: Always
                 name: submariner-operator
                 resources:
@@ -879,21 +879,21 @@ spec:
   provider:
     name: submariner.io
   relatedImages:
-  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
+  - image: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8
     name: submariner-operator
-  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:f31e0282f8e7512b840a0c8c3017ef96267882fff101db13e4f176de3faf4bf7
+  - image: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:86aa589a4336307d8719533696e47e7530aad0c96394ada8829ffc2d21ba4563
     name: submariner-gateway
-  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:ead549b8fd3140cb09bda4393dcbdea53264f9ad5e0d1a0fde1ffeb14f360f8f
+  - image: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:f1791a980e57b22d008414aace45eab1212a66dbd4d45b8810a983baec53dc83
     name: submariner-routeagent
-  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:310eda5d4c4c0263c3654e180c36680ed6e92c38d98164be92e60946afad19e0
+  - image: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:b642756c5cff9666e88c109b37b0a10dc2fb090e207059177603b68733737be6
     name: submariner-globalnet
-  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:9d003dd81854a6cf414117aec4db726614725a81cdd1071a8cefdb3e69f650d0
+  - image: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:29db89723b9b03dcefaff3a4b4819e10e5cc97f3e5947d78ba2855c63920c86a
     name: submariner-lighthouse-agent
-  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:521afd49e45c32f0f0ebc18708825bdf93b3aab2a990d20e773ca87d6b197389
+  - image: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:530574c718eb66f953bc7ba2c46551b659625774bba58dd125af1aa0ffb240ea
     name: submariner-lighthouse-coredns
-  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:315dace8eac306f56d642314859e1f9c02441b6c7c76f9754decf020562702a5
+  - image: registry.redhat.io/rhacm2/nettest-rhel9@sha256:5851260ce400931b2ac183f307a1c9e9ef4686ae94f73166dcd714635fa2e189
     name: ""
   selector:
     matchLabels:
       control-plane: submariner-operator
-  version: 0.23.1
+  version: 0.23.2

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -5,10 +5,10 @@ patches:
   target:
     group: operators.coreos.com
     kind: ClusterServiceVersion
-    name: submariner.v0.23.1
+    name: submariner.v0.23.2
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-08-12 13:32:53"
+  createdAt: "2026-09-11 02:28:11"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml

--- a/config/manager/patches/related-images.deployment.config.yaml
+++ b/config/manager/patches/related-images.deployment.config.yaml
@@ -3,42 +3,42 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-operator
-    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
+    value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-gateway
-    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:f31e0282f8e7512b840a0c8c3017ef96267882fff101db13e4f176de3faf4bf7
+    value: registry.redhat.io/rhacm2/submariner-gateway-rhel9@sha256:86aa589a4336307d8719533696e47e7530aad0c96394ada8829ffc2d21ba4563
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-routeagent
-    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:ead549b8fd3140cb09bda4393dcbdea53264f9ad5e0d1a0fde1ffeb14f360f8f
+    value: registry.redhat.io/rhacm2/submariner-route-agent-rhel9@sha256:f1791a980e57b22d008414aace45eab1212a66dbd4d45b8810a983baec53dc83
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-globalnet
-    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:310eda5d4c4c0263c3654e180c36680ed6e92c38d98164be92e60946afad19e0
+    value: registry.redhat.io/rhacm2/submariner-globalnet-rhel9@sha256:b642756c5cff9666e88c109b37b0a10dc2fb090e207059177603b68733737be6
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-agent
-    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:9d003dd81854a6cf414117aec4db726614725a81cdd1071a8cefdb3e69f650d0
+    value: registry.redhat.io/rhacm2/lighthouse-agent-rhel9@sha256:29db89723b9b03dcefaff3a4b4819e10e5cc97f3e5947d78ba2855c63920c86a
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-lighthouse-coredns
-    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:521afd49e45c32f0f0ebc18708825bdf93b3aab2a990d20e773ca87d6b197389
+    value: registry.redhat.io/rhacm2/lighthouse-coredns-rhel9@sha256:530574c718eb66f953bc7ba2c46551b659625774bba58dd125af1aa0ffb240ea
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-nettest
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:315dace8eac306f56d642314859e1f9c02441b6c7c76f9754decf020562702a5
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:5851260ce400931b2ac183f307a1c9e9ef4686ae94f73166dcd714635fa2e189
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: RELATED_IMAGE_submariner-metrics-proxy
-    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:315dace8eac306f56d642314859e1f9c02441b6c7c76f9754decf020562702a5
+    value: registry.redhat.io/rhacm2/nettest-rhel9@sha256:5851260ce400931b2ac183f307a1c9e9ef4686ae94f73166dcd714635fa2e189
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:3c25c51ca45b205f856d44e4b7ae706ae21ebc3c4268c81c14d8863349cd0203
+  value: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 images:
 - name: controller
   newName: quay.io/submariner/submariner-operator
-  newTag: release-0.23-f38d2964b13a
+  newTag: 0.23.2
 - name: repo
   newName: quay.io/submariner


### PR DESCRIPTION
Updates container image SHAs to match Konflux snapshot.

Snapshot: submariner-0-23-20260911-014518-000

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated the Submariner operator to version 0.23.2.
  - Updated example configurations to reference the 0.23.2 release.
  - Refreshed the operator and associated component container images to newer pinned versions.
  - Updated deployment configuration to use the refreshed image set consistently.
  - Updated release metadata and timestamps included with the operator bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->