### PR TITLE
Update bundle SHAs for 0.23.2

### DIFF
--- a/bundle/manifests/submariner.clusterserviceversion.yaml
+++ b/bundle/manifests/submariner.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: registry.redhat.io/rhacm2/submariner-rhel9-operator@sha256:18ce55cef56731e4f9e00db7bfcd85623a1c8405cd9e9d8a5fef11a829aebda8
-    createdAt: "2026-09-11 02:28:11"
+    createdAt: "2026-09-11 04:38:25"
     description: Creates and manages Submariner deployments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/config/bundle/kustomization.yaml
+++ b/config/bundle/kustomization.yaml
@@ -9,6 +9,6 @@ patches:
     namespace: placeholder
     version: v1alpha1
 commonAnnotations:
-  createdAt: "2026-09-11 02:28:11"
+  createdAt: "2026-09-11 04:38:25"
 resources:
 - ../../bundle/manifests/submariner.clusterserviceversion.yaml


### PR DESCRIPTION
Snapshot: submariner-0-23-20260911-081924-000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the Submariner release to version 0.23.2.
  * Refreshed deployment configuration and bundled examples to align with the new release.

* **Maintenance**
  * Updated the operator and associated component images to their latest release-compatible versions.
  * Refreshed image references used for gateway, routing, discovery, DNS, networking, testing, and metrics functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->